### PR TITLE
Added unit grp filter on paths

### DIFF
--- a/src/app/signalk.service.ts
+++ b/src/app/signalk.service.ts
@@ -408,10 +408,10 @@ export class SignalKService {
     return this.skDataObservable.asObservable();
   }
 
-  getPathsAndMetaByType(valueType: string, selfOnly?: boolean): IPathMetaData[] { //TODO(David): See how we should handle string and boolean type value. We should probably return error and not search for it, plus remove from the Units UI.
+  getPathsAndMetaByType(valueType: string, selfOnly?: boolean, unit?: string): IPathMetaData[] { //TODO(David): See how we should handle string and boolean type value. We should probably return error and not search for it, plus remove from the Units UI.
     let pathsMeta: IPathMetaData[] = [];
     for (let i = 0; i < this.skData.length;  i++) {
-       if (this.skData[i].type == valueType) {
+      if ((this.skData[i].type == valueType) && (this.unitFilter(this.skData[i],unit))) {
          if (selfOnly) {
           if (this.skData[i].path.startsWith("self")) {
             let p:IPathMetaData = {
@@ -430,6 +430,19 @@ export class SignalKService {
       }
     }
     return pathsMeta; // copy it....
+  }
+  // A weak filter only test if skData and unit have unit data
+  // return true if units match
+  private unitFilter(skData, unit: string): boolean{
+    let isOk=true;
+    if (unit){
+      if ((unit!='unitless') && (skData.type == 'number')){
+        if (('meta' in skData) && ('units' in skData.meta)){
+          isOk = (skData.meta.units == unit)
+        }
+      }
+    }
+    return isOk
   }
 
   getPathObject(path): IPathData {

--- a/src/app/units.service.ts
+++ b/src/app/units.service.ts
@@ -10,6 +10,7 @@ import { Subscription } from 'rxjs';
 export interface IUnitGroup {
   group: string;
   units: IUnit[];
+  skUnit: string;
 }[]
 
 /**
@@ -44,25 +45,25 @@ export class UnitsService {
   conversionList: IUnitGroup[] = [
     { group: 'Unitless', units: [
       { measure: 'unitless', description: "As-Is numeric value" }
-    ] },
+    ],skUnit: null},
     { group: 'Speed', units: [
       { measure: 'knots', description: "Knots - Nautical miles per hour"},
       { measure: 'kph', description: "kph - Kilometers per hour"},
       { measure: 'mph', description: "mph - Miles per hour"},
       { measure: 'm/s', description: "m/s - Meters per second (default)"}
-    ] },
+    ],skUnit: 'm/s'},
     { group: 'Flow', units: [
       { measure: 'm3/s', description: "Cubic meters per second (default)"},
       { measure: 'l/min', description: "Liters per minute"},
       { measure: 'l/h', description: "Liters per hour"},
       { measure: 'g/min', description: "Gallons per minute"},
       { measure: 'g/h', description: "Gallons per hour"}
-    ] },
+    ],skUnit: 'm3/s'},
     { group: 'Temperature', units: [
       { measure: 'K', description: "Kelvin (default)"},
       { measure: 'celsius', description: "Celsius"},
       { measure: 'fahrenheit', description: "Fahrenheit"}
-     ] },
+    ],skUnit: 'K'},
     { group: 'Length', units: [
       { measure: 'm', description: "Metres (default)"},
       { measure: 'fathom', description: "Fathoms"},
@@ -70,32 +71,32 @@ export class UnitsService {
       { measure: 'km', description: "Kilometers"},
       { measure: 'nm', description: "Nautical Miles"},
       { measure: 'mi', description: "Miles"},
-    ] },
+    ],skUnit: 'm'},
     { group: 'Volume', units: [
       { measure: 'liter', description: "Liters (default)"},
       { measure: 'm3', description: "Cubic Meters"},
       { measure: 'gallon', description: "Gallons"},
-     ] },
+    ],skUnit: 'm3'},
     { group: 'Current', units: [
       { measure: 'A', description: "Amperes"},
       { measure: 'mA', description: "Milliamperes"}
-    ] },
+    ],skUnit: 'A'},
     { group: 'Potential', units: [
       { measure: 'V', description: "Volts"},
       { measure: 'mV', description: "Millivolts"}
-    ] },
+    ],skUnit: 'V'},
     { group: 'Charge', units: [
       { measure: 'C', description: "Coulomb"},
       { measure: 'Ah', description: "Ampere*Hours"},
-    ] },
+    ],skUnit: 'C'},
     { group: 'Power', units: [
       { measure: 'W', description: "Watts"},
       { measure: 'mW', description: "Milliwatts"},
-    ] },
+    ],skUnit: 'W'},
     { group: 'Energy', units: [
       { measure: 'J', description: "Joules"},
       { measure: 'kWh', description: "Kilo-Watt*Hours"},
-    ] },
+    ],skUnit: 'J'},
     { group: 'Pressure', units: [
       { measure: 'Pa', description: "Pascal (default)" },
       { measure: 'bar', description: "Bars" },
@@ -104,43 +105,45 @@ export class UnitsService {
       { measure: 'inHg', description: "inHg" },
       { measure: 'hPa', description: "hPa" },
       { measure: 'mbar', description: "mbar" },
-    ] },
-    { group: 'Density', units: [ { measure: 'kg/m3', description: "Air density - kg/cubic meter"} ] },
+    ],skUnit: 'Pa'},
+    { group: 'Density', units: [
+      { measure: 'kg/m3', description: "Air density - kg/cubic meter"}
+    ],skUnit: 'kg/m3'},
     { group: 'Time', units: [
       { measure: 's', description: "Seconds (default)" },
       { measure: 'Minutes', description: "Minutes" },
       { measure: 'Hours', description: "Hours" },
       { measure: 'Days', description: "Days" },
       { measure: 'HH:MM:SS', description: "Hours:Minute:seconds"}
-    ] },
+    ],skUnit: 's'},
     { group: 'Angular Velocity', units: [
       { measure: 'rad/s', description: "Radians per second" },
       { measure: 'deg/s', description: "Degrees per second" },
       { measure: 'deg/min', description: "Degrees per minute" },
-    ] },
-    { group: 'Angle', units: [
-      { measure: 'rad', description: "Radians" },
-      { measure: 'deg', description: "Degrees" },
-      { measure: 'grad', description: "Gradians" },
-    ] },
+    ],skUnit: 'rad/s'},
     { group: 'Frequency', units: [
       { measure: 'rpm', description: "RPM - Rotations per minute" },
       { measure: 'Hz', description: "Hz - Hertz (default)" },
       { measure: 'KHz', description: "KHz - KiloHertz" },
       { measure: 'MHz', description: "MHz - MegaHertz" },
       { measure: 'GHz', description: "GHz - GigaHertz" },
-    ] },
+    ],skUnit: 'Hz' },
     { group: 'Ratio', units: [
       { measure: 'percent', description: "As percentage value" },
       { measure: 'percentraw', description: "As ratio 0-1 with % sign" },
       { measure: 'ratio', description: "Ratio 0-1 (default)" }
-    ] },
+    ],skUnit: 'ratio'},
+    { group: 'Angle', units: [
+      { measure: 'rad', description: "Radians" },
+      { measure: 'deg', description: "Degrees" },
+      { measure: 'grad', description: "Gradians" },
+    ],skUnit: 'rad'},
     { group: 'Position', units: [
       { measure: 'latitudeMin', description: "Latitude in minutes" },
       { measure: 'latitudeSec', description: "Latitude in seconds" },
       { measure: 'longitudeMin', description: "Longitude in minutes" },
       { measure: 'longitudeSec', description: "Longitude in seconds" },
-    ] },
+    ],skUnit: 'rad'},
   ];
 
 
@@ -299,5 +302,37 @@ export class UnitsService {
   getConversions(): IUnitGroup[] {
     return this.conversionList;
   }
-
+  getSkUnit(groupId: string):string {
+    let skUnit = null
+    for (const unitGroup of this.conversionList){
+      if (unitGroup.group === groupId){
+        skUnit = unitGroup.skUnit;
+        break;
+      }
+    }
+    return skUnit;
+  }
+  getGroupOfUnit(unit: string) :string{
+    let groupId = 'Unitless';
+    loop1:
+    for (const unitGroup of this.conversionList){
+      for (const ugUnit of unitGroup.units){
+        if (ugUnit.measure === unit){
+          groupId = unitGroup.group;
+          break loop1;
+        }
+      }
+    }
+    return groupId;
+  }
+  getUnitGroup(groupId: string) :IUnitGroup{
+    let group = null;
+    for (const unitGroup of this.conversionList){
+      if (unitGroup.group == groupId){
+        group = unitGroup;
+        break;
+      }
+    }
+    return group;
+  }
 }

--- a/src/app/units.service.ts
+++ b/src/app/units.service.ts
@@ -143,7 +143,7 @@ export class UnitsService {
       { measure: 'latitudeSec', description: "Latitude in seconds" },
       { measure: 'longitudeMin', description: "Longitude in minutes" },
       { measure: 'longitudeSec', description: "Longitude in seconds" },
-    ],skUnit: 'rad'},
+    ],skUnit: 'rad'},// Postion data stream data can be both deg and rad but we only handle rad
   ];
 
 

--- a/src/app/widget-config/path-control-config/path-control-config.component.html
+++ b/src/app/widget-config/path-control-config/path-control-config.component.html
@@ -9,6 +9,7 @@
         placeholder="Select path (note dropdown limited to 50, type to use autocomplete)"
         formControlName="path"
         required
+        spellcheck="false"
         [matAutocomplete]="pathAutoComplete">
       <button style="top:-8px" mat-button *ngIf="pathFormGroup.value.path" matSuffix mat-icon-button aria-label="Clear" (click)="pathFormGroup.controls['path'].setValue('')">
         <span class="fa-solid fa-close"></span>
@@ -63,7 +64,7 @@
             placeholder="Select unit"
             formControlName="convertUnitTo"
             required>
-            <mat-optgroup *ngFor="let group of unitList.conversions" [label]="group.group">
+            <mat-optgroup *ngFor="let group of unitCtrl.conversions" [label]="group.group">
               <mat-option *ngFor="let unit of group.units" [value]="unit.measure">
                 {{unit.description}}
               </mat-option>

--- a/src/app/widget-config/path-control-config/path-control-config.component.html
+++ b/src/app/widget-config/path-control-config/path-control-config.component.html
@@ -64,12 +64,29 @@
             placeholder="Select unit"
             formControlName="convertUnitTo"
             required>
-            <mat-optgroup *ngFor="let group of unitCtrl.conversions" [label]="group.group">
+            <mat-optgroup *ngFor="let group of unitList.conversions" [label]="group.group">
               <mat-option *ngFor="let unit of group.units" [value]="unit.measure">
                 {{unit.description}}
               </mat-option>
             </mat-optgroup>
         </mat-select>
+      </mat-form-field>
+    </div>
+    <div class="unitGrpFilter">
+      <mat-form-field *ngIf="pathFormGroup.value.pathType == 'number'" class="fields" appearance="outline" floatLabel="always" >
+        <mat-label>Filter path results</mat-label>
+        <mat-form-field class="fields" appearance="outline" floatLabel="always">
+          <mat-label>Unit Types</mat-label>
+          <mat-select
+          placeholder="Select unit type"
+          formControlName="unitGrpFilter"
+          required>
+            <mat-option *ngFor="let group of unitGrpsCtrl.conversions" [value]="group.group">
+              {{group.group}}
+            </mat-option>
+          </mat-select>
+        </mat-form-field>
+        <button *ngIf="unitGrpsCtrl.conversions.length != 1" mat-flat-button type="button" color ="accent" (click)="clearUnitGrpFilter()" class="filterButton">Clear filter</button>
       </mat-form-field>
     </div>
   </div>

--- a/src/app/widget-config/path-control-config/path-control-config.component.html
+++ b/src/app/widget-config/path-control-config/path-control-config.component.html
@@ -72,22 +72,20 @@
         </mat-select>
       </mat-form-field>
     </div>
-    <div class="unitGrpFilter">
-      <mat-form-field *ngIf="pathFormGroup.value.pathType == 'number'" class="fields" appearance="outline" floatLabel="always" >
-        <mat-label>Filter path results</mat-label>
-        <mat-form-field class="fields" appearance="outline" floatLabel="always">
-          <mat-label>Unit Types</mat-label>
-          <mat-select
-          placeholder="Select unit type"
-          formControlName="unitGrpFilter"
-          required>
-            <mat-option *ngFor="let group of unitGrpsCtrl.conversions" [value]="group.group">
-              {{group.group}}
-            </mat-option>
-          </mat-select>
-        </mat-form-field>
-        <button *ngIf="unitGrpsCtrl.conversions.length != 1" mat-flat-button type="button" color ="accent" (click)="clearUnitGrpFilter()" class="filterButton">Clear filter</button>
+    <div *ngIf="pathFormGroup.value.pathType == 'number'" class="unitGrpFilter">
+      <mat-label>Filter Path Results</mat-label>
+      <mat-form-field class="fields" appearance="outline" floatLabel="always">
+        <mat-label>Unit Types</mat-label>
+        <mat-select
+        placeholder="Select unit type"
+        formControlName="unitGrpFilter"
+        required>
+          <mat-option *ngFor="let group of unitGrpsCtrl.conversions" [value]="group.group">
+            {{group.group}}
+          </mat-option>
+        </mat-select>
       </mat-form-field>
+      <button *ngIf="unitGrpsCtrl.conversions.length != 1" mat-flat-button type="button" color ="accent" (click)="clearUnitGrpFilter()" class="filterButton">Clear filter</button>
     </div>
   </div>
 </div>

--- a/src/app/widget-config/path-control-config/path-control-config.component.scss
+++ b/src/app/widget-config/path-control-config/path-control-config.component.scss
@@ -50,3 +50,6 @@
 .unitField {
   flex: 3 1;
 }
+.unitGrpFilter{
+  flex: 3 1;
+}

--- a/src/app/widget-config/path-control-config/path-control-config.component.ts
+++ b/src/app/widget-config/path-control-config/path-control-config.component.ts
@@ -25,16 +25,14 @@ export class ModalPathControlConfigComponent implements OnInit, OnChanges, OnDes
   public availablePaths: IPathMetaData[];
   public filteredPaths: Observable<IPathMetaData[]>;
   private pathValueChange$: Subscription = null;
-  private unitValueChange$: Subscription = null;
+  private unitGrpValChange$: Subscription = null;
 
   // Sources control
   public availableSources: Array<string>;
 
-  //unit control
-  public unitCtrl: {conversions?: IUnitGroup[],
-                    isSingle?: boolean,
-                    groupId?: string,
-                   };
+  // Units control
+  public unitList: {default?: string, conversions?: IUnitGroup[] };
+  public unitGrpsCtrl: {conversions: IUnitGroup[],curGrpId: string};
 
   constructor(
     private signalKService: SignalKService,
@@ -42,13 +40,10 @@ export class ModalPathControlConfigComponent implements OnInit, OnChanges, OnDes
     ) { }
 
   ngOnInit() {
-    this.unitInit()
-    //populate available paths
-    this.getPaths(this.filterSelfPaths,this.unitCtrl.groupId);
-
-    // add path validator fn and validate
-    this.pathFormGroup.controls['path'].setValidators([Validators.required, requirePathMatch(this.availablePaths)]);
-    this.pathFormGroup.controls['path'].updateValueAndValidity({onlySelf: true, emitEvent: false});
+    this.unitList = {};
+    this.initUnitGrp();
+        //populate available paths
+    this.getPaths(this.filterSelfPaths,false);
 
     // If SampleTime control is not present because the path property is missing, add it.
     if (!this.pathFormGroup.controls['sampleTime']) {
@@ -56,8 +51,8 @@ export class ModalPathControlConfigComponent implements OnInit, OnChanges, OnDes
       this.pathFormGroup.controls['sampleTime'].updateValueAndValidity();
     }
 
-    //populate sources for this path (or just the current or default setting if we know nothing about the path)
-    this.updateSources();
+    //populate sources and units for this path (or just the current or default setting if we know nothing about the path)
+    this.updateSourcesAndUnits();
 
     // this.formGroup.updateValueAndValidity();
 
@@ -72,10 +67,8 @@ export class ModalPathControlConfigComponent implements OnInit, OnChanges, OnDes
     this.pathValueChange$ = this.pathFormGroup.controls['path'].valueChanges.subscribe( pathValue => {
         if (this.pathFormGroup.controls['path'].valid) {
           this.enableFormFields(true);
-          this.unitPathChg(true);
         } else {
           this.disablePathFields();
-          this.unitPathChg(false);
         }
       }
     );
@@ -84,7 +77,7 @@ export class ModalPathControlConfigComponent implements OnInit, OnChanges, OnDes
   ngOnChanges(changes: {[propertyName: string]: SimpleChange}) {
     //subscribe to filterSelfPaths parent formControl changes
     if (changes['filterSelfPaths'] && !changes['filterSelfPaths'].firstChange) {
-      this.getPaths(this.filterSelfPaths,this.unitCtrl.groupId);
+      this.getPaths(this.filterSelfPaths);
     } else if (changes['pathFormGroup'] && !changes['pathFormGroup'].firstChange) {
       this.pathFormGroup.updateValueAndValidity();
     }
@@ -95,13 +88,22 @@ export class ModalPathControlConfigComponent implements OnInit, OnChanges, OnDes
     }
  }
 
-  private getPaths(isOnlySef: boolean, groupId: string) {
-    if (groupId == 'Unitless'){
-      this.availablePaths = this.signalKService.getPathsAndMetaByType(this.pathFormGroup.value.pathType, isOnlySef).sort();
-    }else{
-      let skUnit = this.unitService.getSkUnit(groupId)
+  private getPaths(isOnlySef: boolean, emitEvent=true) {
+    if (this.pathFormGroup.controls['pathType'].value == 'number'){
+      const grpId = this.pathFormGroup.controls['unitGrpFilter'].value
+      if (grpId == 'Unitless'){
+        this.availablePaths = this.signalKService.getPathsAndMetaByType(this.pathFormGroup.value.pathType, isOnlySef).sort();
+      }else{
+      let skUnit = this.unitService.getSkUnit(grpId)
       this.availablePaths = this.signalKService.getPathsAndMetaByType(this.pathFormGroup.value.pathType, isOnlySef, skUnit).sort();
+      }
+    }else{
+      this.availablePaths = this.signalKService.getPathsAndMetaByType(this.pathFormGroup.value.pathType, isOnlySef).sort();
     }
+    // add path validator fn and validate
+    this.pathFormGroup.controls['path'].setValidators([Validators.required, requirePathMatch(this.availablePaths)]);
+    this.pathFormGroup.controls['path'].updateValueAndValidity({onlySelf: true,emitEvent: emitEvent});
+
   }
 
   private filterPaths( value: string ): IPathMetaData[] {
@@ -109,7 +111,7 @@ export class ModalPathControlConfigComponent implements OnInit, OnChanges, OnDes
     return this.availablePaths.filter(pathAndMetaObj => pathAndMetaObj.path.toLowerCase().includes(filterValue)).slice(0,50);
   }
 
-  private updateSources() {
+  private updateSourcesAndUnits() {
     if ((!this.pathFormGroup.value.path) || (this.pathFormGroup.value.path == '') || (!this.pathFormGroup.controls['path'].valid)) {
       this.disablePathFields();
     } else {
@@ -121,6 +123,17 @@ export class ModalPathControlConfigComponent implements OnInit, OnChanges, OnDes
     let pathObject = this.signalKService.getPathObject(this.pathFormGroup.controls['path'].value);
     if (pathObject != null) {
       this.pathFormGroup.controls['sampleTime'].enable({onlySelf: true});
+      if (this.pathFormGroup.controls['pathType'].value == 'number') { // convertUnitTo control not present unless pathType is number
+        if (!this.pathFormGroup.controls['isFilterFixed'].value) {
+          this.unitList = this.signalKService.getConversionsForPath(this.pathFormGroup.controls['path'].value); // array of Group or Groups: "angle", "speed", etc...
+        }
+        if (setValues) {
+          this.pathFormGroup.controls['convertUnitTo'].setValue(this.unitList.default, {onlySelf: true});
+          this.unitGrpPathChg()
+        }
+        this.pathFormGroup.controls['convertUnitTo'].enable({onlySelf: true});
+      }
+
       if (Object.keys(pathObject.sources).length == 1) {
         this.availableSources = ['default'];
         if (setValues) {
@@ -145,70 +158,74 @@ export class ModalPathControlConfigComponent implements OnInit, OnChanges, OnDes
     this.pathFormGroup.controls['source'].reset('', {onlySelf: true});
     this.pathFormGroup.controls['source'].disable({onlySelf: true});
     this.pathFormGroup.controls['sampleTime'].disable({onlySelf: true});
-  }
-  private unitInit() {
-    if (this.pathFormGroup.controls['pathType'].value == 'number'){
-      const cfGroup = this.pathFormGroup.controls['unitGroup'].value;
-      if (cfGroup == 'Unitless') {
-        let groupId = this.unitService.getGroupOfUnit(cfGroup)
-        this.unitCtrl = {conversions: this.unitService.getConversions(),
-                         isSingle: false,
-                         groupId: groupId,
-                        };
-        this.unitValueChange$ = this.pathFormGroup.controls['convertUnitTo'].valueChanges.subscribe({
-          next:  unitValue => {
-            this.unitChg(unitValue);
-          },
-        });
-
-      }else{
-        this.unitCtrl = {conversions: [this.unitService.getUnitGroup(cfGroup)],
-                         isSingle: true,
-                         groupId: cfGroup,
-                        };
-      }
-    }else{
-      this.unitCtrl = {groupId: 'Unitless'};
-    }
-  }
-
- private unitChg(newUnit: string){
-    let nextGroupId = this.unitService.getGroupOfUnit(newUnit);
-    if (this.unitCtrl.groupId != nextGroupId){
-      this.unitCtrl.groupId  = nextGroupId;
-      this.getPaths(this.filterSelfPaths,this.unitCtrl.groupId);
-      this.pathFormGroup.controls['path'].updateValueAndValidity({onlySelf: true});
-    }
-  }
-
-  private unitPathChg(isValid: boolean){
     if (this.pathFormGroup.controls['pathType'].value == 'number') { // convertUnitTo control not present unless pathType is number
-      if (isValid) {
-        if (!this.unitCtrl.isSingle){
-          let skUnits = this.signalKService.getConversionsForPath(this.pathFormGroup.controls['path'].value);
-          if (skUnits.conversions.length == 1){
-            if (skUnits.conversions[0].group!=this.unitCtrl.groupId){
-              this.pathFormGroup.controls['convertUnitTo'].setValue(skUnits.default, {onlySelf: true});
-
-            }
-          }else if(skUnits.conversions.length == 2){
-            //Position returns two groups and default on deg from Angle
-            //Position is the only group that do not have a default setting.
-            //Place Position and Angle group next to each other so the default
-            //value do not matter much.
-            if (skUnits.conversions[1].group!=this.unitCtrl.groupId && skUnits.conversions[0].group!=this.unitCtrl.groupId){
-              this.pathFormGroup.controls['convertUnitTo'].setValue(skUnits.default, {onlySelf: true});
-            }
-          }
-        }
-      }
+      this.pathFormGroup.controls['convertUnitTo'].reset('', {onlySelf: true});
+      this.pathFormGroup.controls['convertUnitTo'].disable({onlySelf: true});
     }
   }
 
   ngOnDestroy(): void {
-    if (this.unitValueChange$){
-      this.unitValueChange$.unsubscribe();
+    if (this.unitGrpValChange$){
+      this.unitGrpValChange$.unsubscribe()
     }
     this.pathValueChange$.unsubscribe();
+  }
+  clearUnitGrpFilter(): void{
+    const newGrpId = 'Unitless'
+    this.pathFormGroup.controls['unitGrpFilter'].setValue(newGrpId, {onlySelf: true,emitEvent: false});
+    this.unitGrpUpd(newGrpId,false);
+  }
+
+  private initUnitGrp(): void{
+    if (this.pathFormGroup.controls['pathType'].value == 'number'){
+      let cfGroupId = this.pathFormGroup.controls['unitGrpFilter'].value;
+      if (this.pathFormGroup.controls['isFilterFixed'].value) {
+        this.unitList={
+          default: this.unitService.getDefaults()[cfGroupId],
+          conversions: [this.unitService.getUnitGroup(cfGroupId)]
+        };
+        this.unitGrpsCtrl={conversions: [this.unitService.getUnitGroup(cfGroupId)],curGrpId:cfGroupId};
+      }else{
+        this.unitGrpValChange$ = this.pathFormGroup.controls['unitGrpFilter'].valueChanges.subscribe({
+          next:  newGrpId => {
+            this.unitGrpUpd(newGrpId,true);
+          },
+        });
+        const curUnit = this.pathFormGroup.controls['convertUnitTo'].value;
+        if ( curUnit!=="unitless"){
+          const unitGrpId = this.unitService.getGroupOfUnit(curUnit);
+          if ( unitGrpId!== cfGroupId){
+            this.pathFormGroup.controls['unitGrpFilter'].setValue(unitGrpId, {onlySelf: true,emitEvent: false});
+            cfGroupId = unitGrpId;
+          }
+        }
+        this.unitGrpsCtrl={conversions: this.unitService.getConversions(),curGrpId:cfGroupId};
+      }
+    }
+  }
+
+  private unitGrpPathChg(){
+    if (this.unitList.conversions.length == 1){
+      const newGrpId=this.unitList.conversions[0].group
+      if (newGrpId != this.unitGrpsCtrl.curGrpId){
+        this.pathFormGroup.controls['unitGrpFilter'].setValue(newGrpId, {onlySelf: true,emitEvent: false});
+        this.unitGrpUpd(newGrpId,false)
+      }
+    }else{
+      //Position returns two groups and default on deg from Angle
+      //Position is the only group that do not have a default setting.
+      //Position skUnit is rad signal k path definition is deg but the conversion function is rad.
+      //The data in signal k test is rad but the meta data have units sat to deg.
+      //Setting widget default config (unitGrpFilter) to position and fixed would be a problem
+      //when meta data dont match.
+      //I have seen both deg and rad data on positions paths.
+      this.pathFormGroup.controls['unitGrpFilter'].setValue('Unitless', {onlySelf: true});
+    }
+  }
+  private unitGrpUpd(newGrpId: string,emitPathEvent: boolean){
+    if (this.unitGrpsCtrl.curGrpId !== newGrpId){// It is easy to tricker a loop stop it here
+      this.unitGrpsCtrl.curGrpId = newGrpId;
+      this.getPaths(this.filterSelfPaths,emitPathEvent);
+    }
   }
 }

--- a/src/app/widget-config/path-control-config/path-control-config.component.ts
+++ b/src/app/widget-config/path-control-config/path-control-config.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnInit, OnChanges, SimpleChange, OnDestroy } from '@angular/core';
 import { SignalKService } from '../../signalk.service';
 import { IPathMetaData } from "../../app-interfaces";
-import { IUnitGroup } from '../../units.service';
+import { UnitsService, IUnitGroup } from '../../units.service';
 import { UntypedFormGroup, UntypedFormControl, Validators, ValidatorFn, AbstractControl, ValidationErrors } from '@angular/forms';
 import { debounceTime, map, startWith } from 'rxjs/operators';
 import { Observable, Subscription } from 'rxjs'
@@ -25,21 +25,26 @@ export class ModalPathControlConfigComponent implements OnInit, OnChanges, OnDes
   public availablePaths: IPathMetaData[];
   public filteredPaths: Observable<IPathMetaData[]>;
   private pathValueChange$: Subscription = null;
+  private unitValueChange$: Subscription = null;
 
   // Sources control
   public availableSources: Array<string>;
 
-  // Units control
-  public unitList: {default?: string, conversions?: IUnitGroup[] };
+  //unit control
+  public unitCtrl: {conversions?: IUnitGroup[],
+                    isSingle?: boolean,
+                    groupId?: string,
+                   };
 
   constructor(
-    private signalKService: SignalKService
+    private signalKService: SignalKService,
+    private unitService: UnitsService
     ) { }
 
   ngOnInit() {
-    this.unitList = {};
+    this.unitInit()
     //populate available paths
-    this.getPaths(this.filterSelfPaths);
+    this.getPaths(this.filterSelfPaths,this.unitCtrl.groupId);
 
     // add path validator fn and validate
     this.pathFormGroup.controls['path'].setValidators([Validators.required, requirePathMatch(this.availablePaths)]);
@@ -51,8 +56,8 @@ export class ModalPathControlConfigComponent implements OnInit, OnChanges, OnDes
       this.pathFormGroup.controls['sampleTime'].updateValueAndValidity();
     }
 
-    //populate sources and units for this path (or just the current or default setting if we know nothing about the path)
-    this.updateSourcesAndUnits();
+    //populate sources for this path (or just the current or default setting if we know nothing about the path)
+    this.updateSources();
 
     // this.formGroup.updateValueAndValidity();
 
@@ -67,8 +72,10 @@ export class ModalPathControlConfigComponent implements OnInit, OnChanges, OnDes
     this.pathValueChange$ = this.pathFormGroup.controls['path'].valueChanges.subscribe( pathValue => {
         if (this.pathFormGroup.controls['path'].valid) {
           this.enableFormFields(true);
+          this.unitPathChg(true);
         } else {
           this.disablePathFields();
+          this.unitPathChg(false);
         }
       }
     );
@@ -77,7 +84,7 @@ export class ModalPathControlConfigComponent implements OnInit, OnChanges, OnDes
   ngOnChanges(changes: {[propertyName: string]: SimpleChange}) {
     //subscribe to filterSelfPaths parent formControl changes
     if (changes['filterSelfPaths'] && !changes['filterSelfPaths'].firstChange) {
-      this.getPaths(this.filterSelfPaths);
+      this.getPaths(this.filterSelfPaths,this.unitCtrl.groupId);
     } else if (changes['pathFormGroup'] && !changes['pathFormGroup'].firstChange) {
       this.pathFormGroup.updateValueAndValidity();
     }
@@ -88,8 +95,13 @@ export class ModalPathControlConfigComponent implements OnInit, OnChanges, OnDes
     }
  }
 
-  private getPaths(isOnlySef: boolean) {
-    this.availablePaths = this.signalKService.getPathsAndMetaByType(this.pathFormGroup.value.pathType, isOnlySef).sort();
+  private getPaths(isOnlySef: boolean, groupId: string) {
+    if (groupId == 'Unitless'){
+      this.availablePaths = this.signalKService.getPathsAndMetaByType(this.pathFormGroup.value.pathType, isOnlySef).sort();
+    }else{
+      let skUnit = this.unitService.getSkUnit(groupId)
+      this.availablePaths = this.signalKService.getPathsAndMetaByType(this.pathFormGroup.value.pathType, isOnlySef, skUnit).sort();
+    }
   }
 
   private filterPaths( value: string ): IPathMetaData[] {
@@ -97,7 +109,7 @@ export class ModalPathControlConfigComponent implements OnInit, OnChanges, OnDes
     return this.availablePaths.filter(pathAndMetaObj => pathAndMetaObj.path.toLowerCase().includes(filterValue)).slice(0,50);
   }
 
-  private updateSourcesAndUnits() {
+  private updateSources() {
     if ((!this.pathFormGroup.value.path) || (this.pathFormGroup.value.path == '') || (!this.pathFormGroup.controls['path'].valid)) {
       this.disablePathFields();
     } else {
@@ -109,14 +121,6 @@ export class ModalPathControlConfigComponent implements OnInit, OnChanges, OnDes
     let pathObject = this.signalKService.getPathObject(this.pathFormGroup.controls['path'].value);
     if (pathObject != null) {
       this.pathFormGroup.controls['sampleTime'].enable({onlySelf: true});
-      if (this.pathFormGroup.controls['pathType'].value == 'number') { // convertUnitTo control not present unless pathType is number
-        this.unitList = this.signalKService.getConversionsForPath(this.pathFormGroup.controls['path'].value); // array of Group or Groups: "angle", "speed", etc...
-        if (setValues) {
-          this.pathFormGroup.controls['convertUnitTo'].setValue(this.unitList.default, {onlySelf: true});
-        }
-        this.pathFormGroup.controls['convertUnitTo'].enable({onlySelf: true});
-      }
-
       if (Object.keys(pathObject.sources).length == 1) {
         this.availableSources = ['default'];
         if (setValues) {
@@ -141,13 +145,70 @@ export class ModalPathControlConfigComponent implements OnInit, OnChanges, OnDes
     this.pathFormGroup.controls['source'].reset('', {onlySelf: true});
     this.pathFormGroup.controls['source'].disable({onlySelf: true});
     this.pathFormGroup.controls['sampleTime'].disable({onlySelf: true});
+  }
+  private unitInit() {
+    if (this.pathFormGroup.controls['pathType'].value == 'number'){
+      const cfGroup = this.pathFormGroup.controls['unitGroup'].value;
+      if (cfGroup == 'Unitless') {
+        let groupId = this.unitService.getGroupOfUnit(cfGroup)
+        this.unitCtrl = {conversions: this.unitService.getConversions(),
+                         isSingle: false,
+                         groupId: groupId,
+                        };
+        this.unitValueChange$ = this.pathFormGroup.controls['convertUnitTo'].valueChanges.subscribe({
+          next:  unitValue => {
+            this.unitChg(unitValue);
+          },
+        });
+
+      }else{
+        this.unitCtrl = {conversions: [this.unitService.getUnitGroup(cfGroup)],
+                         isSingle: true,
+                         groupId: cfGroup,
+                        };
+      }
+    }else{
+      this.unitCtrl = {groupId: 'Unitless'};
+    }
+  }
+
+ private unitChg(newUnit: string){
+    let nextGroupId = this.unitService.getGroupOfUnit(newUnit);
+    if (this.unitCtrl.groupId != nextGroupId){
+      this.unitCtrl.groupId  = nextGroupId;
+      this.getPaths(this.filterSelfPaths,this.unitCtrl.groupId);
+      this.pathFormGroup.controls['path'].updateValueAndValidity({onlySelf: true});
+    }
+  }
+
+  private unitPathChg(isValid: boolean){
     if (this.pathFormGroup.controls['pathType'].value == 'number') { // convertUnitTo control not present unless pathType is number
-      this.pathFormGroup.controls['convertUnitTo'].reset('', {onlySelf: true});
-      this.pathFormGroup.controls['convertUnitTo'].disable({onlySelf: true});
+      if (isValid) {
+        if (!this.unitCtrl.isSingle){
+          let skUnits = this.signalKService.getConversionsForPath(this.pathFormGroup.controls['path'].value);
+          if (skUnits.conversions.length == 1){
+            if (skUnits.conversions[0].group!=this.unitCtrl.groupId){
+              this.pathFormGroup.controls['convertUnitTo'].setValue(skUnits.default, {onlySelf: true});
+
+            }
+          }else if(skUnits.conversions.length == 2){
+            //Position returns two groups and default on deg from Angle
+            //Position is the only group that do not have a default setting.
+            //Place Position and Angle group next to each other so the default
+            //value do not matter much.
+            if (skUnits.conversions[1].group!=this.unitCtrl.groupId && skUnits.conversions[0].group!=this.unitCtrl.groupId){
+              this.pathFormGroup.controls['convertUnitTo'].setValue(skUnits.default, {onlySelf: true});
+            }
+          }
+        }
+      }
     }
   }
 
   ngOnDestroy(): void {
+    if (this.unitValueChange$){
+      this.unitValueChange$.unsubscribe();
+    }
     this.pathValueChange$.unsubscribe();
   }
 }

--- a/src/app/widgets-interface.ts
+++ b/src/app/widgets-interface.ts
@@ -260,4 +260,6 @@ export interface IWidgetPath {
   policy?: Policy;
   /** NOT IMPLEMENTED -Signal K - minPeriod=[milliseconds] becomes the fastest message transmission rate allowed, e.g. every minPeriod/1000 seconds. This is only relevant for policy='instant' to avoid swamping the client or network. */
   minPeriod?: number;
+  /**If pathType is number unitGroup most be included. Path is filtered  on unit group(ex Speed) if more groups is possible use Unitless .*/
+  unitGroup?: string
 }

--- a/src/app/widgets-interface.ts
+++ b/src/app/widgets-interface.ts
@@ -260,6 +260,11 @@ export interface IWidgetPath {
   policy?: Policy;
   /** NOT IMPLEMENTED -Signal K - minPeriod=[milliseconds] becomes the fastest message transmission rate allowed, e.g. every minPeriod/1000 seconds. This is only relevant for policy='instant' to avoid swamping the client or network. */
   minPeriod?: number;
-  /**If pathType is number unitGroup most be included. Path is filtered  on unit group(ex Speed) if more groups is possible use Unitless .*/
-  unitGroup?: string
+  /**If pathType is number unitGrpFilter and isFilterFixed most be included.
+  Path is filtered on unit group(ex Speed) Unitless is the same as no filter
+  If isFilterFixed the unitGrpFilter can not be changes by the user
+  If isFilterFixed convertUnitTo should match. The filter use meta data
+  in case meta does not exist the path is include*/
+  unitGrpFilter?: string;
+  isFilterFixed?: boolean;
 }

--- a/src/app/widgets/widget-autopilot/widget-autopilot.component.ts
+++ b/src/app/widgets/widget-autopilot/widget-autopilot.component.ts
@@ -111,7 +111,8 @@ export class WidgetAutopilotComponent extends BaseWidgetComponent implements OnI
             convertUnitTo: "deg",
             isPathConfigurable: true,
             sampleTime: 500,
-            unitGroup: "Angle"
+            isFilterFixed: true,
+            unitGrpFilter: "Angle"
           },
           "apTargetWindAngleApp": {
             description: "Autopilot Target Wind Angle Apparent",
@@ -121,7 +122,8 @@ export class WidgetAutopilotComponent extends BaseWidgetComponent implements OnI
             convertUnitTo: "deg",
             isPathConfigurable: true,
             sampleTime: 500,
-            unitGroup: "Angle"
+            isFilterFixed: true,
+            unitGrpFilter: "Angle"
           },
           "apNotifications": {
             description: "Autopilot Notifications",
@@ -140,7 +142,8 @@ export class WidgetAutopilotComponent extends BaseWidgetComponent implements OnI
             convertUnitTo: "deg",
             isPathConfigurable: true,
             sampleTime: 500,
-            unitGroup: "Angle"
+            isFilterFixed: true,
+            unitGrpFilter: "Angle"
           },
           "headingTrue": {
             description: "Heading True",
@@ -150,7 +153,8 @@ export class WidgetAutopilotComponent extends BaseWidgetComponent implements OnI
             convertUnitTo: "deg",
             isPathConfigurable: true,
             sampleTime: 500,
-            unitGroup: "Angle"
+            isFilterFixed: true,
+            unitGrpFilter: "Angle"
           },
           "windAngleApparent": {
             description: "Wind Angle Apparent",
@@ -160,7 +164,8 @@ export class WidgetAutopilotComponent extends BaseWidgetComponent implements OnI
             convertUnitTo: "deg",
             isPathConfigurable: true,
             sampleTime: 500,
-            unitGroup: "Angle"
+            isFilterFixed: true,
+            unitGrpFilter: "Angle"
           },
           "windAngleTrueWater": {
             description: "Wind Angle True Water",
@@ -170,7 +175,8 @@ export class WidgetAutopilotComponent extends BaseWidgetComponent implements OnI
             convertUnitTo: "deg",
             isPathConfigurable: true,
             sampleTime: 500,
-            unitGroup: "Angle"
+            isFilterFixed: true,
+            unitGrpFilter: "Angle"
           },
           "rudderAngle": {
             description: "Rudder Angle",
@@ -180,7 +186,8 @@ export class WidgetAutopilotComponent extends BaseWidgetComponent implements OnI
             convertUnitTo: "deg",
             isPathConfigurable: true,
             sampleTime: 500,
-            unitGroup: "Angle"
+            isFilterFixed: true,
+            unitGrpFilter: "Angle"
           },
         },
         usage: {

--- a/src/app/widgets/widget-autopilot/widget-autopilot.component.ts
+++ b/src/app/widgets/widget-autopilot/widget-autopilot.component.ts
@@ -110,7 +110,8 @@ export class WidgetAutopilotComponent extends BaseWidgetComponent implements OnI
             pathType: "number",
             convertUnitTo: "deg",
             isPathConfigurable: true,
-            sampleTime: 500
+            sampleTime: 500,
+            unitGroup: "Angle"
           },
           "apTargetWindAngleApp": {
             description: "Autopilot Target Wind Angle Apparent",
@@ -119,7 +120,8 @@ export class WidgetAutopilotComponent extends BaseWidgetComponent implements OnI
             pathType: "number",
             convertUnitTo: "deg",
             isPathConfigurable: true,
-            sampleTime: 500
+            sampleTime: 500,
+            unitGroup: "Angle"
           },
           "apNotifications": {
             description: "Autopilot Notifications",
@@ -137,7 +139,8 @@ export class WidgetAutopilotComponent extends BaseWidgetComponent implements OnI
             pathType: "number",
             convertUnitTo: "deg",
             isPathConfigurable: true,
-            sampleTime: 500
+            sampleTime: 500,
+            unitGroup: "Angle"
           },
           "headingTrue": {
             description: "Heading True",
@@ -146,7 +149,8 @@ export class WidgetAutopilotComponent extends BaseWidgetComponent implements OnI
             pathType: "number",
             convertUnitTo: "deg",
             isPathConfigurable: true,
-            sampleTime: 500
+            sampleTime: 500,
+            unitGroup: "Angle"
           },
           "windAngleApparent": {
             description: "Wind Angle Apparent",
@@ -155,7 +159,8 @@ export class WidgetAutopilotComponent extends BaseWidgetComponent implements OnI
             pathType: "number",
             convertUnitTo: "deg",
             isPathConfigurable: true,
-            sampleTime: 500
+            sampleTime: 500,
+            unitGroup: "Angle"
           },
           "windAngleTrueWater": {
             description: "Wind Angle True Water",
@@ -164,7 +169,8 @@ export class WidgetAutopilotComponent extends BaseWidgetComponent implements OnI
             pathType: "number",
             convertUnitTo: "deg",
             isPathConfigurable: true,
-            sampleTime: 500
+            sampleTime: 500,
+            unitGroup: "Angle"
           },
           "rudderAngle": {
             description: "Rudder Angle",
@@ -173,7 +179,8 @@ export class WidgetAutopilotComponent extends BaseWidgetComponent implements OnI
             pathType: "number",
             convertUnitTo: "deg",
             isPathConfigurable: true,
-            sampleTime: 500
+            sampleTime: 500,
+            unitGroup: "Angle"
           },
         },
         usage: {

--- a/src/app/widgets/widget-gauge-ng-linear/widget-gauge-ng-linear.component.ts
+++ b/src/app/widgets/widget-gauge-ng-linear/widget-gauge-ng-linear.component.ts
@@ -46,7 +46,8 @@ export class WidgetGaugeNgLinearComponent extends BaseWidgetComponent implements
           isPathConfigurable: true,
           convertUnitTo: "unitless",
           sampleTime: 500,
-          unitGroup: "Unitless"
+          isFilterFixed: false,
+          unitGrpFilter: "Unitless"
         }
       },
       gaugeType: 'ngLinearVertical',  //ngLinearVertical or ngLinearHorizontal

--- a/src/app/widgets/widget-gauge-ng-linear/widget-gauge-ng-linear.component.ts
+++ b/src/app/widgets/widget-gauge-ng-linear/widget-gauge-ng-linear.component.ts
@@ -45,7 +45,8 @@ export class WidgetGaugeNgLinearComponent extends BaseWidgetComponent implements
           pathType: "number",
           isPathConfigurable: true,
           convertUnitTo: "unitless",
-          sampleTime: 500
+          sampleTime: 500,
+          unitGroup: "Unitless"
         }
       },
       gaugeType: 'ngLinearVertical',  //ngLinearVertical or ngLinearHorizontal

--- a/src/app/widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component.ts
+++ b/src/app/widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component.ts
@@ -48,7 +48,8 @@ export class WidgetGaugeNgRadialComponent extends BaseWidgetComponent implements
           isPathConfigurable: true,
           convertUnitTo: "unitless",
           sampleTime: 500,
-          unitGroup: 'Unitless'
+          isFilterFixed: false,
+          unitGrpFilter: "Unitless"
         }
       },
       gaugeType: 'ngRadial',  //ngLinearVertical or ngLinearHorizontal

--- a/src/app/widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component.ts
+++ b/src/app/widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component.ts
@@ -47,7 +47,8 @@ export class WidgetGaugeNgRadialComponent extends BaseWidgetComponent implements
           pathType: "number",
           isPathConfigurable: true,
           convertUnitTo: "unitless",
-          sampleTime: 500
+          sampleTime: 500,
+          unitGroup: 'Unitless'
         }
       },
       gaugeType: 'ngRadial',  //ngLinearVertical or ngLinearHorizontal

--- a/src/app/widgets/widget-gauge/widget-gauge.component.ts
+++ b/src/app/widgets/widget-gauge/widget-gauge.component.ts
@@ -24,7 +24,8 @@ export class WidgetGaugeComponent extends BaseWidgetComponent implements OnInit,
           isPathConfigurable: true,
           convertUnitTo: "unitless",
           sampleTime: 500,
-          unitGroup: "Unitless"
+          isFilterFixed: false,
+          unitGrpFilter: "Unitless"
         }
       },
       gaugeType: 'linear',

--- a/src/app/widgets/widget-gauge/widget-gauge.component.ts
+++ b/src/app/widgets/widget-gauge/widget-gauge.component.ts
@@ -23,7 +23,8 @@ export class WidgetGaugeComponent extends BaseWidgetComponent implements OnInit,
           pathType: "number",
           isPathConfigurable: true,
           convertUnitTo: "unitless",
-          sampleTime: 500
+          sampleTime: 500,
+          unitGroup: "Unitless"
         }
       },
       gaugeType: 'linear',

--- a/src/app/widgets/widget-numeric/widget-numeric.component.ts
+++ b/src/app/widgets/widget-numeric/widget-numeric.component.ts
@@ -47,7 +47,8 @@ export class WidgetNumericComponent extends BaseWidgetComponent implements OnIni
           pathType: "number",
           isPathConfigurable: true,
           convertUnitTo: "unitless",
-          sampleTime: 500
+          sampleTime: 500,
+          unitGroup: "Unitless"
         }
       },
       showMax: false,

--- a/src/app/widgets/widget-numeric/widget-numeric.component.ts
+++ b/src/app/widgets/widget-numeric/widget-numeric.component.ts
@@ -48,7 +48,8 @@ export class WidgetNumericComponent extends BaseWidgetComponent implements OnIni
           isPathConfigurable: true,
           convertUnitTo: "unitless",
           sampleTime: 500,
-          unitGroup: "Unitless"
+          isFilterFixed: false,
+          unitGrpFilter: "Unitless"
         }
       },
       showMax: false,

--- a/src/app/widgets/widget-simple-linear/widget-simple-linear.component.ts
+++ b/src/app/widgets/widget-simple-linear/widget-simple-linear.component.ts
@@ -28,7 +28,8 @@ export class WidgetSimpleLinearComponent extends BaseWidgetComponent implements 
           pathType: "number",
           isPathConfigurable: true,
           convertUnitTo: "V",
-          sampleTime: 500
+          sampleTime: 500,
+          unitGroup: "Unitless"
         }
       },
       minValue: 0,

--- a/src/app/widgets/widget-simple-linear/widget-simple-linear.component.ts
+++ b/src/app/widgets/widget-simple-linear/widget-simple-linear.component.ts
@@ -29,7 +29,8 @@ export class WidgetSimpleLinearComponent extends BaseWidgetComponent implements 
           isPathConfigurable: true,
           convertUnitTo: "V",
           sampleTime: 500,
-          unitGroup: "Unitless"
+          isFilterFixed: false,
+          unitGrpFilter: "Unitless"
         }
       },
       minValue: 0,

--- a/src/app/widgets/widget-wind/widget-wind.component.ts
+++ b/src/app/widgets/widget-wind/widget-wind.component.ts
@@ -39,7 +39,8 @@ export class WidgetWindComponent extends BaseWidgetComponent implements OnInit, 
           isPathConfigurable: true,
           convertUnitTo: "deg",
           sampleTime: 500,
-          unitGroup: 'Angle'
+          isFilterFixed: true,
+          unitGrpFilter: "Angle"
         },
         "courseOverGround": {
           description: "Course Over Ground",
@@ -49,7 +50,8 @@ export class WidgetWindComponent extends BaseWidgetComponent implements OnInit, 
           isPathConfigurable: true,
           convertUnitTo: "deg",
           sampleTime: 500,
-          unitGroup: 'Angle'
+          isFilterFixed: true,
+          unitGrpFilter: "Angle"
         },
         "trueWindAngle": {
           description: "True Wind Angle",
@@ -59,7 +61,8 @@ export class WidgetWindComponent extends BaseWidgetComponent implements OnInit, 
           isPathConfigurable: true,
           convertUnitTo: "deg",
           sampleTime: 500,
-          unitGroup: 'Angle'
+          isFilterFixed: true,
+          unitGrpFilter: "Angle"
         },
         "trueWindSpeed": {
           description: "True Wind Speed",
@@ -69,7 +72,8 @@ export class WidgetWindComponent extends BaseWidgetComponent implements OnInit, 
           isPathConfigurable: true,
           convertUnitTo: "knots",
           sampleTime: 500,
-          unitGroup: 'Speed'
+          isFilterFixed: true,
+          unitGrpFilter: "Speed"
         },
         "appWindAngle": {
           description: "Apparent Wind Angle",
@@ -79,7 +83,8 @@ export class WidgetWindComponent extends BaseWidgetComponent implements OnInit, 
           isPathConfigurable: true,
           convertUnitTo: "deg",
           sampleTime: 500,
-          unitGroup: 'Angle'
+          isFilterFixed: true,
+          unitGrpFilter: "Angle"
         },
         "appWindSpeed": {
           description: "Apparent Wind Speed",
@@ -89,7 +94,8 @@ export class WidgetWindComponent extends BaseWidgetComponent implements OnInit, 
           isPathConfigurable: true,
           convertUnitTo: "knots",
           sampleTime: 500,
-          unitGroup: 'Speed'
+          isFilterFixed: true,
+          unitGrpFilter: "Speed"
         },
         "nextWaypointBearing": {
           description: "Next Waypoint Bearing",
@@ -99,7 +105,8 @@ export class WidgetWindComponent extends BaseWidgetComponent implements OnInit, 
           isPathConfigurable: true,
           convertUnitTo: "deg",
           sampleTime: 500,
-          unitGroup: 'Angle'
+          isFilterFixed: true,
+          unitGrpFilter: "Angle"
         },
       },
       windSectorEnable: true,

--- a/src/app/widgets/widget-wind/widget-wind.component.ts
+++ b/src/app/widgets/widget-wind/widget-wind.component.ts
@@ -38,7 +38,8 @@ export class WidgetWindComponent extends BaseWidgetComponent implements OnInit, 
           pathType: "number",
           isPathConfigurable: true,
           convertUnitTo: "deg",
-          sampleTime: 500
+          sampleTime: 500,
+          unitGroup: 'Angle'
         },
         "courseOverGround": {
           description: "Course Over Ground",
@@ -47,7 +48,8 @@ export class WidgetWindComponent extends BaseWidgetComponent implements OnInit, 
           pathType: "number",
           isPathConfigurable: true,
           convertUnitTo: "deg",
-          sampleTime: 500
+          sampleTime: 500,
+          unitGroup: 'Angle'
         },
         "trueWindAngle": {
           description: "True Wind Angle",
@@ -56,7 +58,8 @@ export class WidgetWindComponent extends BaseWidgetComponent implements OnInit, 
           pathType: "number",
           isPathConfigurable: true,
           convertUnitTo: "deg",
-          sampleTime: 500
+          sampleTime: 500,
+          unitGroup: 'Angle'
         },
         "trueWindSpeed": {
           description: "True Wind Speed",
@@ -65,7 +68,8 @@ export class WidgetWindComponent extends BaseWidgetComponent implements OnInit, 
           pathType: "number",
           isPathConfigurable: true,
           convertUnitTo: "knots",
-          sampleTime: 500
+          sampleTime: 500,
+          unitGroup: 'Speed'
         },
         "appWindAngle": {
           description: "Apparent Wind Angle",
@@ -74,7 +78,8 @@ export class WidgetWindComponent extends BaseWidgetComponent implements OnInit, 
           pathType: "number",
           isPathConfigurable: true,
           convertUnitTo: "deg",
-          sampleTime: 500
+          sampleTime: 500,
+          unitGroup: 'Angle'
         },
         "appWindSpeed": {
           description: "Apparent Wind Speed",
@@ -83,7 +88,8 @@ export class WidgetWindComponent extends BaseWidgetComponent implements OnInit, 
           pathType: "number",
           isPathConfigurable: true,
           convertUnitTo: "knots",
-          sampleTime: 500
+          sampleTime: 500,
+          unitGroup: 'Speed'
         },
         "nextWaypointBearing": {
           description: "Next Waypoint Bearing",
@@ -92,7 +98,8 @@ export class WidgetWindComponent extends BaseWidgetComponent implements OnInit, 
           pathType: "number",
           isPathConfigurable: true,
           convertUnitTo: "deg",
-          sampleTime: 500
+          sampleTime: 500,
+          unitGroup: 'Angle'
         },
       },
       windSectorEnable: true,


### PR DESCRIPTION
I would like paths to be filter after unit group ex Speed,Angel etc  when possible. On phones and tables finding the path is challenging.

On some widget we know the unit Group on a path on other we do not. When we know just apply it. When we do not know If the user select a unit then the filter is applied.

The benefits of the extra filtering will depend on the meta data including units. I do not know how often that happen on my boat the extra filtering helps a lot. If that is not normal the extra code may not be worth it. Anyway this is my suggestion on how to do it.