### PR TITLE
Fix null values and default sources Godind/issue254

### DIFF
--- a/src/app/modal-path-selector/modal-path-selector.component.html
+++ b/src/app/modal-path-selector/modal-path-selector.component.html
@@ -10,7 +10,7 @@
           formControlName="path"
           required
           [matAutocomplete]="pathAutoComplete">
-        <button style="top:-8px" mat-button *ngIf="formGroup.value.path" matSuffix mat-icon-button aria-label="Clear" (click)="formGroup.controls['path'].patchValue('')">
+        <button style="top:-8px" mat-button *ngIf="formGroup.value.path" matSuffix mat-icon-button aria-label="Clear" (click)="formGroup.controls['path'].setValue('')">
           <span class="fa-solid fa-close"></span>
         </button>
         <mat-autocomplete #pathAutoComplete="matAutocomplete">

--- a/src/app/modal-path-selector/modal-path-selector.component.ts
+++ b/src/app/modal-path-selector/modal-path-selector.component.ts
@@ -64,9 +64,10 @@ export class ModalPathSelectorComponent implements OnInit, OnChanges {
     // autocomplete filtering
     this.filteredPaths = this.formGroup.controls['path'].valueChanges.pipe(startWith(''), map(value => this.filterPaths(value)))
 
+    this.formGroup.updateValueAndValidity();
+
     //subscribe to path formControl changes
     this.formGroup.controls['path'].valueChanges.subscribe(pathValue => {
-
       this.updateSourcesAndUnits();
       try {
         this.formGroup.controls['source'].reset(); // clear value
@@ -121,15 +122,19 @@ export class ModalPathSelectorComponent implements OnInit, OnChanges {
         this.availableSources = ['default'];
       } else if (Object.keys(pathObject.sources).length > 1) {
         this.availableSources = Object.keys(pathObject.sources);
+        if (this.formGroup.controls['source'].value == 'default') {
+          this.formGroup.controls['source'].reset();
+        }
       }
-      // this.availableSources = ['default'].concat(Object.keys(pathObject.sources));
     } else {
       // the path cannot be found. It's probably coming from default fixed Widget config, or user changed server URL, or Signal K server config. We need to disable the fields.
       try {
         this.formGroup.controls['source'].disable();
+        this.formGroup.controls['source'].reset();
         this.formGroup.controls['sampleTime'].disable();
         if (this.formGroup.controls['pathType'].value == 'number') { // convertUnitTo control not present unless pathType is number
           this.formGroup.controls['convertUnitTo'].disable();
+          this.formGroup.controls['convertUnitTo'].reset();
         }
       } catch (error) {
         console.debug(error);

--- a/src/app/signalk-delta.service.ts
+++ b/src/app/signalk-delta.service.ts
@@ -274,8 +274,8 @@ export class SignalKDeltaService {
             this.signalKNotifications$.next(notification);
 
           } else {
-            // It's a path value source update
-            if (typeof(item.value) == 'object') {
+            // It's a path value source update. Check if it's an Object. NOTE: null represents an undefined object and so is an object it's self, but in SK it should be handled as a value to mean: the path/source exists, but no value can ge generated. Ie. a depth sensor that can't read bottom depth in very deep water will send null.
+            if ((typeof(item.value) == 'object') && (item.value !== null)) {
 
               let keys = Object.keys(item.value);
               for (let i = 0; i < keys.length; i++) {
@@ -299,7 +299,7 @@ export class SignalKDeltaService {
                 this.signalKDataPath$.next(dataPath);
               }
             } else {
-              // It's a simple data value
+              // It's a Primitive type or a null value
               let dataPath: IPathValueData = {
                 context: context,
                 path: item.path,

--- a/src/app/signalk.service.ts
+++ b/src/app/signalk.service.ts
@@ -219,13 +219,17 @@ export class SignalKService {
     let pathIndex = this.skData.findIndex(pathObject => pathObject.path == updatePath);
     if (pathIndex >= 0) { // exists
 
-      if (this.skData[pathIndex].defaultSource == null) { // null means the path was first created to a Meta update. Meta updates don't contain source information so we set default source on first source data update.
+      if (this.skData[pathIndex].defaultSource === undefined) { // undefined means the path was first created to a Meta update. Meta updates don't contain source information so we set default source on first source data update.
         this.skData[pathIndex].defaultSource = dataPath.source;
       }
-      if (this.skData[pathIndex].type == null) { // null means the path was first created to a Meta update. Meta updates don't contain source information so we set default source on first source data update.
+      if ((this.skData[pathIndex].type === undefined) && (dataPath.value !== null)) {
+        // undefined means the path was first created by a Meta update. Meta updates don't
+        // contain source information so we set default source on first source data update.
+        // If the value is null, we don't set the value type yet as null is of type object
+        // and it's not what we want. If null we wait to set the type when we get a value.
         this.skData[pathIndex].type = typeof(dataPath.value);
 
-        // set path data type to accommodate for SK datetype
+        // Manually set path string data type if of valid SK datetype
         if (typeof(dataPath.value) == "string") {
           if (isRfc3339StringDate(dataPath.value)) {
             this.skData[pathIndex].type = "Date";
@@ -360,11 +364,11 @@ export class SignalKService {
     } else { // not in our list yet. The Meta update came before the Source update.
       this.skData.push({
         path: metaPath,
-        pathValue: null,
-        defaultSource: null,
+        pathValue: undefined,
+        defaultSource: undefined,
         sources: {},
         meta: meta.meta,
-        type: null,
+        type: undefined,
         state: IZoneState.normal
       });
     }


### PR DESCRIPTION
Fix null values parsing received from SK. Do not set KIP data type to object when values is null and wait until a value that can be set to a type is received as this prevents widget from listing appropriate path types. Fix widget Options to clear invalide sources and improve source selection dorpdown list.