### PR TITLE
fixes issue where simple linear gauge assumes min value=0

### DIFF
--- a/src/app/svg-simple-linear-gauge/svg-simple-linear-gauge.component.ts
+++ b/src/app/svg-simple-linear-gauge/svg-simple-linear-gauge.component.ts
@@ -40,7 +40,7 @@ export class SvgSimpleLinearGaugeComponent implements OnChanges {
         let scaleSliceValue = 195 / scaleRange;
 
         this.oldGaugeValue = this.newGaugeValue;
-        this.newGaugeValue = changes.gaugeValue.currentValue * scaleSliceValue;
+        this.newGaugeValue = (changes.gaugeValue.currentValue - this.gaugeMinValue) * scaleSliceValue;
 
         this.gaugeBarAnimate.nativeElement.beginElement();
       }


### PR DESCRIPTION
Fixes https://github.com/mxtommy/Kip/issues/140 where simple gauge doesn't show properly if `min!=0`.