### PR TITLE
Block shared config on sk version

### DIFF
--- a/src/app/settings-signalk/settings-signalk.component.html
+++ b/src/app/settings-signalk/settings-signalk.component.html
@@ -15,7 +15,9 @@
           </mat-error>
         </mat-form-field>
         <br/>
-        <mat-slide-toggle name="useSharedConfig"[(ngModel)]="connectionConfig.useSharedConfig" [ngModelOptions]="{standalone: true}" (click)="useSharedConfigToggleClick(connectionConfig.useSharedConfig)">Enable user Sign in and configuration sharing</mat-slide-toggle>
+        <mat-slide-toggle name="useSharedConfigToggle" #useSharedConfigToggle [(ngModel)]="connectionConfig.useSharedConfig" [ngModelOptions]="{standalone: true}" (change)="useSharedConfigToggleClick($event)">
+          Enable user Sign in and configuration sharing
+        </mat-slide-toggle>
         <br/><br/>
         <button mat-raised-button type="button" color="primary" matTooltip="Configure User Credentials" [disabled]="!connectionConfig.useSharedConfig" (click)="openUserCredentialModal(null)">
           Set Sign in credentials

--- a/src/app/settings-signalk/settings-signalk.component.ts
+++ b/src/app/settings-signalk/settings-signalk.component.ts
@@ -13,6 +13,7 @@ import { SignalkRequestsService } from '../signalk-requests.service';
 import { NotificationsService } from '../notifications.service';
 import { ModalUserCredentialComponent } from '../modal-user-credential/modal-user-credential.component';
 import { HttpErrorResponse } from '@angular/common/http';
+import { compare } from 'compare-versions';
 
 
 @Component({
@@ -34,7 +35,6 @@ export class SettingsSignalkComponent implements OnInit {
 
   endpointServiceStatus: IEndpointStatus;
   skEndpointServiceStatusSub: Subscription;
-  skFullDocumentStatusSub: Subscription;
   streamStatus: IStreamStatus;
   skStreamStatusSub: Subscription;
 
@@ -252,11 +252,17 @@ export class SettingsSignalkComponent implements OnInit {
     })
   }
 
-  public useSharedConfigToggleClick(value: boolean) {
-    if(!value) {
+  public useSharedConfigToggleClick(e) {
+    if(e.checked) {
+      let version = this.signalKConnectionService.serverVersion$.getValue();
+      if (!compare(version, '1.46.2', ">=")) {
+        this.notificationsService.sendSnackbarNotification("Configuration sharing requires Signal K version 1.46.2 or better",0);
+        this.connectionConfig.useSharedConfig = false;
+        return;
+      }
       this.openUserCredentialModal(null);
     }
-  }
+  };
 
   ngOnDestroy() {
     this.skEndpointServiceStatusSub.unsubscribe();


### PR DESCRIPTION
Make sure we have version Signal K v1.46.2 or more. Their was a bug with CORS support in sk that crashes all secured http call (login, logout, PUT, etc.) 