### PR TITLE
Fix: default wind Widget heading data path

### DIFF
--- a/src/app/config.demo.const.ts
+++ b/src/app/config.demo.const.ts
@@ -84,7 +84,7 @@ export const DemoWidgetConfig: IWidgetConfig = {
         "paths": {
           "headingPath": {
             "description": "Heading",
-            "path": "self.navigation.courseOverGroundTrue",
+            "path": "self.navigation.headingTrue",
             "source": "default",
             "pathType": "number",
             "isPathConfigurable": true,

--- a/src/app/widget-wind/widget-wind.component.ts
+++ b/src/app/widget-wind/widget-wind.component.ts
@@ -14,7 +14,7 @@ const defaultConfig: IWidgetSvcConfig = {
   paths: {
     "headingPath": {
       description: "Heading",
-      path: 'self.navigation.courseOverGroundTrue',
+      path: 'self.navigation.headingTrue',
       source: 'default',
       pathType: "number",
       isPathConfigurable: true,


### PR DESCRIPTION
Changed default Wind gauge Widget default data path to self.navigation.headingTrue