### PR TITLE
Feature: RxJS WebSocket migration

### DIFF
--- a/src/app/app-settings.service.ts
+++ b/src/app/app-settings.service.ts
@@ -19,7 +19,7 @@ const configVersion = 6; // used to invalidate old configs.
 
 export interface IAppConfig {
   configVersion: number;
-  kipUUID: string; 
+  kipUUID: string;
   signalKUrl: string;
   signalKToken: string;
   dataSets: IDataSet[];
@@ -413,27 +413,27 @@ export class AppSettingsService {
 
   //Saving to Storage
   private saveAppConfigToLocalStorage() {
-    console.log("Saving App config to LocalStorage");
+    console.log("[AppSettings Service] Saving Application config to LocalStorage");
     localStorage.setItem('appConfig', JSON.stringify(this.buildAppStorageObject()));
   }
 
   private saveWidgetConfigToLocalStorage() {
-    console.log("Saving Widgets config to LocalStorage");
+    console.log("[AppSettings Service] Saving Widgets config to LocalStorage");
     localStorage.setItem('widgetConfig', JSON.stringify(this.buildWidgetStorageObject()));
   }
 
   private saveLayoutConfigToLocalStorage() {
-    console.log("Saving Layouts config to LocalStorage");
+    console.log("[AppSettings Service] Saving Layouts config to LocalStorage");
     localStorage.setItem('layoutConfig', JSON.stringify(this.buildLayoutStorageObject()));
   }
 
   private saveThemeConfigToLocalStorage() {
-    console.log("Saving Theme config to LocalStorage");
+    console.log("S[AppSettings Service] aving Theme config to LocalStorage");
     localStorage.setItem('themeConfig', JSON.stringify(this.buildThemeStorageObject()));
   }
 
   private saveZonesConfigToLocalStorage() {
-    console.log("Saving Zones config to LocalStorage");
+    console.log("[AppSettings Service] Saving Zones config to LocalStorage");
     localStorage.setItem('zonesConfig', JSON.stringify(this.buildZonesStorageObject()));
   }
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -197,4 +197,24 @@ const appRoutes: Routes = [
 })
 
 export class AppModule {
+  constructor(
+    /**
+     * Below provides Services instanciation only - there is no calls to Services
+     * in this class. It provides/forces early instanciation of services if needed.
+     * This fixes instanciation issues on loossely couple services (where some services
+     * use Observers but are only instaciated by component later in the app, causing
+     * them to miss some events until instanciated.
+     *
+     * Example: SignalKDeltaService needs to be instaciated to receive connection status
+     * from SignalKConnectionService in order to connect WebSocket immediatly upon
+     * connection to listen and process deltas. Both services are not interdependant
+     * and only communicated using Obervable. If not instaciated before it is called by
+     * a component, SignalKDeltaService will miss connection status and not connect WebSockets.
+     *
+     * Below should be Singletons Services ie. "providedIn: root" and/or part of prodivers
+     * listed above.
+    */
+    signalKDeltaService: SignalKDeltaService,
+  ) {
+}
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -199,8 +199,8 @@ const appRoutes: Routes = [
 export class AppModule {
   constructor(
     /**
-     * Below provides Services instanciation only - there is no calls to Services
-     * in this class. It provides/forces early instanciation of services if needed.
+     * Below provides Services instanciation only - there is no calls to Service.
+     * It provides/forces early instanciation of services if needed.
      * This fixes instanciation issues on loossely couple services (where some services
      * use Observers but are only instaciated by component later in the app, causing
      * them to miss some events until instanciated.
@@ -212,7 +212,7 @@ export class AppModule {
      * a component, SignalKDeltaService will miss connection status and not connect WebSockets.
      *
      * Below should be Singletons Services ie. "providedIn: root" and/or part of prodivers
-     * listed above.
+     * section listed above.
     */
     signalKDeltaService: SignalKDeltaService,
   ) {

--- a/src/app/notifications.service.ts
+++ b/src/app/notifications.service.ts
@@ -195,7 +195,7 @@ export class NotificationsService {
   public acknowledgeAlarm(path: string, timeout: number = 0): boolean {
     if (path in this.alarms) {
       this.alarms[path].isAck = true;
-      this.activeAlarmsSubject.next(this.alarms);      
+      this.activeAlarmsSubject.next(this.alarms);
       if (timeout > 0) {
         setTimeout(()=>{
           console.log("unack: "+ path);
@@ -213,7 +213,7 @@ export class NotificationsService {
 
   /**
    * Checks all alarms for worst state, and sets any visualSev/AudioSev
-   * @returns 
+   * @returns
    */
   public checkAlarms() {
     // find worse alarm state
@@ -268,7 +268,7 @@ export class NotificationsService {
       audioSev = Math.max(audioSev, aSev);
       visualSev = Math.max(visualSev, vSev);
     }
-    
+
     if (!this.notificationConfig.sound.disableSound) {
       this.playAlarm(1000 + audioSev);
     }
@@ -372,7 +372,6 @@ export class NotificationsService {
    * @param trackId track to play
    */
    playAlarm(trackId: number) {
-    console.log(this.notificationConfig);
     if (this.activeAlarmSoundtrack == trackId) {   // same track, do nothing
       return;
     }

--- a/src/app/signalk-full.service.ts
+++ b/src/app/signalk-full.service.ts
@@ -13,9 +13,6 @@ export class SignalKFullService {
     //set self urn
     this.SignalKService.setSelf(data.self)
 
-    // set Sources
-    //this.SignalKService.setDataFull(data);
-
     // so we will walk the array recusively
     this.findKeys(data);
   }
@@ -27,14 +24,14 @@ export class SignalKFullService {
       return;
     }
     if (path == 'sources') { return; } // ignore the sources tree
-    
+
     if ( (typeof(data) == 'string') || (typeof(data) == 'number') || (typeof(data) == 'boolean')) {  // is it a simple value?
       let timestamp = Date.now();
       let source = 'noSource'
       this.SignalKService.updatePathData(path, source, timestamp, data);
       this.SignalKService.setDefaultSource(path, source);
       return;
-    }     
+    }
     else if ('timestamp' in data) { // is it a timestamped value?
 
       // try and get source
@@ -46,7 +43,7 @@ export class SignalKFullService {
       } else {
         source = 'noSource';
       }
-      
+
       let timestamp = Date.parse(data.timestamp);
 
 
@@ -57,7 +54,7 @@ export class SignalKFullService {
           Object.keys(data['value']).forEach(key => {
             let compoundPath = path+"."+key;
             this.SignalKService.updatePathData(compoundPath, source, timestamp, data.value[key]);
-            this.SignalKService.setDefaultSource(compoundPath, source);       
+            this.SignalKService.setDefaultSource(compoundPath, source);
             // try and get metadata.
             if (typeof(data['meta']) == 'object') {
               //does meta have one with properties for each one?
@@ -75,13 +72,13 @@ export class SignalKFullService {
           // try and get metadata.
           if (typeof(data['meta']) == 'object') {
             this.SignalKService.setMeta(path, data['meta']);
-          } 
+          }
         }
       }
 
       return;
     }
-    
+
     // it's not a value, dig deaper
     else {
       // process children
@@ -94,6 +91,6 @@ export class SignalKFullService {
       }
     }
   }
- 
+
 
 }

--- a/src/app/signalk-interfaces.ts
+++ b/src/app/signalk-interfaces.ts
@@ -43,7 +43,7 @@ export interface IDeltaMessage {
   requestId?: string;
   state?: string;
   statusCode?: number;
-  context: string;
+  context?: string;
   self?: string;
   version?: string;
   message?: string;
@@ -51,6 +51,9 @@ export interface IDeltaMessage {
     permission?: string;
     token?: string
   }
+  role?: [];
+  name?: string;
+  timestamp?: string;
 }
 
 /**

--- a/src/app/signalk-requests.service.ts
+++ b/src/app/signalk-requests.service.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@angular/core';
 import { Subscription ,  Observable ,  Subject } from 'rxjs';
 
 import { AppSettingsService } from './app-settings.service';
-import { SignalKConnectionService } from './signalk-connection.service';
 import { IDeltaMessage } from './signalk-interfaces';
 import { SignalKDeltaService } from './signalk-delta.service';
 import { NotificationsService } from './notifications.service';
@@ -36,24 +35,16 @@ export class SignalkRequestsService {
   private requests: skRequest[] = []; // Private array of all requests.
 
   constructor(
-    private SignalKConnectionService: SignalKConnectionService,
-    private SignalKDeltaService: SignalKDeltaService,
+//    private SignalKConnectionService: SignalKConnectionService,
+    private signalKDeltaService: SignalKDeltaService,
     private AppSettingsService: AppSettingsService,
     private NotificationsService: NotificationsService,
     ) {
+
       let requestsSub: Subscription; // used to get all the requests from signalk-delta while avoiding circular dependencies in services...
 
-      requestsSub = this.SignalKDeltaService.subscribeRequest().subscribe(
+      requestsSub = this.signalKDeltaService.subscribeRequest().subscribe(
         requestMessage => { this.updateRequest(requestMessage); }
-      );
-
-      let endPointStatus: Subscription; // Monitor if Endpoints are reset and clean up
-      endPointStatus = this.SignalKConnectionService.getSignalKConnectionsStatus().subscribe(
-        signalKConnections => {
-          if (!signalKConnections.rest.status) {
-            this.requests = []; // flush array to clean values that will become stale post error or server reconnect
-          }
-        }
       );
     }
 
@@ -76,7 +67,7 @@ export class SignalkRequestsService {
       }
     }
 
-    this.SignalKConnectionService.publishDelta(JSON.stringify(accessRequest));
+    this.signalKDeltaService.publishDelta(accessRequest);
     let request = {
       requestId: requestId,
       state: null,
@@ -105,7 +96,7 @@ export class SignalkRequestsService {
         "value": value
       }
     }
-    this.SignalKConnectionService.publishDelta(JSON.stringify(message)); //send request
+    this.signalKDeltaService.publishDelta(message); //send request
 
     let request: skRequest = {
       requestId: requestId,
@@ -163,7 +154,9 @@ export class SignalkRequestsService {
   }
 
   /**
-   * Subscribe to SignalK request response. This allows you to inspect server response information such as State, Status Codes and such for further processing logic. Subscription object should be used for the Return :)
+   * Subscribe to SignalK request response. This allows you to inspect server
+   * response information such as State, Status Codes and such for further processing
+   * logic. Subscription object should be used for the Return :)
    *
    * @return Observable if type skRequest.
    */

--- a/src/app/signalk.service.ts
+++ b/src/app/signalk.service.ts
@@ -29,7 +29,9 @@ export interface updateStatistics {
 
 }
 
-@Injectable()
+@Injectable({
+  providedIn: 'root'
+})
 export class SignalKService {
 
   degToRad = Qty.swiftConverter('deg', 'rad');
@@ -64,10 +66,10 @@ export class SignalKService {
   constructor(
     private appSettingsService: AppSettingsService,
     private UnitService: UnitsService,
-    private NotificationsService: NotificationsService) { 
+    private NotificationsService: NotificationsService) {
     //every second update the stats for seconds array
     setInterval(() => {
-      
+
       // if seconds is more than 60 long, remove item
       if (this.updateStatistics.secondsUpdates.length >= 60) {
         this.updateStatistics.secondsUpdates.shift() //removes first item
@@ -79,7 +81,7 @@ export class SignalKService {
 
     // every minute update status for minute array
     setInterval(() => {
-      
+
       // if seconds is more than 60 long, remove item
       if (this.updateStatistics.minutesUpdates.length >= 60) {
         this.updateStatistics.minutesUpdates.shift() //removes first item
@@ -158,8 +160,10 @@ export class SignalKService {
   }
 
   setSelf(value: string) {
-    console.debug('Setting self to: ' + value);
-    this.selfurn = value;
+    if ((value != "" || value != null) && value != this.selfurn) {
+      console.debug('[SignalK Service] Setting self to: ' + value);
+      this.selfurn = value;
+    }
   }
 
   setServerVersion(version: string) {
@@ -279,9 +283,9 @@ export class SignalKService {
           //we're looking for a source we don't know of... do nothing I guess?
         }
         if (source !== null) {
-          pathRegister.observable.next({ 
-            value: this.paths[pathIndex].sources[source].value, 
-            state: this.paths[pathIndex].state 
+          pathRegister.observable.next({
+            value: this.paths[pathIndex].sources[source].value,
+            state: this.paths[pathIndex].state
           });
         }
 
@@ -301,7 +305,7 @@ export class SignalKService {
     }
   }
 
-  setMeta(path: string, meta) { //TODO(David): Look at Meta and maybe build Zones
+  setMeta(path: string, meta) {
     let pathSelf: string = path.replace(this.selfurn, 'self');
     let pathIndex = this.paths.findIndex(pathObject => pathObject.path == pathSelf);
     if (pathIndex >= 0) {


### PR DESCRIPTION
I move to the latest RsJx WebSocket implementation built on Observer. It reduces the services circular references challenges we had in some case and make socket status much simpler. Also initiated the Delta Service on app startup instead of waiting for a service to instantiate it late in the startup process. This insures the delta service is up and ready to gets messages before the connection service makes a successful connection. The app startup is fast and slick.

I fixed the WebSocket connection service to get rid of unclosed SignalK delta subscriptions caused by manual or network error reconnections. It lessens the burden on the server who, in the current implementation, was caching all delta updates for that connection until it overflowed its buffer and killed the dead connection. I also reduce some unnecessary iterative Open/Close socket calls that were not necessary and improved server reconnection speed.

Also streamlined some console messages with by adding the Source Service and Process that is logging the message for improved clarity when trying to understand what's is going on.

It’s a bit cleaner and faster.

Open to feedback!