### PR TITLE
feature: delta meta processing

### DIFF
--- a/src/app/app-interfaces.ts
+++ b/src/app/app-interfaces.ts
@@ -1,0 +1,93 @@
+/*********************************************************************************
+ * This file contains App (Kip) internal data interfaces.
+ *
+ * Those interfaces describe most (only is reuse is needed) shared app data types
+ * and data structures used in the application. They are use by various services,
+ * componenets and widgets.
+ *
+ * For Signal K data interfaces (external data), see signalk-interfaces file.
+ *********************************************************************************/
+
+import { ISignalKMetadata, State, Method } from "./signalk-interfaces";
+import { IZoneState } from './app-settings.interfaces';
+
+/**
+ * An App data structure that represents the values (ie. sensor data)
+ * of a path. Used as a Read/Write interface on internal App paths data source.
+
+ * Use by: signalk-full services (parser), signalk-delta services (parser) and
+ * signalk services (internal app datasource)
+ *
+ * @memberof app-interfaces
+ */
+ export interface IPathValueData {
+  path: string;
+  source: string;
+  timestamp: number;
+  value: any;
+}
+
+/**
+ * An App data structure that represents a path's rich/complet data structure;
+ * all possible signal K data sources and their values, default source, data type description,
+ * data zone state, all meta data, etc.
+ *
+ * Use by: data-browser (consumer) and signalk services (internal datasource)
+ *
+ * @memberof app-interfaces
+ */
+ export interface IPathData {
+  path: string;
+  defaultSource: string; // default source
+  sources: {
+    [sourceName: string]: { // per source data
+      timestamp: number;
+      value: any;
+    }
+  }
+  meta?: ISignalKMetadata;
+  type: string;
+  state: IZoneState;
+}
+
+/**
+ * An App data structure that represents all meta values of a path. Used
+ * as an interface to access meta data subset extracted from internal App
+ * paths data source.
+ *
+ * Use by: modal-path-selection (consumer), setting-zones (consumer) and signalk (internal datasource) service
+ *
+ * @memberof app-interfaces
+ */
+ export interface IPathMetaData {
+  path: string;
+  meta?: ISignalKMetadata;
+}
+
+/**
+ * An App data structure that represents a resquest/response "ie. a notification"
+ * message.
+ *
+ * Use by: Notification service (consumer), signalk-delta (parser)
+ *
+ * Follow URL for full SignalK specification and description of fields:
+ * @url https://signalk.org/specification/1.7.0/doc/request_response.html
+ *
+ * @memberof app-interfaces
+ */
+ export interface INotification {
+  method: Method[],
+  state: State,
+  message: string
+  timestamp: string,
+}
+
+export interface IDefaultSource {
+  path: string;
+  source: string;
+}
+
+export interface IMeta {
+  path: string;
+  meta: ISignalKMetadata;
+}

--- a/src/app/signalk-interfaces.ts
+++ b/src/app/signalk-interfaces.ts
@@ -1,14 +1,21 @@
-import { ZoneState } from './app-settings.interfaces';
+/**
+ * This file contains Signal K data interfaces.
+ *
+ * Those interfaces describe the different data types and structures of the
+ * Signal K specification. They apply to both REST and WebSocket.
+ *
+ * For internal Kip data interfaces, see app-interfaces file.
+ */
 
 // Metadata, Notification and Stream Subscription type restrictions.
 const states = ["nominal", "normal", "alert", "warn", "alarm", "emergency"] as ["nominal", "normal", "alert", "warn", "alarm", "emergency"];
-type State = typeof states[number];
+export type State = typeof states[number];
 
 const types = ["linear", "logarithmic", "squareroot", "power"] as ["linear", "logarithmic", "squareroot", "power"];
-type Type = typeof types[number];
+export type Type = typeof types[number];
 
 const methods = ["visual", "sound"] as ["visual", "sound"];
-type Method = typeof methods[number];
+export type Method = typeof methods[number];
 
 const formats = ["delta", "full"] as ["delta", "full"];
 export type Format = typeof formats[number];
@@ -16,35 +23,25 @@ export type Format = typeof formats[number];
 const policies = ["instant", "ideal", "fixed"] as ["instant", "ideal", "fixed"];
 export type Policy = typeof policies[number];
 
-/**
- * Not used
- */
-export interface IUpdateMessage {
-  source: {
-    label: string;
-    type: string;
-    pgn?: string;
-    src?: string;
-    talker?: string;
-  };
-  timestamp: string;
-  values: {
-    path: string;
-    value: any;
-  }[]
-}
-
-export interface ISignalKDataPath {
-  path: string;
-  source: string;
-  timestamp: number;
-  value: any;
+export interface ISignalKFullDocument {
+  version: string;
+  self: string;
+  vessels: any;
+  sources: any;
+  atons: any;
+  shore: any;
 }
 
 /**
- * SignalK Delta low level raw message interface.
+ * Services: signalk-delta service
+ * Use in: Root interface - Signal K (WebSocket stream) lowest level raw message interface.
+ *
+ * Description: lowest level object interface of all data updates send by the server. This includes
+ * server resquests, login, token requests and validation, data updates.
+ *
+ * @memberof signalk-interfaces
  */
-export interface IDeltaMessage {
+ export interface ISignalKDeltaMessage {
   accessRequest?: {
     permission?: string;
     token: string;
@@ -64,7 +61,7 @@ export interface IDeltaMessage {
   state?: string;
   statusCode?: number;
   timestamp?:string;
-  updates?: IUpdateMessage[];
+  updates?: ISignalKUpdateMessage[];
   validate?: {
     token?: string;
     timeToLive?: number; //not yet implemented on server
@@ -73,76 +70,73 @@ export interface IDeltaMessage {
 }
 
 /**
- * Kip SignalK path Objects interface. This object is used to contain all server received data
+ * Services: signalk-delta service
+ * Used in: IDeltaMessage.updates interface propertie
+ *
+ * Description: data update message object interface. This includes: sources, values and metadata
+ *
+ * @memberof signalk-interfaces
  */
-export interface IPathObject {
-  path: string;
-  defaultSource: string; // default source
-  sources: {
-    [sourceName: string]: { // per source data
-      timestamp: number;
-      value: any;
-    }
-  }
-  meta?: ISignalKMetadata;
-  type: string;
-  state: ZoneState;
+export interface ISignalKUpdateMessage {
+  source: {
+    label: string;
+    type: string;
+    pgn?: string;
+    src?: string;
+    talker?: string;
+  };
+  timestamp: string;
+  values: {
+    path: string;
+    value: any;
+  }[];
+  meta?: ISignalKMeta[];
 }
 
 /**
- * SignalK Metadata Object interface. Follow URL for full SignalK specification
- * and description of fields:
- * @url https://signalk.org/specification/1.4.0/doc/data_model_metadata.html
+ * Signal K messsage object interface. Describes meta data received from server.
+ *
+ * Used by: signalk-delta (parser) and signalk-full (parser) services
+ *
+ * Included in: IUpdateMessage, IPathFullObject, IPathMetaObject
+ *
+ * Follow URL for full SignalK specification and description of fields:
+ * @url https://signalk.org/specification/1.7.0/doc/data_model_metadata.html
+ *
+ * When present, metadata can be use for gauge configuration and the state of
+ * values in a given scale. It's meant to help automatic gauge configuration, and describe
+ * the type of data provided by a given path.
+ *
+ * @memberof signalk-interfaces
  */
+ export interface ISignalKMeta {
+  path: string; // not in the spec but always present in the data
+  value: ISignalKMetadata;
+}
+
 export interface ISignalKMetadata {
-  // normal state value
-  description: string;  //SK base required value
-  units: string;         //SK base required value
   displayName?: string;
-  longName?: string;
   shortName?: string;
-  state?: State;
-  timeout?: number;
+  longName?: string;
+  description: string;
+  units: string;        // required if value is present. describe the type of data
+  timeout?: number;     // tells the consumer how long it should consider the value valid
+  properties: {}; // Not defined. Used by GPS and Ship details and other complexe data types
   method?: Method[];
   displayScale?: {      //This object provides information regarding the recommended type and extent of the scale used for displaying values.
     lower?: number;
     upper?: number;
-    type?: Type;
+    type: Type;
+    power?: number;
   }
-  // elevated state value
   alertMethod?: Method[];
   warnMethod?: Method[];
   alarmMethod?: Method[];
   emergencyMethod?: Method[];
   zones?: {             //This provides a series of hints to the consumer which can be used to properly set a range on a display gauge and also color sectors of a gauge to indicate normal or dangerous operating conditions.
-    state: string;
+    state: State;
     lower?: number;
     upper?: number;
     message?: string;
   }[]
-}
-
-/**
- * Interface for Metadata by Paths
- */
-export interface IPathAndMetaObjects {
-  path: string;
-  meta?: ISignalKMetadata;
-}
-
-/**
- * SignalK Notification Object interface. Follow URL for full SignalK specification
- * and description of fields:
- * @url https://signalk.org/specification/1.4.0/doc/notifications.html
- */
-export interface ISignalKNotification {
-  method: Method[],
-  state: State,
-  message: string
-  timestamp: string,
-}
-
-export interface IPathInfo {
-  path: string;
-
 }


### PR DESCRIPTION
Adding metadata processing to Delta service. This allows to get metadata updates post Full Document request which only happens on app connect.

### Issue / usecase
- SK only sends certain data (such as boat name, width, etc) as part of deltas.
- Another usecase is if devices come online after Kip is started. Kip does not get the new device metadata info. 