### PR TITLE
Historial data widget theming

### DIFF
--- a/src/app/widget-historical/widget-historical.component.ts
+++ b/src/app/widget-historical/widget-historical.component.ts
@@ -112,7 +112,7 @@ export class WidgetHistoricalComponent implements OnInit, OnDestroy {
           data: this.chartDataAvg,
           fill: 'false',
           //borderWidth: 1
-          borderColor: this.textColor
+          borderColor: this.textColor,
         }
       ];
       if (this.config.displayMinMax) {
@@ -149,13 +149,16 @@ export class WidgetHistoricalComponent implements OnInit, OnDestroy {
           parsing: {
             xAxisKey: xAxis,
             yAxisKey: yAxis,
-        },
+          },
           scales: {
               [yAxis]: {
                   position: this.config.verticalGraph ? 'top' : 'right',
                   ...(this.config.minValue !== null && {suggestedMin: this.config.minValue}),
                   ...(this.config.maxValue !== null && {suggestedMax: this.config.maxValue}),
                   ...(this.config.includeZero && { beginAtZero: true}),
+                  ticks: {
+                    color: this.textColor,
+                  }
               },
               [xAxis]: {
                   position: this.config.verticalGraph ? 'right': 'bottom',
@@ -165,10 +168,18 @@ export class WidgetHistoricalComponent implements OnInit, OnDestroy {
                       round: 'second',
                   },
                   ticks: {
+                    color: this.textColor,
                     callback: timeDifferenceFromNow,
                   }
               }
-          }
+          },
+          plugins:{
+            legend: {
+              labels: {
+                color: this.textColor,
+              }
+            }
+          },
       }
     });
 


### PR DESCRIPTION
When using a darker theme with the historical data widget, it's hard to see the axis / label due to the default "black/dark grey" colour used by the widget

![image](https://user-images.githubusercontent.com/1069212/184616420-92b9885f-8692-405f-aaec-bf763a678c1c.png)
![image](https://user-images.githubusercontent.com/1069212/184616581-cddf6ef3-129b-4ac4-9794-e21458a82584.png)
![image](https://user-images.githubusercontent.com/1069212/184616650-c875340a-1dfe-43b9-a162-f135f13522fd.png)

This PR changes legend and axis colours to match the line colour so that the legend/axis can actually be read on dark themes/night mode

![image](https://user-images.githubusercontent.com/1069212/184616513-0bdd533a-6431-4a05-ab95-ff42a725be68.png)
![image](https://user-images.githubusercontent.com/1069212/184616756-fe4eb47c-38d3-486e-96cc-0cd6bb7237d2.png)
![image](https://user-images.githubusercontent.com/1069212/184616723-b175cef0-93c4-4024-9c97-68befa35ca59.png)

Particularly relevant on tablets in high brightness with dim screens

Closes #129 