### PR TITLE
rewrite: empty notification Godind/issue317

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@types/jasminewd2": "^2.0.9",
         "@types/js-quantities": "^1.6.4",
         "@types/lodash-es": "^4.17.9",
-        "@types/node": "^20.8.6",
+        "@types/node": "^18.19.30",
         "angular-resize-event": "git+https://git@github.com/dereekb/angular-resize-event#00ef5139ccd6a02f0afd7639ae1bd365ac8b13f9",
         "angular-split": "^17.2.0",
         "chart.js": "^4.4.2",
@@ -4581,9 +4581,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.11.24",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.24.tgz",
-      "integrity": "sha512-Kza43ewS3xoLgCEpQrsT+xRo/EJej1y0kVYGiLFE1NEODXGzTfwiC6tXTLMQskn1X4/Rjlh0MQUvx9W+L9long==",
+      "version": "18.19.30",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.30.tgz",
+      "integrity": "sha512-453z1zPuJLVDbyahaa1sSD5C2sht6ZpHp5rgJNs+H8YGqhluCXcuOUmBYsAo0Tos0cHySJ3lVUGbGgLlqIkpyg==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@angular/platform-browser": "17.2.1",
     "@angular/platform-browser-dynamic": "17.2.1",
     "@angular/router": "17.2.1",
+    "@biacsics/ng-canvas-gauges": "^6.0.14",
     "@robloche/chartjs-plugin-streaming": "^3.1.0",
     "@types/canvas-gauges": "^2.1.2",
     "@types/hammerjs": "^2.0.45",
@@ -67,10 +68,9 @@
     "@types/jasminewd2": "^2.0.9",
     "@types/js-quantities": "^1.6.4",
     "@types/lodash-es": "^4.17.9",
-    "@types/node": "^20.8.6",
+    "@types/node": "^18.19.30",
     "angular-resize-event": "git+https://git@github.com/dereekb/angular-resize-event#00ef5139ccd6a02f0afd7639ae1bd365ac8b13f9",
     "angular-split": "^17.2.0",
-    "@biacsics/ng-canvas-gauges": "^6.0.14",
     "chart.js": "^4.4.2",
     "chartjs-adapter-date-fns": "^3.0.0",
     "chartjs-plugin-annotation": "^3.0.1",
@@ -101,6 +101,5 @@
     "tslint": "^6.1.3",
     "typescript": "^5.3.3",
     "zone.js": "~0.14.4"
-  },
-  "dependencies": {}
+  }
 }

--- a/src/app/alarm-menu/alarm-menu.component.html
+++ b/src/app/alarm-menu/alarm-menu.component.html
@@ -1,13 +1,26 @@
 @if(notificationInfo$ | async; as notificationInfo) {
   <mat-menu #actions="matMenu">
     <ng-template matMenuContent let-path="path">
-      <button mat-menu-item matTooltip="Silence this notification's audio prompt until new state is received"
-        (click)="ackAlarm(path)">
+      <button mat-menu-item
+        matTooltip="Mark the notification as acknowledged, and remove from the list of active notifications. This action has no bearing on the state of the alarm."
+        (click)="acknowledge(path)">
         Acknowledge
       </button>
-      <button mat-menu-item  matTooltip="Pause notification audio for 5 minutes, unless a new state is received, then the audio will resume"
-        (click)="ackAlarm(path, 300000)">
-        Mute for 5 minutes
+      <button mat-menu-item
+        matTooltip="Mark the notification as acknowledged for 5 minutes only, then it will reappear if the state is still active. This action has no bearing on the state of the alarm."
+        (click)="acknowledge(path, 300000)">
+        Acknowledge for 5 Minutes
+      </button>
+      <mat-divider></mat-divider>
+      <button mat-menu-item
+        matTooltip="Set the notification to a normal state. This action will prompt Signal K to change the state of the notification."
+        (click)="setState(path, 'normal')">
+        Set to Normal State
+      </button>
+      <button mat-menu-item
+        matTooltip="Delete the notification from the list of notifications. This action will prompt Signal K to remove the notification."
+        (click)="remove(path)">
+        Remove
       </button>
     </ng-template>
   </mat-menu>
@@ -16,8 +29,7 @@
     <ng-template matMenuContent>
       <button mat-menu-item *ngFor="let menuItem of menuNotifications$ | async"
         [mat-menu-trigger-for]="actions"
-        [matMenuTriggerData]="menuItem"
-        (click)="ackAlarm(menuItem)">
+        [matMenuTriggerData]="menuItem">
         @if(menuItem.isAck) {
           <div  class="menu-items-with-icons fa-solid fa-lg fa-check"></div>
         } @else {

--- a/src/app/alarm-menu/alarm-menu.component.html
+++ b/src/app/alarm-menu/alarm-menu.component.html
@@ -15,32 +15,41 @@
     <i class="fa-solid fa-ban fa-stack-2x text-danger" aria-hidden="true"></i>
   </div>
 </button>
+
 <mat-menu #alarmMenu="matMenu" focusFirstItem>
-  <div *ngFor="let alarm of alarms | keyvalue; index as i; trackBy:trackAlarmPath">
-    <button mat-menu-item [matMenuTriggerFor]="actions" [matTooltip]="alarm.value.notification.message">
-      <div class="menu-items-with-icons" *ngIf="alarm.value.isAck" class="fa-solid fa-lg fa-check"></div>
-      <div class="menu-items-with-icons" *ngIf="!alarm.value.isAck" class="fa-solid fa-lg fa-exclamation"></div>
-      {{ alarm.value.notification.message.replace("self.", "") }}
-    </button>
-    <mat-menu #actions="matMenu">
-      <button
-        mat-menu-item
-        (click)="ackAlarm(alarm.key)"
 
-        matTooltip="Silence Alarm (until state change)"
-        >
-        Acknowledge
+  @for (alarm of alarm$ | async; track alarm.path) {
+    <ng-template matMenuContent>
+      <button mat-menu-item [matMenuTriggerFor]="actions" [matTooltip]="alarm.alarm.notification.message">
+        <div class="menu-items-with-icons" *ngIf="alarm.alarm.isAck" class="fa-solid fa-lg fa-check"></div>
+        <div class="menu-items-with-icons" *ngIf="!alarm.alarm.isAck" class="fa-solid fa-lg fa-exclamation"></div>
+        {{ alarm.alarm.notification.message.replace("self.", "") }}
       </button>
-      <button
-        mat-menu-item
-        (click)="ackAlarm(alarm.key, 300000)"
+      <mat-menu #actions="matMenu">
+        <button
+          mat-menu-item
+          (click)="ackAlarm(alarm.path)"
 
-        matTooltip="Silence Alarm for 5 minutes(state change can re-trigger)"
-        >
-        Acknowledge (5 Min)
-      </button>
-    </mat-menu>
-  </div>
+          matTooltip="Silence Alarm (until state change)"
+          >
+          Acknowledge
+        </button>
+        <button
+          mat-menu-item
+          (click)="ackAlarm(alarm.path, 300000)"
+
+          matTooltip="Silence Alarm for 5 minutes(state change can re-trigger)"
+          >
+          Acknowledge (5 Min)
+        </button>
+      </mat-menu>
+    </ng-template>
+  }
+
+
+
+
+
   <mat-action-list>
     <mat-divider></mat-divider>
     <button mat-list-item class="muteSoundButton" matTooltip="Mute notification sounds" (click)="mutePlayer(isMuted ? false : true)">

--- a/src/app/alarm-menu/alarm-menu.component.html
+++ b/src/app/alarm-menu/alarm-menu.component.html
@@ -3,22 +3,26 @@
     <ng-template matMenuContent let-path="path">
       <button mat-menu-item
         matTooltip="Mark the notification as acknowledged, and remove from the list of active notifications. This action has no bearing on the state of the alarm."
+        matTooltipPosition="right"
         (click)="acknowledge(path)">
         Acknowledge
       </button>
       <button mat-menu-item
         matTooltip="Mark the notification as acknowledged for 5 minutes only, then it will reappear if the state is still active. This action has no bearing on the state of the alarm."
+        matTooltipPosition="right"
         (click)="acknowledge(path, 300000)">
         Acknowledge for 5 Minutes
       </button>
       <mat-divider></mat-divider>
       <button mat-menu-item
         matTooltip="Set the notification to a normal state. This action will prompt Signal K to change the state of the notification."
+        matTooltipPosition="right"
         (click)="setState(path, 'normal')">
         Set to Normal State
       </button>
       <button mat-menu-item
         matTooltip="Delete the notification from the list of notifications. This action will prompt Signal K to remove the notification."
+        matTooltipPosition="right"
         (click)="remove(path)">
         Remove
       </button>

--- a/src/app/alarm-menu/alarm-menu.component.html
+++ b/src/app/alarm-menu/alarm-menu.component.html
@@ -1,30 +1,14 @@
 @if(notificationInfo$ | async; as notificationInfo) {
   <mat-menu #actions="matMenu">
-    <ng-template matMenuContent let-path="path">
+    <ng-template matMenuContent let-path="path" let-method="notification.method">
       <button mat-menu-item
-        matTooltip="Mark the notification as acknowledged, and remove from the list of active notifications. This action has no bearing on the state of the alarm."
-        matTooltipPosition="right"
-        (click)="acknowledge(path)">
-        Acknowledge
+        *ngIf="method.includes('sound')"
+        (click)="silence(path)">
+        Silence
       </button>
       <button mat-menu-item
-        matTooltip="Mark the notification as acknowledged for 5 minutes only, then it will reappear if the state is still active. This action has no bearing on the state of the alarm."
-        matTooltipPosition="right"
-        (click)="acknowledge(path, 300000)">
-        Acknowledge for 5 Minutes
-      </button>
-      <mat-divider></mat-divider>
-      <button mat-menu-item
-        matTooltip="Set the notification to a normal state. This action will prompt Signal K to change the state of the notification."
-        matTooltipPosition="right"
-        (click)="setState(path, 'normal')">
-        Set to Normal State
-      </button>
-      <button mat-menu-item
-        matTooltip="Delete the notification from the list of notifications. This action will prompt Signal K to remove the notification."
-        matTooltipPosition="right"
-        (click)="remove(path)">
-        Remove
+        (click)="clear(path)">
+        Clear
       </button>
     </ng-template>
   </mat-menu>
@@ -34,11 +18,6 @@
       <button mat-menu-item *ngFor="let menuItem of menuNotifications$ | async"
         [mat-menu-trigger-for]="actions"
         [matMenuTriggerData]="menuItem">
-        @if(menuItem.isAck) {
-          <div  class="menu-items-with-icons fa-solid fa-lg fa-check"></div>
-        } @else {
-          <div class="menu-items-with-icons fa-solid fa-lg fa-exclamation"></div>
-        }
         {{ menuItem.notification.message }}
     </button>
 
@@ -62,21 +41,14 @@
     [class.alarmCrit]="notificationInfo.blinkCrit"
     [class.alarmWarning]="notificationInfo.blinkWarn"
     [disabled]="notificationInfo.alarmCount == 0 || notificationConfig.disableNotifications">
-    @if(!notificationConfig.disableNotifications) {
-      <div class="menu-items-with-icons" [matBadgeHidden]="!notificationInfo.unackCount"
-        [matBadge]="notificationInfo.unackCount"
-        matBadgeSize="medium"
-        matBadgePosition="after"
-        matBadgeOverlap="false"
-        matBadgeColor="warn"
-        class="fa-solid fa-envelope fa-2x">
-      </div>
-    }
-    @if(notificationConfig.disableNotifications) {
-      <div class="menu-items-with-icons" class="fa-stack fa-lg">
-        <i class="fa-solid fa-bell fa-1x" aria-hidden="true"></i>
-        <i class="fa-solid fa-ban fa-stack-2x text-danger" aria-hidden="true"></i>
-      </div>
-    }
+    <div class="menu-items-with-icons"
+      [matBadgeHidden]="!notificationInfo.alarmCount"
+      [matBadge]="notificationInfo.alarmCount"
+      matBadgeSize="medium"
+      matBadgePosition="after"
+      matBadgeOverlap="false"
+      matBadgeColor="warn">
+      <i class="fa-solid fa-envelope fa-2x" aria-hidden="true"></i>
+    </div>
   </button>
 }

--- a/src/app/alarm-menu/alarm-menu.component.html
+++ b/src/app/alarm-menu/alarm-menu.component.html
@@ -1,64 +1,73 @@
-<button [matMenuTriggerFor]="alarmMenu" color="accent" mat-flat-button class="menuBarAlarmsButton button-elevation"
-        [class.alarmCrit]="blinkCrit"
-        [class.alarmWarning]="blinkWarn"
-        [disabled]="alarmCount == 0 || notificationConfig.disableNotifications">
-  <div class="menu-items-with-icons" *ngIf="!notificationConfig.disableNotifications" [matBadgeHidden]="!unAckAlarms"
-        [matBadge]="unAckAlarms"
-        matBadgeSize="medium"
-        matBadgePosition="after"
-        matBadgeOverlap="false"
-        matBadgeColor="warn"
-        class="fa-solid fa-envelope fa-2x">
-  </div>
-  <div class="menu-items-with-icons" *ngIf="notificationConfig.disableNotifications" class="fa-stack fa-lg">
-    <i class="fa-solid fa-bell fa-1x" aria-hidden="true"></i>
-    <i class="fa-solid fa-ban fa-stack-2x text-danger" aria-hidden="true"></i>
-  </div>
-</button>
-
-<mat-menu #alarmMenu="matMenu" focusFirstItem>
-
-  @for (alarm of alarm$ | async; track alarm.path) {
-    <ng-template matMenuContent>
-      <button mat-menu-item [matMenuTriggerFor]="actions" [matTooltip]="alarm.alarm.notification.message">
-        <div class="menu-items-with-icons" *ngIf="alarm.alarm.isAck" class="fa-solid fa-lg fa-check"></div>
-        <div class="menu-items-with-icons" *ngIf="!alarm.alarm.isAck" class="fa-solid fa-lg fa-exclamation"></div>
-        {{ alarm.alarm.notification.message.replace("self.", "") }}
-      </button>
-      <mat-menu #actions="matMenu">
-        <button
-          mat-menu-item
-          (click)="ackAlarm(alarm.path)"
-
-          matTooltip="Silence Alarm (until state change)"
-          >
-          Acknowledge
-        </button>
-        <button
-          mat-menu-item
-          (click)="ackAlarm(alarm.path, 300000)"
-
-          matTooltip="Silence Alarm for 5 minutes(state change can re-trigger)"
-          >
-          Acknowledge (5 Min)
-        </button>
-      </mat-menu>
-    </ng-template>
-  }
+@if(notificationInfo$ | async; as notificationInfo) {
+    <mat-menu #actions="matMenu">
+      <!-- <ng-template matMenuContent let-name="item" matTooltip="Silence Alarm (until state change)"> -->
+       <button mat-menu-item
+         (click)="ackAlarm(null)">
+         Acknowledge
+       </button>
+       <button mat-menu-item  matTooltip="Silence notification for 5 minutes, unless state changes"
+         (click)="ackAlarm(null, 300000)">
+         Acknowledge (5 Min)
+       </button>
+      <!-- </ng-template> -->
+    </mat-menu>
 
 
+  <mat-menu #alarmMenu="matMenu" focusFirstItem>
+    <button mat-menu-item *ngFor="let menuItem of menuNotifications$ | async"
+      [mat-menu-trigger-for]="actions"
+      [matMenuTriggerData]="menuItem"
+      (click)="ackAlarm(menuItem)">
+      <div  class="menu-items-with-icons" *ngIf="menuItem.isAck" class="fa-solid fa-lg fa-check"></div>
+      <div class="menu-items-with-icons" *ngIf="!menuItem.isAck" class="fa-solid fa-lg fa-exclamation"></div>
+      {{ menuItem.notification.message }}
+    </button>
 
 
-
-  <mat-action-list>
     <mat-divider></mat-divider>
-    <button mat-list-item class="muteSoundButton" matTooltip="Mute notification sounds" (click)="mutePlayer(isMuted ? false : true)">
-      <div class="menu-items-with-icons" class="mute-unmte-alarm" *ngIf="!isMuted">
+    <button *ngIf="notificationInfo$ | async as notificationInfo"  mat-menu-item class="muteSoundButton" matTooltip="Mute notification sounds"
+      (click)="mutePlayer(notificationInfo.isMuted ? false : true)">
+      <div class="menu-items-with-icons mute-unumte-alarm" *ngIf="!notificationInfo.isMuted">
         <i class="fa-solid fa-bell" aria-hidden="true"></i> Mute Alarm Audio
       </div>
-      <div class="menu-items-with-icons" class="mute-unmte-alarm" *ngIf="isMuted">
+      <div class="menu-items-with-icons mute-unmute-alarm" *ngIf="notificationInfo.isMuted">
         <i class="fa-solid fa-bell-slash" aria-hidden="true"></i> Unmute Alarm Audio
       </div>
     </button>
-  </mat-action-list>
-</mat-menu>
+
+  </mat-menu>
+
+
+  <button [matMenuTriggerFor]="alarmMenu" color="accent" mat-flat-button class="menuBarAlarmsButton button-elevation"
+    [class.alarmCrit]="notificationInfo.blinkCrit"
+    [class.alarmWarning]="notificationInfo.blinkWarn"
+    [disabled]="notificationInfo.alarmCount == 0 || notificationConfig.disableNotifications">
+
+  @if(notificationConfig.disableNotifications) {
+    <div class="menu-items-with-icons" [matBadgeHidden]="!notificationInfo.unackCount"
+      [matBadge]="notificationInfo.unackCount"
+      matBadgeSize="medium"
+      matBadgePosition="after"
+      matBadgeOverlap="false"
+      matBadgeColor="warn"
+      class="fa-solid fa-envelope fa-2x">
+    </div>
+  } @else {
+    <div class="menu-items-with-icons" [matBadgeHidden]="!notificationInfo.unackCount"
+      [matBadge]="notificationInfo.unackCount"
+      matBadgeSize="medium"
+      matBadgePosition="after"
+      matBadgeOverlap="false"
+      matBadgeColor="warn"
+      class="fa-solid fa-envelope fa-2x">
+    </div>
+  }
+
+  @if(notificationConfig.disableNotifications) {
+    <div class="menu-items-with-icons fa-stack fa-lg">
+      <i class="fa-solid fa-bell fa-1x" aria-hidden="true"></i>
+      <i class="fa-solid fa-ban fa-stack-2x text-danger" aria-hidden="true"></i>
+    </div>
+  }
+  </button>
+}

--- a/src/app/alarm-menu/alarm-menu.component.html
+++ b/src/app/alarm-menu/alarm-menu.component.html
@@ -1,73 +1,64 @@
 @if(notificationInfo$ | async; as notificationInfo) {
-    <mat-menu #actions="matMenu">
-      <!-- <ng-template matMenuContent let-name="item" matTooltip="Silence Alarm (until state change)"> -->
-       <button mat-menu-item
-         (click)="ackAlarm(null)">
-         Acknowledge
-       </button>
-       <button mat-menu-item  matTooltip="Silence notification for 5 minutes, unless state changes"
-         (click)="ackAlarm(null, 300000)">
-         Acknowledge (5 Min)
-       </button>
-      <!-- </ng-template> -->
-    </mat-menu>
-
+  <mat-menu #actions="matMenu">
+    <ng-template matMenuContent let-path="path">
+      <button mat-menu-item matTooltip="Silence this notification's audio prompt until new state is received"
+        (click)="ackAlarm(path)">
+        Acknowledge
+      </button>
+      <button mat-menu-item  matTooltip="Pause notification audio for 5 minutes, unless a new state is received, then the audio will resume"
+        (click)="ackAlarm(path, 300000)">
+        Mute for 5 minutes
+      </button>
+    </ng-template>
+  </mat-menu>
 
   <mat-menu #alarmMenu="matMenu" focusFirstItem>
     <button mat-menu-item *ngFor="let menuItem of menuNotifications$ | async"
       [mat-menu-trigger-for]="actions"
       [matMenuTriggerData]="menuItem"
       (click)="ackAlarm(menuItem)">
-      <div  class="menu-items-with-icons" *ngIf="menuItem.isAck" class="fa-solid fa-lg fa-check"></div>
-      <div class="menu-items-with-icons" *ngIf="!menuItem.isAck" class="fa-solid fa-lg fa-exclamation"></div>
+      @if(menuItem.isAck) {
+        <div  class="menu-items-with-icons fa-solid fa-lg fa-check"></div>
+      } @else {
+        <div class="menu-items-with-icons fa-solid fa-lg fa-exclamation"></div>
+      }
       {{ menuItem.notification.message }}
-    </button>
+  </button>
 
-
-    <mat-divider></mat-divider>
-    <button *ngIf="notificationInfo$ | async as notificationInfo"  mat-menu-item class="muteSoundButton" matTooltip="Mute notification sounds"
+  <mat-divider></mat-divider>
+    <button mat-menu-item class="muteSoundButton" matTooltip="Mute notification sounds"
       (click)="mutePlayer(notificationInfo.isMuted ? false : true)">
-      <div class="menu-items-with-icons mute-unumte-alarm" *ngIf="!notificationInfo.isMuted">
-        <i class="fa-solid fa-bell" aria-hidden="true"></i> Mute Alarm Audio
-      </div>
-      <div class="menu-items-with-icons mute-unmute-alarm" *ngIf="notificationInfo.isMuted">
-        <i class="fa-solid fa-bell-slash" aria-hidden="true"></i> Unmute Alarm Audio
-      </div>
+      @if(notificationInfo.isMuted) {
+        <div class="menu-items-with-icons mute-unmute-alarm" *ngIf="notificationInfo.isMuted">
+          <i class="fa-solid fa-bell-slash" aria-hidden="true"></i> Unmute Audio
+        </div>
+      } @else {
+        <div class="menu-items-with-icons mute-unumte-alarm" *ngIf="!notificationInfo.isMuted">
+          <i class="fa-solid fa-bell" aria-hidden="true"></i> Mute Audio
+        </div>
+      }
     </button>
-
   </mat-menu>
-
 
   <button [matMenuTriggerFor]="alarmMenu" color="accent" mat-flat-button class="menuBarAlarmsButton button-elevation"
     [class.alarmCrit]="notificationInfo.blinkCrit"
     [class.alarmWarning]="notificationInfo.blinkWarn"
     [disabled]="notificationInfo.alarmCount == 0 || notificationConfig.disableNotifications">
-
-  @if(notificationConfig.disableNotifications) {
-    <div class="menu-items-with-icons" [matBadgeHidden]="!notificationInfo.unackCount"
-      [matBadge]="notificationInfo.unackCount"
-      matBadgeSize="medium"
-      matBadgePosition="after"
-      matBadgeOverlap="false"
-      matBadgeColor="warn"
-      class="fa-solid fa-envelope fa-2x">
-    </div>
-  } @else {
-    <div class="menu-items-with-icons" [matBadgeHidden]="!notificationInfo.unackCount"
-      [matBadge]="notificationInfo.unackCount"
-      matBadgeSize="medium"
-      matBadgePosition="after"
-      matBadgeOverlap="false"
-      matBadgeColor="warn"
-      class="fa-solid fa-envelope fa-2x">
-    </div>
-  }
-
-  @if(notificationConfig.disableNotifications) {
-    <div class="menu-items-with-icons fa-stack fa-lg">
-      <i class="fa-solid fa-bell fa-1x" aria-hidden="true"></i>
-      <i class="fa-solid fa-ban fa-stack-2x text-danger" aria-hidden="true"></i>
-    </div>
-  }
+    @if(!notificationConfig.disableNotifications) {
+      <div class="menu-items-with-icons" [matBadgeHidden]="!notificationInfo.unackCount"
+        [matBadge]="notificationInfo.unackCount"
+        matBadgeSize="medium"
+        matBadgePosition="after"
+        matBadgeOverlap="false"
+        matBadgeColor="warn"
+        class="fa-solid fa-envelope fa-2x">
+      </div>
+    }
+    @if(notificationConfig.disableNotifications) {
+      <div class="menu-items-with-icons" class="fa-stack fa-lg">
+        <i class="fa-solid fa-bell fa-1x" aria-hidden="true"></i>
+        <i class="fa-solid fa-ban fa-stack-2x text-danger" aria-hidden="true"></i>
+      </div>
+    }
   </button>
 }

--- a/src/app/alarm-menu/alarm-menu.component.html
+++ b/src/app/alarm-menu/alarm-menu.component.html
@@ -12,7 +12,6 @@
       </button>
     </ng-template>
   </mat-menu>
-
   <mat-menu #alarmMenu="matMenu" focusFirstItem>
     <ng-template matMenuContent>
       @for(menuItem of menuNotifications$ | async; track menuItem) {
@@ -31,7 +30,6 @@
       }
     </ng-template>
   </mat-menu>
-
   <button [matMenuTriggerFor]="alarmMenu" color="accent" mat-flat-button class="menuBarAlarmsButton button-elevation"
     [class.alarmCrit]="notificationInfo.blinkCrit"
     [class.alarmWarning]="notificationInfo.blinkWarn"

--- a/src/app/alarm-menu/alarm-menu.component.html
+++ b/src/app/alarm-menu/alarm-menu.component.html
@@ -15,25 +15,20 @@
 
   <mat-menu #alarmMenu="matMenu" focusFirstItem>
     <ng-template matMenuContent>
-      <button mat-menu-item *ngFor="let menuItem of menuNotifications$ | async"
-        [mat-menu-trigger-for]="actions"
-        [matMenuTriggerData]="menuItem">
-        {{ menuItem.notification.message }}
-    </button>
-
-    <mat-divider></mat-divider>
-      <button mat-menu-item class="muteSoundButton" matTooltip="Mute notification sounds"
-        (click)="mutePlayer(notificationInfo.isMuted ? false : true)">
-        @if(notificationInfo.isMuted) {
-          <div class="menu-items-with-icons mute-unmute-alarm" *ngIf="notificationInfo.isMuted">
-            <i class="fa-solid fa-bell-slash" aria-hidden="true"></i> Unmute Audio
-          </div>
+      @for(menuItem of menuNotifications$ | async; track menuItem) {
+        @if(menuItem.notification.state !== "normal") {
+          <button mat-menu-item
+            [mat-menu-trigger-for]="actions"
+            [matMenuTriggerData]="menuItem">
+            {{ menuItem.notification.message }}
+          </button>
         } @else {
-          <div class="menu-items-with-icons mute-unumte-alarm" *ngIf="!notificationInfo.isMuted">
-            <i class="fa-solid fa-bell" aria-hidden="true"></i> Mute Audio
-          </div>
+          <button mat-menu-item>
+            {{ menuItem.notification.message }}
+          </button>
         }
-      </button>
+
+      }
     </ng-template>
   </mat-menu>
 

--- a/src/app/alarm-menu/alarm-menu.component.html
+++ b/src/app/alarm-menu/alarm-menu.component.html
@@ -13,31 +13,33 @@
   </mat-menu>
 
   <mat-menu #alarmMenu="matMenu" focusFirstItem>
-    <button mat-menu-item *ngFor="let menuItem of menuNotifications$ | async"
-      [mat-menu-trigger-for]="actions"
-      [matMenuTriggerData]="menuItem"
-      (click)="ackAlarm(menuItem)">
-      @if(menuItem.isAck) {
-        <div  class="menu-items-with-icons fa-solid fa-lg fa-check"></div>
-      } @else {
-        <div class="menu-items-with-icons fa-solid fa-lg fa-exclamation"></div>
-      }
-      {{ menuItem.notification.message }}
-  </button>
-
-  <mat-divider></mat-divider>
-    <button mat-menu-item class="muteSoundButton" matTooltip="Mute notification sounds"
-      (click)="mutePlayer(notificationInfo.isMuted ? false : true)">
-      @if(notificationInfo.isMuted) {
-        <div class="menu-items-with-icons mute-unmute-alarm" *ngIf="notificationInfo.isMuted">
-          <i class="fa-solid fa-bell-slash" aria-hidden="true"></i> Unmute Audio
-        </div>
-      } @else {
-        <div class="menu-items-with-icons mute-unumte-alarm" *ngIf="!notificationInfo.isMuted">
-          <i class="fa-solid fa-bell" aria-hidden="true"></i> Mute Audio
-        </div>
-      }
+    <ng-template matMenuContent>
+      <button mat-menu-item *ngFor="let menuItem of menuNotifications$ | async"
+        [mat-menu-trigger-for]="actions"
+        [matMenuTriggerData]="menuItem"
+        (click)="ackAlarm(menuItem)">
+        @if(menuItem.isAck) {
+          <div  class="menu-items-with-icons fa-solid fa-lg fa-check"></div>
+        } @else {
+          <div class="menu-items-with-icons fa-solid fa-lg fa-exclamation"></div>
+        }
+        {{ menuItem.notification.message }}
     </button>
+
+    <mat-divider></mat-divider>
+      <button mat-menu-item class="muteSoundButton" matTooltip="Mute notification sounds"
+        (click)="mutePlayer(notificationInfo.isMuted ? false : true)">
+        @if(notificationInfo.isMuted) {
+          <div class="menu-items-with-icons mute-unmute-alarm" *ngIf="notificationInfo.isMuted">
+            <i class="fa-solid fa-bell-slash" aria-hidden="true"></i> Unmute Audio
+          </div>
+        } @else {
+          <div class="menu-items-with-icons mute-unumte-alarm" *ngIf="!notificationInfo.isMuted">
+            <i class="fa-solid fa-bell" aria-hidden="true"></i> Mute Audio
+          </div>
+        }
+      </button>
+    </ng-template>
   </mat-menu>
 
   <button [matMenuTriggerFor]="alarmMenu" color="accent" mat-flat-button class="menuBarAlarmsButton button-elevation"

--- a/src/app/alarm-menu/alarm-menu.component.scss
+++ b/src/app/alarm-menu/alarm-menu.component.scss
@@ -47,7 +47,7 @@
 }
 
 .menu-items-with-icons {
-  display: flex;
+  display: inline-block;
   align-items: center;
   width: max-content;
 }

--- a/src/app/alarm-menu/alarm-menu.component.scss
+++ b/src/app/alarm-menu/alarm-menu.component.scss
@@ -2,7 +2,7 @@
   z-index: 1000;
 }
 
-.mute-unmte-alarm {
+.mute-unmute-alarm {
   width: max-content;
 }
 

--- a/src/app/alarm-menu/alarm-menu.component.ts
+++ b/src/app/alarm-menu/alarm-menu.component.ts
@@ -6,8 +6,8 @@ import { MatDivider } from '@angular/material/divider';
 import { MatActionList, MatListItem } from '@angular/material/list';
 import { MatTooltip } from '@angular/material/tooltip';
 import { MatBadge } from '@angular/material/badge';
-import { NgIf, AsyncPipe, NgFor } from '@angular/common';
-import { MatMenuTrigger, MatMenu, MatMenuItem } from '@angular/material/menu';
+import { NgIf, AsyncPipe, NgFor, NgTemplateOutlet } from '@angular/common';
+import { MatMenuTrigger, MatMenu, MatMenuItem, MatMenuModule } from '@angular/material/menu';
 import { MatButton } from '@angular/material/button';
 
 interface IMenuItem {
@@ -26,7 +26,7 @@ interface INotificationInfo extends IAlarmInfo{
     templateUrl: './alarm-menu.component.html',
     styleUrls: ['./alarm-menu.component.scss'],
     standalone: true,
-    imports: [MatButton, MatMenuTrigger, MatBadge, MatMenu, MatMenuItem, MatTooltip, MatActionList, MatDivider, MatListItem, AsyncPipe, NgFor, NgIf]
+    imports: [MatButton, MatMenuModule, MatBadge, MatTooltip, MatDivider, MatListItem, AsyncPipe, NgFor, NgIf]
 })
 export class AlarmMenuComponent implements OnDestroy {
   private static readonly NORMAL_STATE = "normal";
@@ -80,8 +80,8 @@ export class AlarmMenuComponent implements OnDestroy {
     this.notificationsService.mutePlayer(state);
   }
 
-  public ackAlarm(menuItem: INotificationMessage, timeout: number = 0): void {
-    this.notificationsService.acknowledge(menuItem.path, timeout);
+  public ackAlarm(path: string, timeout: number = 0): void {
+    this.notificationsService.acknowledge(path, timeout);
   }
 
   ngOnDestroy() {

--- a/src/app/alarm-menu/alarm-menu.component.ts
+++ b/src/app/alarm-menu/alarm-menu.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnDestroy } from '@angular/core';
 import { NotificationsService, INotificationMessage, IAlarmInfo } from '../core/services/notifications.service';
-import { Observable, Subscription, filter, iif, map, of, switchMap } from 'rxjs';
+import { Observable, Subscription, filter, iif, map, of, switchMap, tap } from 'rxjs';
 import { INotificationConfig } from '../core/interfaces/app-settings.interfaces';
 import { MatDivider } from '@angular/material/divider';
 import { MatListItem } from '@angular/material/list';
@@ -32,8 +32,7 @@ export class AlarmMenuComponent implements OnDestroy {
   private static readonly NORMAL_STATE = "normal";
   private notificationServiceSettingsSubscription: Subscription = null;
   private notifications$: Observable<INotificationMessage[]> = this.notificationsService.observe().pipe(
-    filter(notification => notification !== null)
-  );
+    filter(notification => notification !== null));
   public menuNotifications$ = this.notifications$.pipe(
     switchMap(notifications =>
       iif(
@@ -64,8 +63,7 @@ export class AlarmMenuComponent implements OnDestroy {
         blinkWarn,
         blinkCrit
       } as INotificationInfo;
-    })
-  );
+    }));
   public notificationConfig: INotificationConfig;
 
   constructor(private notificationsService: NotificationsService) {

--- a/src/app/alarm-menu/alarm-menu.component.ts
+++ b/src/app/alarm-menu/alarm-menu.component.ts
@@ -66,7 +66,6 @@ export class AlarmMenuComponent implements OnDestroy {
       } as INotificationInfo;
     })
   );
-
   public notificationConfig: INotificationConfig;
 
   constructor(private notificationsService: NotificationsService) {

--- a/src/app/alarm-menu/alarm-menu.component.ts
+++ b/src/app/alarm-menu/alarm-menu.component.ts
@@ -3,11 +3,11 @@ import { NotificationsService, INotificationMessage, IAlarmInfo } from '../core/
 import { Observable, Subscription, filter, iif, map, of, switchMap } from 'rxjs';
 import { INotificationConfig } from '../core/interfaces/app-settings.interfaces';
 import { MatDivider } from '@angular/material/divider';
-import { MatActionList, MatListItem } from '@angular/material/list';
+import { MatListItem } from '@angular/material/list';
 import { MatTooltip } from '@angular/material/tooltip';
 import { MatBadge } from '@angular/material/badge';
-import { NgIf, AsyncPipe, NgFor, NgTemplateOutlet } from '@angular/common';
-import { MatMenuTrigger, MatMenu, MatMenuItem, MatMenuModule } from '@angular/material/menu';
+import { NgIf, AsyncPipe, NgFor } from '@angular/common';
+import {MatMenuModule } from '@angular/material/menu';
 import { MatButton } from '@angular/material/button';
 
 interface IMenuItem {

--- a/src/app/alarm-menu/alarm-menu.component.ts
+++ b/src/app/alarm-menu/alarm-menu.component.ts
@@ -66,7 +66,7 @@ export class AlarmMenuComponent implements OnDestroy {
 
   constructor(private notificationsService: NotificationsService) {
     // Get service configuration
-    this.notificationServiceSettingsSubscription = this.notificationsService.getNotificationServiceConfigAsO().subscribe((config: INotificationConfig) => {
+    this.notificationServiceSettingsSubscription = this.notificationsService.observeNotificationConfiguration().subscribe((config: INotificationConfig) => {
       this.notificationConfig = config;
     });
   }

--- a/src/app/alarm-menu/alarm-menu.component.ts
+++ b/src/app/alarm-menu/alarm-menu.component.ts
@@ -1,171 +1,91 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
-import { NotificationsService, IAlarm, IAlarmMsg } from '../core/services/notifications.service';
-import { BehaviorSubject, Subscription, filter, tap } from 'rxjs';
+import { Component, OnDestroy } from '@angular/core';
+import { NotificationsService, INotificationMessage, IAlarmInfo } from '../core/services/notifications.service';
+import { Observable, Subscription, filter, iif, map, of, switchMap } from 'rxjs';
 import { INotificationConfig } from '../core/interfaces/app-settings.interfaces';
 import { MatDivider } from '@angular/material/divider';
 import { MatActionList, MatListItem } from '@angular/material/list';
 import { MatTooltip } from '@angular/material/tooltip';
 import { MatBadge } from '@angular/material/badge';
-import { NgIf, AsyncPipe } from '@angular/common';
+import { NgIf, AsyncPipe, NgFor } from '@angular/common';
 import { MatMenuTrigger, MatMenu, MatMenuItem } from '@angular/material/menu';
 import { MatButton } from '@angular/material/button';
 
-interface IMenuNode {
-  [key: string]: any;
-  label: string;
-  childNode?: [IMenuItem | IMenuNode];
-}
 interface IMenuItem {
   [key: string]: any;
   label: string;
-  Alarm?: IAlarm;
+  Alarm?: INotificationMessage;
 }
 
+interface INotificationInfo extends IAlarmInfo{
+  blinkWarn: boolean;
+  blinkCrit: boolean;
+}
 
 @Component({
     selector: 'app-alarm-menu',
     templateUrl: './alarm-menu.component.html',
     styleUrls: ['./alarm-menu.component.scss'],
     standalone: true,
-    imports: [MatButton, MatMenuTrigger, NgIf, MatBadge, MatMenu, MatMenuItem, MatTooltip, MatActionList, MatDivider, MatListItem, AsyncPipe]
+    imports: [MatButton, MatMenuTrigger, MatBadge, MatMenu, MatMenuItem, MatTooltip, MatActionList, MatDivider, MatListItem, AsyncPipe, NgFor, NgIf]
 })
-export class AlarmMenuComponent implements OnInit, OnDestroy {
-
-  private alarmSubscription: Subscription = null;
+export class AlarmMenuComponent implements OnDestroy {
+  private static readonly NORMAL_STATE = "normal";
   private notificationServiceSettingsSubscription: Subscription = null;
-  private alarmInfoSubscription: Subscription = null;
+  private notifications$: Observable<INotificationMessage[]> = this.notificationsService.observe().pipe(
+    filter(notification => notification !== null)
+  );
+  public menuNotifications$ = this.notifications$.pipe(
+    switchMap(notifications =>
+      iif(
+        () => this.notificationConfig.devices.showNormalState,
+        of(notifications),
+        of(notifications.filter(
+          msg => msg.notification.state !== AlarmMenuComponent.NORMAL_STATE
+        ))
+      )
+    )
+  );
+  public notificationInfo$ = this.notificationsService.observerNotificationInfo().pipe(
+    map((info: IAlarmInfo) => {
+      let blinkWarn = false;
+      let blinkCrit = false;
 
-  private msg$ = this.notificationsService.getAlarms().pipe(filter(messages => messages !== null));
-  public alarm$ = this.msg$.pipe(/* tap(x => console.warn(x)),*/ filter((msgs: IAlarmMsg[]) => (msgs?.every(msg => msg.alarm.notification.state == "normal") && !this.notificationConfig.devices.showNormalState)))
+      switch(info.visualSev) {
+        case 1:
+          blinkWarn = true;
+          break;
+        case 2:
+          blinkCrit = true;
+          break;
+      }
 
-  alarmMenu: { [key: string]: string | IMenuItem | IMenuItem } = {}; // local menu array with string key
+      return {
+        ...info,
+        blinkWarn,
+        blinkCrit
+      } as INotificationInfo;
+    })
+  );
 
-  // Menu properties
-  alarmCount: number = 0;
-  unAckAlarms: number = 0;
-  blinkWarn: boolean = false;
-  blinkCrit: boolean = false;
-
-  isMuted: boolean = false;
-  notificationConfig: INotificationConfig;
+  public notificationConfig: INotificationConfig;
 
   constructor(private notificationsService: NotificationsService) {
+    // Get service configuration
     this.notificationServiceSettingsSubscription = this.notificationsService.getNotificationServiceConfigAsO().subscribe((config: INotificationConfig) => {
       this.notificationConfig = config;
     });
   }
 
-  ngOnInit() {
-        // this.alarm$.subscribe(msg => {
-        //   console.log(msg);
-        // })
-
-    // init alarm info
-    this.alarmInfoSubscription = this.notificationsService.getAlarmInfo().subscribe(info => {
-      this.unAckAlarms = info.unackCount;
-      this.isMuted = info.isMuted;
-      this.alarmCount = info.alarmCount;
-      switch(info.visualSev) {
-        case 0:
-          this.blinkWarn = false;
-          this.blinkCrit = false;
-          break;
-        case 1:
-          this.blinkWarn = true;
-          this.blinkCrit = false;
-          break;
-        case 2:
-          this.blinkCrit = true;
-          this.blinkWarn = false;
-      }
-    });
-  }
-
-  mutePlayer(state) {
+  public mutePlayer(state: boolean): void {
     this.notificationsService.mutePlayer(state);
   }
 
-  createMenuRootItem(itemLabel: string): IMenuNode | null {
-    let item: IMenuNode = {
-      label: itemLabel
-    }
-
-    if(Object.entries(this.alarmMenu).length) {
-      let i = Object.keys(this.alarmMenu).indexOf(itemLabel);
-      if(i == -1) {
-        console.log("Root: " + itemLabel + " not found. Search index: " + i);
-        return item;
-      } else {
-        console.log("Root: " + itemLabel + " found. Search index: " + i);
-        console.log(JSON.stringify(Object.values(this.alarmMenu)));
-        return null;
-      }
-    }
-    console.log(JSON.stringify(Object.values(this.alarmMenu)));
-    return item;
-  }
-
-  createMenuChildItem(itemLabel: string, pathPositionIndex: number, pathArray: string[], alarm: IAlarm): IMenuItem | IMenuNode {
-    let item;
-
-    const lastPosition = pathArray.length - 1;
-    let parentLabel = pathArray[pathPositionIndex - 1];
-    let indexParentNode = Object.keys(this.alarmMenu).indexOf(pathArray[parentLabel]);
-
-    if (pathPositionIndex != lastPosition) {
-      item = {
-        label: pathArray[pathPositionIndex],
-      }
-    } else {
-      item = {
-        label: pathArray[pathPositionIndex],
-        Alarm: alarm,
-      }
-    }
-
-    for (const [label, menuNode] of Object.entries(this.alarmMenu)) {
-        if (label == parentLabel) {
-          console.log(JSON.stringify(menuNode));
-          menuNode['childNode'] = item;
-
-          if (pathPositionIndex != lastPosition) {
-            pathPositionIndex++;
-            if (pathPositionIndex != (lastPosition)) {
-              item = {
-                label: pathArray[pathPositionIndex]
-              }
-            } else {
-              item = {
-                label: pathArray[pathPositionIndex],
-                Alarm: alarm,
-              }
-            }
-            menuNode['childNode'][0].childNode = item;
-          }
-        }
-      }
-
-    return null;
-  }
-
-
-  ackAlarm(path: string, timeout: number = 0) {
-    this.notificationsService.acknowledgeAlarm(path, timeout);
-  }
-
-
-  /**
-   * Used by ngFor to tracks alarm items by key for menu optimization
-   * @param alarm object in question
-   */
-  trackAlarmPath(index, alarm) {
-    return alarm ? alarm.value.path : undefined;
+  public ackAlarm(menuItem: INotificationMessage, timeout: number = 0): void {
+    this.notificationsService.acknowledge(menuItem.path, timeout);
   }
 
   ngOnDestroy() {
     this.notificationServiceSettingsSubscription?.unsubscribe();
-    this.alarmSubscription?.unsubscribe();
-    this.alarmInfoSubscription?.unsubscribe();
   }
 
 }

--- a/src/app/alarm-menu/alarm-menu.component.ts
+++ b/src/app/alarm-menu/alarm-menu.component.ts
@@ -4,7 +4,7 @@ import { Observable, Subscription, filter, iif, map, of, switchMap } from 'rxjs'
 import { INotificationConfig } from '../core/interfaces/app-settings.interfaces';
 import { MatDivider } from '@angular/material/divider';
 import { MatListItem } from '@angular/material/list';
-import { MatTooltip } from '@angular/material/tooltip';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatBadge } from '@angular/material/badge';
 import { NgIf, AsyncPipe, NgFor } from '@angular/common';
 import {MatMenuModule } from '@angular/material/menu';
@@ -26,7 +26,7 @@ interface INotificationInfo extends IAlarmInfo{
     templateUrl: './alarm-menu.component.html',
     styleUrls: ['./alarm-menu.component.scss'],
     standalone: true,
-    imports: [MatButton, MatMenuModule, MatBadge, MatTooltip, MatDivider, MatListItem, AsyncPipe, NgFor, NgIf]
+    imports: [MatButton, MatMenuModule, MatBadge, MatTooltipModule, MatDivider, MatListItem, AsyncPipe, NgFor, NgIf]
 })
 export class AlarmMenuComponent implements OnDestroy {
   private static readonly NORMAL_STATE = "normal";
@@ -80,8 +80,16 @@ export class AlarmMenuComponent implements OnDestroy {
     this.notificationsService.mutePlayer(state);
   }
 
-  public ackAlarm(path: string, timeout: number = 0): void {
+  public acknowledge(path: string, timeout: number = 0): void {
     this.notificationsService.acknowledge(path, timeout);
+  }
+
+  public remove(path: string): void {
+    this.notificationsService.clearSignalKNotification(path);
+  }
+
+  public setState(path: string, state: string): void {
+    this.notificationsService.setSignalKNotificationState(path, state);
   }
 
   ngOnDestroy() {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -102,9 +102,7 @@ export class AppComponent implements OnInit, OnDestroy {
     );
 
     // Snackbar Notifications sub
-    this.appNotificationSub = this.appService.getSnackbarAppNotifications().subscribe(
-
-      appNotification => {
+    this.appNotificationSub = this.appService.getSnackbarAppNotifications().subscribe(appNotification => {
         this._snackBar.open(appNotification.message, 'dismiss', {
           duration: appNotification.duration,
           verticalPosition: 'top'

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -102,7 +102,7 @@ export class AppComponent implements OnInit, OnDestroy {
     );
 
     // Snackbar Notifications sub
-    this.appNotificationSub = this.notificationsService.getSnackbarAppNotifications().subscribe(
+    this.appNotificationSub = this.appService.getSnackbarAppNotifications().subscribe(
 
       appNotification => {
         this._snackBar.open(appNotification.message, 'dismiss', {
@@ -142,23 +142,23 @@ export class AppComponent implements OnInit, OnDestroy {
 
     switch (streamStatus.operation) {
       case 0: // not connected
-        this.notificationsService.sendSnackbarNotification("Not connected to server.", 5000, true);
+        this.appService.sendSnackbarNotification("Not connected to server.", 5000, true);
         break;
 
       case 1: // connecting
-        this.notificationsService.sendSnackbarNotification("Connecting to server.", 2000, true);
+        this.appService.sendSnackbarNotification("Connecting to server.", 2000, true);
        break;
 
       case 2: // connected
-        this.notificationsService.sendSnackbarNotification("Connection successful.", 2000, false);
+        this.appService.sendSnackbarNotification("Connection successful.", 2000, false);
         break;
 
       case 3: // connection error
-        this.notificationsService.sendSnackbarNotification("Error connecting to server.", 0, false);
+        this.appService.sendSnackbarNotification("Error connecting to server.", 0, false);
         break;
 
       default:
-        this.notificationsService.sendSnackbarNotification("Unknown stream connection status.", 0, false);
+        this.appService.sendSnackbarNotification("Unknown stream connection status.", 0, false);
         break;
     }
   }

--- a/src/app/core/interfaces/app-interfaces.ts
+++ b/src/app/core/interfaces/app-interfaces.ts
@@ -80,7 +80,7 @@ import { IZoneState } from './app-settings.interfaces';
  *
  * @memberof app-interfaces
  */
- export interface INotification {
+ export interface ISignalKNotification {
   method: Method[],
   state: State,
   message: string

--- a/src/app/core/interfaces/app-interfaces.ts
+++ b/src/app/core/interfaces/app-interfaces.ts
@@ -5,7 +5,7 @@
  * For external data interfaces, such as Signal K, see signalk-interfaces file.
  *********************************************************************************/
 
-import { ISignalKMetadata, State, Method } from "./signalk-interfaces";
+import { ISignalKMetadata, TState, TMethod } from "./signalk-interfaces";
 import { IZoneState } from './app-settings.interfaces';
 
 /**
@@ -81,8 +81,8 @@ import { IZoneState } from './app-settings.interfaces';
  * @memberof app-interfaces
  */
  export interface ISignalKNotification {
-  method: Method[],
-  state: State,
+  method: TMethod[],
+  state: TState,
   message: string
   timestamp: string,
 }

--- a/src/app/core/interfaces/signalk-interfaces.ts
+++ b/src/app/core/interfaces/signalk-interfaces.ts
@@ -9,26 +9,58 @@
 
 // Metadata, Notification and Stream Subscription type restrictions.
 const states = ["nominal", "normal", "alert", "warn", "alarm", "emergency"] as ["nominal", "normal", "alert", "warn", "alarm", "emergency"];
-export type State = typeof states[number];
+export type TState = typeof states[number];
+
+export enum States {
+  Nominal = "nominal",
+  Normal = "normal",
+  Alert = "alert",
+  Warn = "warn",
+  Alarm = "alarm",
+  Emergency = "emergency"
+}
 
 const types = ["linear", "logarithmic", "squareroot", "power"] as ["linear", "logarithmic", "squareroot", "power"];
-export type Type = typeof types[number];
+export type TType = typeof types[number];
+
+export enum Types {
+  Linear = "linear",
+  Logarithmic = "logarithmic",
+  Squareroot = "squareroot",
+  Power = "power"
+}
 
 const methods = ["visual", "sound"] as ["visual", "sound"];
-export type Method = typeof methods[number];
+export type TMethod = typeof methods[number];
+
+export enum Method {
+  Visual = "visual",
+  Sound = "sound"
+}
 
 const formats = ["delta", "full"] as ["delta", "full"];
-export type Format = typeof formats[number];
+export type TFormat = typeof formats[number];
+
+export enum Format {
+  Delta = "delta",
+  Full = "full"
+}
 
 const policies = ["instant", "ideal", "fixed"] as ["instant", "ideal", "fixed"];
-export type Policy = typeof policies[number];
+export type TPolicy = typeof policies[number];
+
+export enum Policy {
+  Instant = "instant",
+  Ideal = "ideal",
+  Fixed = "fixed"
+}
 
 /**
  * Services: signalk-delta service
  * Use in: Root Delta interface - Signal K (WebSocket stream) lowest level raw message interface.
  *
  * Description: lowest level object interface of all data updates send by the server. This includes
- * server Hello, resquest/response (PUTs, login, device token and validation) and data updates.
+ * server Hello, request/response (PUTs, login, device token and validation) and data updates.
  *
  * @memberof signalk-interfaces
  */
@@ -74,7 +106,7 @@ export type Policy = typeof policies[number];
  * Data Update message object interface.
  *
  * Services: signalk-delta service
- * Used in: IDeltaMessage.updates interface propertie
+ * Used in: IDeltaMessage.updates interface properties
  *
  * @memberof signalk-interfaces
  */
@@ -88,7 +120,7 @@ export interface ISignalKUpdateMessage {
 
 /**
  * Source update message object interface.
- * Used in: IDeltaMessage.updates.source interface propertie
+ * Used in: IDeltaMessage.updates.source interface properties
  *
  * @memberof signalk-interfaces
  */
@@ -96,19 +128,19 @@ export interface ISignalKSource {
   // common
   label: string;
   type: string;
-  //buth n2k and I2C sensors
+  // both n2k and I2C sensors
   src?: string;
-  //n2k
+  // n2k
   deviceInstance?: number;
   pgn?: number;
-  //NMEA0183
+  // NMEA0183
   talker?: string;
   sentence?: string;
 }
 
 /**
  * Value update message object interface.
- * Used in: IDeltaMessage.updates.values.[] interface propertie
+ * Used in: IDeltaMessage.updates.values.[] interface properties
  *
  * @memberof signalk-interfaces
  */
@@ -118,7 +150,7 @@ export interface ISignalKDataValueUpdate {
 }
 
 /**
- * Signal K messsage object interface. Describes meta data received from server.
+ * Signal K message object interface. Describes meta data received from server.
  *
  * Used by: signalk-delta (parser) and signalk-full (parser) services
  *
@@ -145,20 +177,20 @@ export interface ISignalKMetadata {
   description: string;
   units: string;        // required if value is present. describe the type of data
   timeout?: number;     // tells the consumer how long it should consider the value valid
-  properties: {}; // Not defined by Kip. Used by GPS and Ship details and other complexe data types
-  method?: Method[];
+  properties: {}; // Not defined by Kip. Used by GPS and Ship details and other complex data types
+  method?: TMethod[];
   displayScale?: {      //This object provides information regarding the recommended type and extent of the scale used for displaying values.
     lower?: number;
     upper?: number;
-    type: Type;
+    type: TType;
     power?: number;
   }
-  alertMethod?: Method[];
-  warnMethod?: Method[];
-  alarmMethod?: Method[];
-  emergencyMethod?: Method[];
+  alertMethod?: TMethod[];
+  warnMethod?: TMethod[];
+  alarmMethod?: TMethod[];
+  emergencyMethod?: TMethod[];
   zones?: {             //This provides a series of hints to the consumer which can be used to properly set a range on a display gauge and also color sectors of a gauge to indicate normal or dangerous operating conditions.
-    state: State;
+    state: TState;
     lower?: number;
     upper?: number;
     message?: string;

--- a/src/app/core/interfaces/widgets-interface.ts
+++ b/src/app/core/interfaces/widgets-interface.ts
@@ -1,4 +1,4 @@
-import { Format, Policy } from './signalk-interfaces';
+import { TFormat, TPolicy } from './signalk-interfaces';
 
 export enum ControlType {
   toggle = 0,
@@ -292,9 +292,9 @@ export interface IWidgetPath {
   /** NOT IMPLEMENTED -Signal K - smoothingPeriod=[milliseconds] becomes the transmission rate, e.g. every smoothingPeriod/1000 seconds. Default: 1000 */
   smoothingPeriod?: number;
   /** NOT IMPLEMENTED -Signal K - format=[delta|full] specifies delta or full format. Default: delta */
-  format?: Format;
+  format?: TFormat;
   /** NOT IMPLEMENTED -Signal K - policy=[instant|ideal|fixed]. Default: ideal */
-  policy?: Policy;
+  policy?: TPolicy;
   /** NOT IMPLEMENTED -Signal K - minPeriod=[milliseconds] becomes the fastest message transmission rate allowed, e.g. every minPeriod/1000 seconds. This is only relevant for policy='instant' to avoid swamping the client or network. */
   minPeriod?: number;
 }

--- a/src/app/core/services/app-service.ts
+++ b/src/app/core/services/app-service.ts
@@ -1,12 +1,20 @@
 import { Injectable, OnDestroy } from '@angular/core';
 import { Observable, Subject, Subscription } from 'rxjs';
 import { IStreamStatus, SignalKDeltaService } from './signalk-delta.service';
-import { AppNotification, NotificationsService } from './notifications.service';
 import { IConnectionConfig } from '../interfaces/app-settings.interfaces';
 import { AppSettingsService } from './app-settings.service';
 import { SignalKDataService } from './signalk-data.service';
 
 const modePath: string = 'self.environment.mode';
+
+/**
+ * Snack-bar notification message interface.
+ */
+export interface AppNotification {
+  message: string;
+  duration: number;
+  silent: boolean;
+}
 
 @Injectable({
   providedIn: 'root'
@@ -26,7 +34,6 @@ export class AppService implements OnDestroy {
     private settings: AppSettingsService,
     private delta: SignalKDeltaService,
     private sk: SignalKDataService,
-    private notification: NotificationsService
   ) {
     this.autoNightMode = this.settings.getAutoNightMode();
     this.autoNightModeObserver();
@@ -72,8 +79,8 @@ export class AppService implements OnDestroy {
   }
 
   public validateAutoNightModeSupported(): boolean {
-    if (this.sk.getPathObject(modePath) == null) {
-      this.notification.sendSnackbarNotification("Dependency Error: self.environment.mode path was not found. To enable Automatic Night Mode, verify that the following Signal K requirements are met: 1) The Derived Data plugin is installed and enabled. 2) The plugin's Sun:Sets environment.sun parameter is checked.", 0);
+    if (this.sk.getPathObject(modePath) === null) {
+      this.sendSnackbarNotification("Dependency Error: self.environment.mode path was not found. To enable Automatic Night Mode, verify that the following Signal K requirements are met: 1) The Derived Data plugin is installed and enabled. 2) The plugin's Sun:Sets environment.sun parameter is checked.", 0);
       return false;
     }
     return true;

--- a/src/app/core/services/app-service.ts
+++ b/src/app/core/services/app-service.ts
@@ -79,7 +79,7 @@ export class AppService implements OnDestroy {
   }
 
   public validateAutoNightModeSupported(): boolean {
-    if (this.sk.getPathObject(modePath) === null) {
+    if (!this.sk.getPathObject(modePath)) {
       this.sendSnackbarNotification("Dependency Error: self.environment.mode path was not found. To enable Automatic Night Mode, verify that the following Signal K requirements are met: 1) The Derived Data plugin is installed and enabled. 2) The plugin's Sun:Sets environment.sun parameter is checked.", 0);
       return false;
     }

--- a/src/app/core/services/app-service.ts
+++ b/src/app/core/services/app-service.ts
@@ -1,10 +1,10 @@
+import { Injectable, OnDestroy } from '@angular/core';
+import { Observable, Subject, Subscription } from 'rxjs';
 import { IStreamStatus, SignalKDeltaService } from './signalk-delta.service';
-import { NotificationsService } from './notifications.service';
+import { AppNotification, NotificationsService } from './notifications.service';
 import { IConnectionConfig } from '../interfaces/app-settings.interfaces';
 import { AppSettingsService } from './app-settings.service';
-import { Injectable, OnDestroy } from '@angular/core';
 import { SignalKDataService } from './signalk-data.service';
-import { Observable, Subscription } from 'rxjs';
 
 const modePath: string = 'self.environment.mode';
 
@@ -19,6 +19,7 @@ export class AppService implements OnDestroy {
   private autoNightModeSubscription: Subscription = null;
   private autoNightModePathSubscription: Subscription = null;
   private autoNightModeThemeSubscription: Subscription = null;
+  public snackbarAppNotifications = new Subject<AppNotification>(); // for snackbar message
   private pathTimer = null;
 
   constructor(
@@ -80,6 +81,31 @@ export class AppService implements OnDestroy {
 
   public set autoNightModeConfig(isEnabled : boolean) {
     this.settings.setAutoNightMode(isEnabled);
+  }
+
+  /**
+   * Display Kip Snackbar notification.
+   *
+   * @param message Text to be displayed.
+   * @param duration Display duration in milliseconds before automatic dismissal.
+   * Duration value of 0 is indefinite or until use clicks Dismiss button. Defaults
+   *  to 10000 of no value is provided.
+   * @param silent A boolean that defines if the notification should make no sound.
+   * Defaults false.
+   */
+  public sendSnackbarNotification(message: string, duration: number = 10000, silent: boolean = false) {
+    this.snackbarAppNotifications.next({ message: message, duration: duration, silent: silent});
+  }
+
+  /**
+   * Observable to receive Kip app Snackbar notification. Use in app.component ONLY.
+   *
+   * @usageNotes To send a Snackbar notification, use sendSnackbarNotification().
+   * Notifications are purely client side and have no relationship or
+   * interactions with the Signal K server.
+   */
+  public getSnackbarAppNotifications() {
+    return this.snackbarAppNotifications.asObservable();
   }
 
   ngOnDestroy(): void {

--- a/src/app/core/services/notifications.service.ts
+++ b/src/app/core/services/notifications.service.ts
@@ -1,5 +1,6 @@
 /**
- * This class handles both App notifications Snackbar and SignalK Notifications
+ * This Angular Service handles both app notifications to the Snackbar and Signal K
+ * Alert Notifications
  */
 import { Injectable, OnDestroy } from '@angular/core';
 import { Subject, BehaviorSubject, Observable, Subscription } from 'rxjs';
@@ -63,7 +64,8 @@ export class NotificationsService implements OnDestroy {
   private notificationConfig: INotificationConfig;
   public notificationConfig$: BehaviorSubject<INotificationConfig> = new BehaviorSubject<INotificationConfig>(DefaultNotificationConfig);
 
-  private alarms: { [path: string]: Alarm } = {}; // local array of Alarms with path as index key
+  
+  // private alarms: { [path: string]: Alarm } = {}; // local array of Alarms with path as index key
   private activeAlarmsSubject = new BehaviorSubject<any>({});
   private alarmsInfo: BehaviorSubject<IAlarmInfo> = new BehaviorSubject<IAlarmInfo>({
     audioSev: 0,
@@ -335,12 +337,13 @@ export class NotificationsService implements OnDestroy {
    */
   public processNotificationDelta(notificationDelta: INotificationDelta) {
     if (this.notificationConfig.disableNotifications) {
+      notificationDelta = null;
       return;
     }
 
     if (notificationDelta.notification === null) {
       // Alarm removed/cleared on server.
-      if (this.deleteAlarm(notificationDelta.path)) {};
+      this.deleteAlarm(notificationDelta.path);
     } else {
       if (notificationDelta.path in this.alarms) {
         //already know of this alarm. Just check if updated (no need to update doc/etc if no change)

--- a/src/app/core/services/notifications.service.ts
+++ b/src/app/core/services/notifications.service.ts
@@ -1,6 +1,5 @@
 /**
- * This Angular Service handles both app notifications to the Snackbar and Signal K
- * Alert Notifications
+ * This Service handles app notifications sent by the Signal K server.
  */
 import { Injectable, OnDestroy } from '@angular/core';
 import { BehaviorSubject, Observable, Subscription } from 'rxjs';
@@ -129,27 +128,18 @@ export class NotificationsService implements OnDestroy {
   }
 
   /**
-   * Returns an Observable of type alarms containing alarms. Used
-   * by observers whom are interested in Alarms such as Widgets and Alarm menu.
+   * Returns a notification Observable of notification or null.
    */
-  public observe(): Observable<any> {
+  public observe(): Observable<INotification[] | null> {
     return this.notifications$.asObservable();
   }
 
-  /**
-   * Add notification to the notifications array
-   * @param msg Signal K notification message
-   */
   private add(notification: INotification) {
     this._notifications.push(notification);
     this.updateNotificationsState();
     this.notifications$.next(this._notifications);
   }
 
-  /**
-   * Update notification data received from SignalK. ie. alarm.notification
-   * @param notification
-   */
   private update(notification: INotification) {
     let notificationToUpdate = this._notifications.find(item => item.path == notification.path);
     if (notificationToUpdate) {
@@ -161,10 +151,6 @@ export class NotificationsService implements OnDestroy {
     }
   }
 
-  /**
-   * Delete alarm by path
-   * @param path
-   */
   private delete(path: string): void {
     const index = this._notifications.findIndex(notification => notification.path == path);
     if (index > -1) {
@@ -272,6 +258,13 @@ export class NotificationsService implements OnDestroy {
     return { aSev, vSev };
   }
 
+  /**
+   * Set the method for a specific path.
+   *
+   * @param {string} path Path to set method for
+   * @param {TMethod[]} method Method to set. See TMethod for definition.
+   * @memberof NotificationsService
+   */
   public setSkMethod(path: string, method: TMethod[]) {
     this.requests.putRequest(
       `${path}.method`,
@@ -280,6 +273,13 @@ export class NotificationsService implements OnDestroy {
     );
   }
 
+  /**
+   * Set the state for a specific path.
+   *
+   * @param {string} path Path to set state for
+   * @param {string} state State to set. See TState for definition.
+   * @memberof NotificationsService
+   */
   public setSkState(path: string, state: string) {
     this.requests.putRequest(
       `${path}.state`,
@@ -350,7 +350,13 @@ export class NotificationsService implements OnDestroy {
     this.activeHowlId = this.howlPlayer.play();
   }
 
-  public getNotificationServiceConfigAsO(): Observable<INotificationConfig> {
+  /**
+   * Returns the Notification Configuration Observable.
+   *
+   * @return {*}  {Observable<INotificationConfig>}
+   * @memberof NotificationsService
+   */
+  public observeNotificationConfiguration(): Observable<INotificationConfig> {
     return this.notificationConfig$.asObservable();
   }
 

--- a/src/app/core/services/notifications.service.ts
+++ b/src/app/core/services/notifications.service.ts
@@ -235,11 +235,9 @@ export class NotificationsService implements OnDestroy {
               || (existingNotification.notification['message'] !== notificationDelta.notification['message'])
               || !isEqual(existingNotification.notification['method'], notificationDelta.notification['method']) ) {
           this.update(notificationDelta);
-          console.log(notificationDelta.notification);
         }
       } else {
         this.add(notificationDelta);
-        console.log(notificationDelta.notification);
       }
     }
   }

--- a/src/app/core/services/notifications.service.ts
+++ b/src/app/core/services/notifications.service.ts
@@ -3,7 +3,7 @@
  * Alert Notifications
  */
 import { Injectable, OnDestroy } from '@angular/core';
-import { Subject, BehaviorSubject, Observable, Subscription } from 'rxjs';
+import { BehaviorSubject, Observable, Subscription } from 'rxjs';
 
 import { AppSettingsService } from "./app-settings.service";
 import { INotificationConfig } from '../interfaces/app-settings.interfaces';
@@ -22,15 +22,6 @@ const alarmTrack = {
   1003 : 'alarm',
   1004 : 'emergency',
 };
-
-/**
- * Snack-bar notification message interface.
- */
-export interface AppNotification {
-  message: string;
-  duration: number;
-  silent: boolean;
-}
 
 /**
  * Kip Alarm object. Alarm index key is the path string. Alarm contains native Signal K Notification
@@ -84,7 +75,6 @@ export class NotificationsService implements OnDestroy {
   private _notifications: INotificationMessage[] = []; // local array of Alarms with path as index key
   private notifications$ = new BehaviorSubject<INotificationMessage[] | null>(null);
   private alarmsInfo$: BehaviorSubject<IAlarmInfo> = new BehaviorSubject<IAlarmInfo>({audioSev: 0, visualSev: 0, alarmCount: 0, unackCount: 0, isMuted: false});
-  public snackbarAppNotifications: Subject<AppNotification> = new Subject<AppNotification>(); // for snackbar message
 
   // sounds properties
   private howlPlayer: Howl;
@@ -319,8 +309,7 @@ export class NotificationsService implements OnDestroy {
     const state = message.notification['state'];
     const severity: ISeverityLevel = NotificationsService.ALARM_SEVERITIES[state];
     if (!severity) {
-      this.sendSnackbarNotification("Unknown Notification State received from Signal K", 0, false);
-      console.log("Unknown Notification State received from Signal K\n" + JSON.stringify(message));
+      console.log("[Notification Service] Unknown Notification State received from Signal K\n" + JSON.stringify(message));
       return { aSev: 0, vSev: 0 };
     }
 
@@ -351,31 +340,6 @@ export class NotificationsService implements OnDestroy {
 
   public observerNotificationInfo() {
     return this.alarmsInfo$.asObservable();
-  }
-
-  /**
-   * Display Kip Snackbar notification.
-   *
-   * @param message Text to be displayed.
-   * @param duration Display duration in milliseconds before automatic dismissal.
-   * Duration value of 0 is indefinite or until use clicks Dismiss button. Defaults
-   *  to 10000 of no value is provided.
-   * @param silent A boolean that defines if the notification should make no sound.
-   * Defaults false.
-   */
-  public sendSnackbarNotification(message: string, duration: number = 10000, silent: boolean = false) {
-    this.snackbarAppNotifications.next({ message: message, duration: duration, silent: silent});
-  }
-
-  /**
-   * Observable to receive Kip app Snackbar notification. Use in app.component ONLY.
-   *
-   * @usageNotes To send a Snackbar notification, use sendSnackbarNotification().
-   * Notifications are purely client side and have no relationship or
-   * interactions with the Signal K server.
-   */
-  public getSnackbarAppNotifications() {
-    return this.snackbarAppNotifications.asObservable();
   }
 
   /**

--- a/src/app/core/services/notifications.service.ts
+++ b/src/app/core/services/notifications.service.ts
@@ -233,7 +233,7 @@ export class NotificationsService implements OnDestroy {
    * Process Notification Delta received from Signal K server.
    * @param notificationDelta Notification Delta object received from Signal K server.
    */
-  public processNotificationDelta(notificationDelta: INotification) {
+  private processNotificationDelta(notificationDelta: INotification) {
     if (/^notifications.security./.test(notificationDelta.path)) {
       return; // as per sbender this part is not ready in the spec - Don't add to alarms
     }
@@ -335,7 +335,7 @@ export class NotificationsService implements OnDestroy {
   }
 
   public clearSignalKNotification(path: string) {
-    this.deltaService.publishDelta({"path": path});
+    this.requests.clearNotification(path, UUID.create());
   }
 
   public observerNotificationInfo() {

--- a/src/app/core/services/notifications.service.ts
+++ b/src/app/core/services/notifications.service.ts
@@ -9,8 +9,11 @@ import { AppSettingsService } from "./app-settings.service";
 import { INotificationConfig } from '../interfaces/app-settings.interfaces';
 import { DefaultNotificationConfig } from '../../../default-config/config.blank.notification.const';
 import { SignalKDeltaService, INotification, IStreamStatus } from './signalk-delta.service';
+import { SignalkRequestsService } from './signalk-requests.service';
 import { Howl } from 'howler';
 import { isEqual } from 'lodash-es';
+import { UUID } from '../../utils/uuid';
+
 
 const alarmTrack = {
   1000 : 'notification', //filler
@@ -96,6 +99,7 @@ export class NotificationsService implements OnDestroy {
   constructor(
     private appSettingsService: AppSettingsService,
     private deltaService: SignalKDeltaService,
+    private requests: SignalkRequestsService
     ) {
     // Observer of Notification Service configuration changes
     this.notificationSettingsSubscription = this.appSettingsService.getNotificationServiceConfigAsO().subscribe((config: INotificationConfig) => {
@@ -331,6 +335,18 @@ export class NotificationsService implements OnDestroy {
     }
 
     return { aSev, vSev };
+  }
+
+  public setSignalKNotificationState(path: string, state: string) {
+    this.requests.putRequest(
+      path,
+      state,
+      UUID.create()
+    );
+  }
+
+  public clearSignalKNotification(path: string) {
+    this.deltaService.publishDelta({"path": path});
   }
 
   public observerNotificationInfo() {

--- a/src/app/core/services/signalk-data.service.ts
+++ b/src/app/core/services/signalk-data.service.ts
@@ -7,7 +7,6 @@ import { IZone, IZoneState } from '../interfaces/app-settings.interfaces';
 import { AppSettingsService } from './app-settings.service';
 import { INotification, SignalKDeltaService } from './signalk-delta.service';
 import { UnitsService, IUnitDefaults, IUnitGroup } from './units.service';
-import { NotificationsService } from './notifications.service';
 import Qty from 'js-quantities';
 
 const SELFROOTDEF: string = "self";
@@ -66,7 +65,7 @@ export class SignalKDataService implements OnDestroy {
   // List of paths used by Kip (Widgets or App (Notifications and such))
   private pathRegister: pathRegistration[] = [];
 
-  // path Observable
+  // Path Delta data
   private skDataObservable: BehaviorSubject<IPathData[]> = new BehaviorSubject<IPathData[]>([]);
   private deltaServiceSelfUrnSubscription: Subscription = null;
   private deltaServiceMetaSubscription: Subscription = null;
@@ -77,16 +76,18 @@ export class SignalKDataService implements OnDestroy {
   private _deltaUpdatesSubject: ReplaySubject<IDeltaUpdate> = new ReplaySubject(60);
   private _deltaUpdatesCounterTimer = null;
 
+  // Units conversions
   private defaultUnits: IUnitDefaults = null;
   private defaultUnitsSub: Subscription = null;
   private conversionList: IUnitGroup[] = [];
+
+  // Zones
   private zonesSub: Subscription = null;
   private zones: Array<IZone> = [];
 
   constructor(
       private appSettingsService: AppSettingsService,
       private deltaService: SignalKDeltaService,
-      private notificationsService: NotificationsService,
       private unitService: UnitsService) {
 
     // Emit Delta message update counter every second
@@ -344,7 +345,7 @@ export class SignalKDataService implements OnDestroy {
           timestamp: Date.now().toString()
         }
       }
-      this.notificationsService.processNotificationDelta(zoneNotification);
+      this.deltaService.signalKNotifications$.next(zoneNotification);
     }
 
     this.skData[pathIndex].state = state;

--- a/src/app/core/services/signalk-data.service.ts
+++ b/src/app/core/services/signalk-data.service.ts
@@ -2,7 +2,7 @@ import { cloneDeep } from 'lodash-es';
 import { Injectable, OnDestroy } from '@angular/core';
 import { Observable , BehaviorSubject, Subscription, ReplaySubject } from 'rxjs';
 import { IPathData, IPathValueData, IPathMetaData, IMeta} from "../interfaces/app-interfaces";
-import { Method, State } from '../interfaces/signalk-interfaces'
+import { TMethod, TState } from '../interfaces/signalk-interfaces'
 import { IZone, IZoneState } from '../interfaces/app-settings.interfaces';
 import { AppSettingsService } from './app-settings.service';
 import { INotification, SignalKDeltaService } from './signalk-delta.service';
@@ -313,8 +313,8 @@ export class SignalKDataService implements OnDestroy {
 
     // if we're not in alarm, and new state is alarm, sound the alarm!
     if (state != this.skData[pathIndex].state) {
-      let stateString: State; // notification service needs string....
-      let methods: Method[] = null;
+      let stateString: TState; // notification service needs string....
+      let methods: TMethod[] = null;
       switch (state) {
         // @ts-ignore
         case IZoneState.alarm:

--- a/src/app/core/services/signalk-data.service.ts
+++ b/src/app/core/services/signalk-data.service.ts
@@ -268,7 +268,7 @@ export class SignalKDataService implements OnDestroy {
         }
       }
 
-      this.skData.push({
+      pathIndex = this.skData.push({
         path: updatePath,
         pathValue: dataPath.value,
         defaultSource: dataPath.source,
@@ -280,9 +280,7 @@ export class SignalKDataService implements OnDestroy {
             sourceValue: dataPath.value
           }
         }
-      });
-      // get new object index for further processing
-      pathIndex = this.skData.findIndex(pathObject => pathObject.path == updatePath);
+      }) - 1;
     }
 
     // Check for any zones to set state

--- a/src/app/core/services/signalk-delta.service.ts
+++ b/src/app/core/services/signalk-delta.service.ts
@@ -37,7 +37,7 @@ export class SignalKDeltaService {
   // Signal K Requests message stream Observable
   private signalKRequests$ = new Subject<ISignalKDeltaMessage>();
   // Signal K Notifications message stream Observable
-  private signalKNotifications$ = new Subject<INotification>();
+  public signalKNotifications$ = new Subject<INotification>();
   // Signal K data path message stream Observable
   private signalKDataPath$ = new Subject<IPathValueData>();
   // Signal K Metadata message stream Observer

--- a/src/app/core/services/signalk-delta.service.ts
+++ b/src/app/core/services/signalk-delta.service.ts
@@ -3,7 +3,7 @@ import { BehaviorSubject, delay, Observable , retryWhen, Subject, tap } from 'rx
 import { webSocket, WebSocketSubject } from 'rxjs/webSocket';
 
 import { ISignalKDeltaMessage, ISignalKMeta, ISignalKUpdateMessage } from '../interfaces/signalk-interfaces';
-import { IMeta, INotification, IPathValueData } from "../interfaces/app-interfaces";
+import { IMeta, ISignalKNotification, IPathValueData } from "../interfaces/app-interfaces";
 import { SignalKConnectionService, IEndpointStatus } from './signalk-connection.service'
 import { AuthenticationService, IAuthorizationToken } from './authentication.service';
 
@@ -24,9 +24,9 @@ export interface IStreamStatus {
   hasToken: boolean;
 }
 
-export interface INotificationDelta {
+export interface INotification {
   path: string;
-  notification: INotification;
+  notification: ISignalKNotification;
 }
 
 @Injectable({
@@ -37,7 +37,7 @@ export class SignalKDeltaService {
   // Signal K Requests message stream Observable
   private signalKRequests$ = new Subject<ISignalKDeltaMessage>();
   // Signal K Notifications message stream Observable
-  private signalKNotifications$ = new Subject<INotificationDelta>();
+  private signalKNotifications$ = new Subject<INotification>();
   // Signal K data path message stream Observable
   private signalKDataPath$ = new Subject<IPathValueData>();
   // Signal K Metadata message stream Observer
@@ -267,7 +267,7 @@ export class SignalKDeltaService {
 
           //TODO: notifications have evolved with the specs. Need to update at some point...
           if (/^notifications./.test(item.path)) {  // It's is a notification message, pass to notification service
-            const notification: INotificationDelta = {
+            const notification: INotification = {
               path: item.path,
               notification: item.value,
             };
@@ -346,7 +346,7 @@ export class SignalKDeltaService {
     return this.signalKRequests$.asObservable();
   }
 
-  public subscribeNotificationsUpdates(): Observable<INotificationDelta> {
+  public subscribeNotificationsUpdates(): Observable<INotification> {
     return this.signalKNotifications$.asObservable();
   }
 

--- a/src/app/core/services/signalk-requests.service.ts
+++ b/src/app/core/services/signalk-requests.service.ts
@@ -11,12 +11,12 @@ import { AppService } from './app-service';
 const deltaStatusCodes = {
   200: "The request was successfully.",
   202: "Request accepted and pending completion.",
-  400: "Bad client request.",
+  400: "Something is wrong with the client's request.",
   401: "Login failed. Your User ID or Password is incorrect.",
-  403: "DENIED: Authentication required with R/W or Admin permission level to send commands. Configure server connection authentication or request a Device Authorization token.",
+  403: "DENIED: Authorization with R/W or Admin permission level is required to send commands. Configure Sign In credential.",
   405: "The server does not support the request.",
   500: "The request failed.",
-  502: "Something went wrong carrying out the request on the server side.",
+  502: "Something went wrong carrying out the request on the server.",
   504: "Timeout on the server side trying to carry out the request."
 }
 export interface skRequest {
@@ -136,38 +136,7 @@ export class SignalkRequestsService {
       "requestId": requestId,
       "put": {
         "path": noSelfPath,
-        "value": value
-      }
-    }
-    this.signalKDeltaService.publishDelta(message); //send request
-
-    const request: skRequest = {
-      requestId: requestId,
-      state: null,
-      statusCode: null,
-      widgetUUID: widgetUUID,
-    };
-
-    this.requests.push(request); // save to private array pending response with widgetUUID so we can filter response from subscriber
-    return requestId; // return the ID to the Subscriber, if tracking of individual request is required
-  }
-
-  /**
-  * Sends a clear Notification request to Signal K server and returns requestId.
-  * @param path Signal K full path. Automatically removes "self" if included in path.
-  * @param widgetUUID Optional - Subscriber's UUID to be included as part of
-  * the subscribeRequest Subject response. Enables Widget specific filtering.
-  * @return requestId Identifier for this specific request. Enables Request specific filtering.
-  */
-  public clearNotification(path: string, widgetUUID: string): string {
-    const requestId = UUID.create();
-    const noSelfPath = path.replace(/^(self\.)/,""); //no self in path...
-    const selfContext: string = "vessels.self";    // hard coded context. Could be dynamic at some point
-    const message = {
-      "context": selfContext,
-      "requestId": requestId,
-      "put": {
-        "path": noSelfPath,
+        "value": value,
       }
     }
     this.signalKDeltaService.publishDelta(message); //send request

--- a/src/app/core/services/signalk-requests.service.ts
+++ b/src/app/core/services/signalk-requests.service.ts
@@ -202,7 +202,6 @@ export class SignalkRequestsService {
 
         if (this.requests[index].statusCode == 202) {
           console.log("[Request Service] Async 202 response received");
-          // this.NotificationsService.sendSnackbarNotification(this.requests[index].statusCodeDescription);
           return;
         }
 

--- a/src/app/core/services/signalk-requests.service.ts
+++ b/src/app/core/services/signalk-requests.service.ts
@@ -153,6 +153,37 @@ export class SignalkRequestsService {
   }
 
   /**
+  * Sends a clear Notification request to Signal K server and returns requestId.
+  * @param path Signal K full path. Automatically removes "self" if included in path.
+  * @param widgetUUID Optional - Subscriber's UUID to be included as part of
+  * the subscribeRequest Subject response. Enables Widget specific filtering.
+  * @return requestId Identifier for this specific request. Enables Request specific filtering.
+  */
+  public clearNotification(path: string, widgetUUID: string): string {
+    let requestId = UUID.create();
+    let noSelfPath = path.replace(/^(self\.)/,""); //no self in path...
+    let selfContext: string = "vessels.self";    // hard coded context. Could be dynamic at some point
+    let message = {
+      "context": selfContext,
+      "requestId": requestId,
+      "put": {
+        "path": noSelfPath,
+      }
+    }
+    this.signalKDeltaService.publishDelta(message); //send request
+
+    let request: skRequest = {
+      requestId: requestId,
+      state: null,
+      statusCode: null,
+      widgetUUID: widgetUUID,
+    };
+
+    this.requests.push(request); // save to private array pending response with widgetUUID so we can filter response from subscriber
+    return requestId; // return the ID to the Subscriber, if tracking of individual request is required
+  }
+
+  /**
    * Handles request updates, issue display and logging.
    *
    * @param delta Signal K Delta message

--- a/src/app/core/services/signalk-requests.service.ts
+++ b/src/app/core/services/signalk-requests.service.ts
@@ -58,8 +58,8 @@ export class SignalkRequestsService {
    * The Device authorization is a manual process done on the server.
    */
   public requestDeviceAccessToken(): string {
-    let requestId = UUID.create();
-    let deviceTokenRequest = {
+    const requestId = UUID.create();
+    const deviceTokenRequest = {
       requestId: requestId,
       accessRequest: {
         clientId: this.appSettingsService.KipUUID,
@@ -71,7 +71,7 @@ export class SignalkRequestsService {
     console.log("[Request Service] Requesting Device Authorization Token");
     this.signalKDeltaService.publishDelta(deviceTokenRequest);
 
-    let request = {
+    const request = {
       requestId: requestId,
       state: null,
       statusCode: null
@@ -98,8 +98,8 @@ export class SignalkRequestsService {
   * @memberof SignalkRequestsService
   */
   public requestUserLogin(userId: string, userPassword: string): string {
-    let requestId = UUID.create();
-    let loginRequest = {
+    const requestId = UUID.create();
+    const loginRequest = {
       requestId: requestId,
       login: {
         username: userId,
@@ -110,7 +110,7 @@ export class SignalkRequestsService {
     console.log("[Request Service] Requesting User Login");
     this.signalKDeltaService.publishDelta(loginRequest);
 
-    let request = {
+    const request = {
       requestId: requestId,
       state: null,
       statusCode: null
@@ -128,10 +128,10 @@ export class SignalkRequestsService {
   * @return requestId Identifier for this specific request. Enables Request specific filtering.
   */
   public putRequest(path: string, value: any, widgetUUID: string): string {
-    let requestId = UUID.create();
-    let noSelfPath = path.replace(/^(self\.)/,""); //no self in path...
-    let selfContext: string = "vessels.self";    // hard coded context. Could be dynamic at some point
-    let message = {
+    const requestId = UUID.create();
+    const noSelfPath = path.replace(/^(self\.)/,""); //no self in path...
+    const selfContext: string = "vessels.self";    // hard coded context. Could be dynamic at some point
+    const message = {
       "context": selfContext,
       "requestId": requestId,
       "put": {
@@ -141,7 +141,7 @@ export class SignalkRequestsService {
     }
     this.signalKDeltaService.publishDelta(message); //send request
 
-    let request: skRequest = {
+    const request: skRequest = {
       requestId: requestId,
       state: null,
       statusCode: null,
@@ -160,10 +160,10 @@ export class SignalkRequestsService {
   * @return requestId Identifier for this specific request. Enables Request specific filtering.
   */
   public clearNotification(path: string, widgetUUID: string): string {
-    let requestId = UUID.create();
-    let noSelfPath = path.replace(/^(self\.)/,""); //no self in path...
-    let selfContext: string = "vessels.self";    // hard coded context. Could be dynamic at some point
-    let message = {
+    const requestId = UUID.create();
+    const noSelfPath = path.replace(/^(self\.)/,""); //no self in path...
+    const selfContext: string = "vessels.self";    // hard coded context. Could be dynamic at some point
+    const message = {
       "context": selfContext,
       "requestId": requestId,
       "put": {
@@ -172,7 +172,7 @@ export class SignalkRequestsService {
     }
     this.signalKDeltaService.publishDelta(message); //send request
 
-    let request: skRequest = {
+    const request: skRequest = {
       requestId: requestId,
       state: null,
       statusCode: null,
@@ -189,7 +189,7 @@ export class SignalkRequestsService {
    * @param delta Signal K Delta message
    */
   private updateRequest(delta: ISignalKDeltaMessage) {
-    let index = this.requests.findIndex(r => r.requestId == delta.requestId);
+    const index = this.requests.findIndex(r => r.requestId == delta.requestId);
     if (index > -1) {  // exists in local array
       this.requests[index].state = delta.state;
       this.requests[index].statusCode = delta.statusCode;

--- a/src/app/core/services/signalk-requests.service.ts
+++ b/src/app/core/services/signalk-requests.service.ts
@@ -4,9 +4,9 @@ import { Subscription ,  Observable ,  Subject } from 'rxjs';
 import { AppSettingsService } from './app-settings.service';
 import { ISignalKDeltaMessage } from '../interfaces/signalk-interfaces';
 import { SignalKDeltaService } from './signalk-delta.service';
-import { NotificationsService } from './notifications.service';
 import { AuthenticationService } from './authentication.service';
 import { UUID } from '../../utils/uuid'
+import { AppService } from './app-service';
 
 const deltaStatusCodes = {
   200: "The request was successfully.",
@@ -39,7 +39,7 @@ export class SignalkRequestsService {
   constructor(
     private signalKDeltaService: SignalKDeltaService,
     private appSettingsService: AppSettingsService,
-    private NotificationsService: NotificationsService,
+    private appService: AppService,
     private auth: AuthenticationService,
     ) {
       // Observer to get all signalk-delta messages of type request type.
@@ -207,7 +207,7 @@ export class SignalkRequestsService {
         }
 
         if (this.requests[index].statusCode == 400) {
-          this.NotificationsService.sendSnackbarNotification(this.requests[index].message);
+          this.appService.sendSnackbarNotification(this.requests[index].message);
           console.log("[Request Service] " + this.requests[index].message );
         }
 
@@ -220,7 +220,7 @@ export class SignalkRequestsService {
         }
 
         if ((delta.accessRequest !== undefined) && (delta.accessRequest.token !== undefined)) {
-          this.NotificationsService.sendSnackbarNotification(delta.accessRequest.permission + ": Device Access Token received from server.");
+          this.appService.sendSnackbarNotification(delta.accessRequest.permission + ": Device Access Token received from server.");
           console.log(`[Request Service] ${delta.accessRequest.permission}: Device Access Token received`);
           this.auth.setDeviceAccessToken(delta.accessRequest.token);
 
@@ -234,7 +234,7 @@ export class SignalkRequestsService {
         }
 
       } else {
-        this.NotificationsService.sendSnackbarNotification("ERROR: Unknown Request Status Code received: " + this.requests[index].statusCode + " - " + deltaStatusCodes[this.requests[index].statusCode] + " - " + this.requests[index].message);
+        this.appService.sendSnackbarNotification("ERROR: Unknown Request Status Code received: " + this.requests[index].statusCode + " - " + deltaStatusCodes[this.requests[index].statusCode] + " - " + this.requests[index].message);
         console.error("[Request Service] Unknown Request Status Code received: " + this.requests[index].statusCode + " - " + deltaStatusCodes[this.requests[index].statusCode] + " - " + this.requests[index].message);
       }
       try {
@@ -246,7 +246,7 @@ export class SignalkRequestsService {
         this.requests = []; // flush array to clean values that will become stale post error
       }
     } else {
-      this.NotificationsService.sendSnackbarNotification("ERROR: A request message that contains an unknown Request ID was received. Request Delta:\n" + JSON.stringify(delta));
+      this.appService.sendSnackbarNotification("ERROR: A request message that contains an unknown Request ID was received. Request Delta:\n" + JSON.stringify(delta));
       console.error("[Request Service] A Request message that contains an unknown Request ID was received. from delta:\n" + JSON.stringify(delta))
     }
   }

--- a/src/app/settings/config/config.component.ts
+++ b/src/app/settings/config/config.component.ts
@@ -3,9 +3,9 @@ import { Subscription } from 'rxjs';
 import { UntypedFormBuilder, UntypedFormGroup, Validators, FormsModule, ReactiveFormsModule }    from '@angular/forms';
 
 import { AuthenticationService, IAuthorizationToken } from '../../core/services/authentication.service';
+import { AppService } from '../../core/services/app-service';
 import { AppSettingsService } from '../../core/services/app-settings.service';
 import { IConfig, IAppConfig, IConnectionConfig, IWidgetConfig, ILayoutConfig, IThemeConfig, IZonesConfig } from '../../core/interfaces/app-settings.interfaces';
-import { NotificationsService } from '../../core/services/notifications.service';
 import { StorageService } from '../../core/services/storage.service';
 import { cloneDeep } from 'lodash-es';
 import { HttpErrorResponse } from '@angular/common/http';
@@ -20,6 +20,7 @@ import { MatButton } from '@angular/material/button';
 import { MatDivider } from '@angular/material/divider';
 import { NgIf, NgFor } from '@angular/common';
 import { RouterLink } from '@angular/router';
+
 
 interface IRemoteConfig {
   scope: string,
@@ -64,7 +65,7 @@ export class SettingsConfigComponent implements OnInit, OnDestroy{
   constructor(
     private appSettingsService: AppSettingsService,
     private storageSvc: StorageService,
-    private notificationsService: NotificationsService,
+    private appService: AppService,
     private auth: AuthenticationService,
     private fb: UntypedFormBuilder,
   ) { }
@@ -126,10 +127,10 @@ export class SettingsConfigComponent implements OnInit, OnDestroy{
 
         switch (error.status) {
           case 401:
-            this.notificationsService.sendSnackbarNotification("Application Storage Error: " + error.statusText + ". Signal K configuration must meet the following requirements; 1) Security enabled. 2) Application Data Storage Interface: On. 3) Either Allow Readonly Access enabled, or connecting with a user.", 0, false);
+            this.appService.sendSnackbarNotification("Application Storage Error: " + error.statusText + ". Signal K configuration must meet the following requirements; 1) Security enabled. 2) Application Data Storage Interface: On. 3) Either Allow Readonly Access enabled, or connecting with a user.", 0, false);
             break;
 
-          default: this.notificationsService.sendSnackbarNotification("Error listing server configurations: " + error, 3000, false);
+          default: this.appService.sendSnackbarNotification("Error listing server configurations: " + error, 3000, false);
             break;
         }
       });
@@ -139,12 +140,12 @@ export class SettingsConfigComponent implements OnInit, OnDestroy{
   public saveConfig(conf: IConfig, scope: string, name: string, dontRefreshConfigList?: boolean) {
     if (this.supportApplicationData) {
       if (this.storageSvc.setConfig(scope, name, conf)) {
-        this.notificationsService.sendSnackbarNotification(`Configuration [${name}] saved to [${scope}] storage scope`, 5000, false);
+        this.appService.sendSnackbarNotification(`Configuration [${name}] saved to [${scope}] storage scope`, 5000, false);
         if (!dontRefreshConfigList) {
           this.getServerConfigList();
         }
       } else {
-        this.notificationsService.sendSnackbarNotification("Error saving configuration to server", 0, false);
+        this.appService.sendSnackbarNotification("Error saving configuration to server", 0, false);
       }
     }
   }
@@ -160,7 +161,7 @@ export class SettingsConfigComponent implements OnInit, OnDestroy{
       }
       else if(this.copyConfigForm.value.copyDestination === 'Local Storage') {
         // local to local
-        this.notificationsService.sendSnackbarNotification("Local Storage cannot be copies to Local Storage ", 0, false);
+        this.appService.sendSnackbarNotification("Local Storage cannot be copies to Local Storage ", 0, false);
       }
 
     } else {
@@ -171,7 +172,7 @@ export class SettingsConfigComponent implements OnInit, OnDestroy{
           conf = config
         });
       } catch (error) {
-        this.notificationsService.sendSnackbarNotification("Error retrieving configuration from server: " + error.statusText, 3000, false);
+        this.appService.sendSnackbarNotification("Error retrieving configuration from server: " + error.statusText, 3000, false);
         return;
       }
 
@@ -194,7 +195,7 @@ export class SettingsConfigComponent implements OnInit, OnDestroy{
 
   public deleteConfig (scope: string, name: string, forceConfigFileVersion?: number, dontRefreshConfigList?: boolean) {
     this.storageSvc.removeItem(scope, name, forceConfigFileVersion);
-    this.notificationsService.sendSnackbarNotification(`Configuration [${name}] deleted from [${scope}] storage scope`, 5000, false);
+    this.appService.sendSnackbarNotification(`Configuration [${name}] deleted from [${scope}] storage scope`, 5000, false);
     if (!dontRefreshConfigList) {
       this.getServerConfigList();
     }
@@ -223,7 +224,7 @@ export class SettingsConfigComponent implements OnInit, OnDestroy{
       console.log('[Configuration] Saving upgraded config [' + oldConfig.name + '] to [' + oldConfig.scope + '] scope');
       this.storageSvc.patchGlobal(oldConfig.name, oldConfig.scope, conf, 'add');
     });
-    this.notificationsService.sendSnackbarNotification("Configuration migration completed. WARNING: Test the migrated configurations before deleting them.", 0, false);
+    this.appService.sendSnackbarNotification("Configuration migration completed. WARNING: Test the migrated configurations before deleting them.", 0, false);
   }
 
   public refreshConfig(): void {
@@ -232,7 +233,7 @@ export class SettingsConfigComponent implements OnInit, OnDestroy{
         this.serverConfigList = configs;
       })
       .catch(error => {
-        this.notificationsService.sendSnackbarNotification("[Configuration] Error listing server configurations: " + error, 3000, false);
+        this.appService.sendSnackbarNotification("[Configuration] Error listing server configurations: " + error, 3000, false);
       });
   }
 

--- a/src/app/settings/general/general.component.html
+++ b/src/app/settings/general/general.component.html
@@ -25,7 +25,7 @@
             Enable notification messages per severity level
           </mat-panel-description>
         </mat-expansion-panel-header>
-        <mat-checkbox [(ngModel)]="notificationConfig.devices.showNormalState" [ngModelOptions]="{standalone: true}">Show Devices Informational notifications</mat-checkbox>
+        <mat-checkbox [(ngModel)]="notificationConfig.devices.showNormalState" [ngModelOptions]="{standalone: true}">Show <b>Normal</b> state notifications</mat-checkbox>
       </mat-expansion-panel>
       <mat-expansion-panel expanded="false">
         <mat-expansion-panel-header>
@@ -38,7 +38,7 @@
         </mat-expansion-panel-header>
         <mat-checkbox [(ngModel)]="notificationConfig.sound.disableSound" [ngModelOptions]="{standalone: true}">Disable <b>All Audio</b> prompts</mat-checkbox>
         <br/>
-        <mat-checkbox [(ngModel)]="notificationConfig.sound.muteNormal" [ngModelOptions]="{standalone: true}">Disable <b>Information</b> severity</mat-checkbox>
+        <mat-checkbox [(ngModel)]="notificationConfig.sound.muteNormal" [ngModelOptions]="{standalone: true}">Disable <b>Normal</b> severity</mat-checkbox>
         <br/>
         <mat-checkbox [(ngModel)]="notificationConfig.sound.muteAlert" [ngModelOptions]="{standalone: true}">Disable <b>Alert</b> severity</mat-checkbox>
         <br/>

--- a/src/app/settings/general/general.component.html
+++ b/src/app/settings/general/general.component.html
@@ -38,8 +38,6 @@
         </mat-expansion-panel-header>
         <mat-checkbox [(ngModel)]="notificationConfig.sound.disableSound" [ngModelOptions]="{standalone: true}">Disable <b>All Audio</b> prompts</mat-checkbox>
         <br/>
-        <mat-checkbox [(ngModel)]="notificationConfig.sound.muteNormal" [ngModelOptions]="{standalone: true}">Disable <b>Normal</b> severity</mat-checkbox>
-        <br/>
         <mat-checkbox [(ngModel)]="notificationConfig.sound.muteAlert" [ngModelOptions]="{standalone: true}">Disable <b>Alert</b> severity</mat-checkbox>
         <br/>
         <mat-checkbox [(ngModel)]="notificationConfig.sound.muteWarning" [ngModelOptions]="{standalone: true}">Disable <b>Warning</b> severity</mat-checkbox>

--- a/src/app/settings/general/general.component.html
+++ b/src/app/settings/general/general.component.html
@@ -18,12 +18,14 @@
     <mat-slide-toggle
       name="disableNotifications"
       [(ngModel)]="notificationConfig.disableNotifications"
+      (change)="togglePanel($event)"
       color="primary">
         Disable Notifications
       </mat-slide-toggle>
     <br/><br/>
     <mat-accordion>
-      <mat-expansion-panel expanded="false">
+      <mat-expansion-panel #statePanel
+        [disabled]="notificationConfig.disableNotifications">
         <mat-expansion-panel-header>
           <mat-panel-title>
             State
@@ -38,7 +40,8 @@
           Show <b>Normal</b> severity
         </mat-checkbox>
       </mat-expansion-panel>
-      <mat-expansion-panel expanded="false">
+      <mat-expansion-panel #soundPanel
+        [disabled]="notificationConfig.disableNotifications">
         <mat-expansion-panel-header>
           <mat-panel-title>
             Sound

--- a/src/app/settings/general/general.component.html
+++ b/src/app/settings/general/general.component.html
@@ -1,8 +1,16 @@
 <div class="mat-typography">
-  <form #general="ngForm" name="GeneraSetting">
+  <form (ngSubmit)="saveAllSettings()" #generalForm="ngForm" id="GeneraSetting">
     <h2>Display Modes</h2>
-    <mat-checkbox class="full-width" [(ngModel)]="autoNightModeConfig" [ngModelOptions]="{standalone: false}" name="autoNightMode" (change)="isAutoNightPathSupported($event)">Automatically change between Day and Night Modes based on sun phases preserving your night vision</mat-checkbox>
-    <mat-checkbox class="full-width" [(ngModel)]="enableHighContrast" [ngModelOptions]="{standalone: false}" name="enableHighContrast" (change)="setTheme($event)">Enable full sunlight High Contrast, black and white display</mat-checkbox>
+    <mat-checkbox class="full-width"
+      [(ngModel)]="autoNightModeConfig"
+      name="autoNightMode">
+      Automatically change between Day and Night Modes based on sun phases preserving your night vision.
+    </mat-checkbox>
+    <mat-checkbox class="full-width"
+      [(ngModel)]="enableHighContrast"
+      name="enableHighContrast">
+      Enable full sunlight High Contrast, black and white display.
+    </mat-checkbox>
     <br/><br/>
     <h2>Notifications</h2>
     <p class="mat-card-subtitle">Notifications are a special type of data sent from Signal K and displayed in the
@@ -11,10 +19,10 @@
     <mat-slide-toggle
       name="disableNotifications"
       [(ngModel)]="notificationConfig.disableNotifications"
-      [ngModelOptions]="{standalone: true}"
       color="primary">
-        Disable Notifications</mat-slide-toggle>
-        <br/><br/>
+        Disable Notifications
+      </mat-slide-toggle>
+    <br/><br/>
     <mat-accordion>
       <mat-expansion-panel expanded="false">
         <mat-expansion-panel-header>
@@ -25,7 +33,11 @@
             Enable notification messages per severity level
           </mat-panel-description>
         </mat-expansion-panel-header>
-        <mat-checkbox [(ngModel)]="notificationConfig.devices.showNormalState" [ngModelOptions]="{standalone: true}">Show <b>Normal</b> state notifications</mat-checkbox>
+        <mat-checkbox
+          name="showNormalState"
+          [(ngModel)]="notificationConfig.devices.showNormalState">
+          Show <b>Normal</b> state notifications
+        </mat-checkbox>
       </mat-expansion-panel>
       <mat-expansion-panel expanded="false">
         <mat-expansion-panel-header>
@@ -36,20 +48,40 @@
             Disable alarm audio notification method per severity levels
           </mat-panel-description>
         </mat-expansion-panel-header>
-        <mat-checkbox [(ngModel)]="notificationConfig.sound.disableSound" [ngModelOptions]="{standalone: true}">Disable <b>All Audio</b> prompts</mat-checkbox>
+        <mat-checkbox
+          name="=disableSound"
+          [(ngModel)]="notificationConfig.sound.disableSound">
+          Disable <b>All Audio</b> prompts
+        </mat-checkbox>
         <br/>
-        <mat-checkbox [(ngModel)]="notificationConfig.sound.muteAlert" [ngModelOptions]="{standalone: true}">Disable <b>Alert</b> severity</mat-checkbox>
+        <mat-checkbox
+        name="muteAlert"
+          [(ngModel)]="notificationConfig.sound.muteAlert">
+          Disable <b>Alert</b> severity
+        </mat-checkbox>
         <br/>
-        <mat-checkbox [(ngModel)]="notificationConfig.sound.muteWarning" [ngModelOptions]="{standalone: true}">Disable <b>Warning</b> severity</mat-checkbox>
+        <mat-checkbox
+        name="muteWarning"
+          [(ngModel)]="notificationConfig.sound.muteWarning">
+          Disable <b>Warning</b> severity
+        </mat-checkbox>
         <br/>
-        <mat-checkbox [(ngModel)]="notificationConfig.sound.muteAlarm" [ngModelOptions]="{standalone: true}">Disable <b>Alarm</b> severity</mat-checkbox>
+        <mat-checkbox
+        name="muteAlarm"
+          [(ngModel)]="notificationConfig.sound.muteAlarm">
+          Disable <b>Alarm</b> severity
+        </mat-checkbox>
         <br/>
-        <mat-checkbox [(ngModel)]="notificationConfig.sound.muteEmergency" [ngModelOptions]="{standalone: true}">Disable <b>Emergency</b> severity</mat-checkbox>
+        <mat-checkbox
+        name="muteEmergency"
+          [(ngModel)]="notificationConfig.sound.muteEmergency">
+          Disable <b>Emergency</b> severity
+        </mat-checkbox>
       </mat-expansion-panel>
     </mat-accordion>
     <div class="formActionFooter">
       <mat-divider class="formActionDivider"></mat-divider>
-      <button mat-raised-button color="accent" class="formActionButton" (click)='saveAllSettings()'>Save</button>
+      <button mat-raised-button type="submit" color="accent" class="formActionButton" [disabled]="!generalForm.form.dirty">Save</button>
     </div>
   </form>
 </div>

--- a/src/app/settings/general/general.component.html
+++ b/src/app/settings/general/general.component.html
@@ -3,6 +3,7 @@
     <h2>Display Modes</h2>
     <mat-checkbox class="full-width" [(ngModel)]="autoNightModeConfig" [ngModelOptions]="{standalone: false}" name="autoNightMode" (change)="isAutoNightPathSupported($event)">Automatically change between Day and Night Modes based on sun phases preserving your night vision</mat-checkbox>
     <mat-checkbox class="full-width" [(ngModel)]="enableHighContrast" [ngModelOptions]="{standalone: false}" name="enableHighContrast" (change)="setTheme($event)">Enable full sunlight High Contrast, black and white display</mat-checkbox>
+    <br/><br/>
     <h2>Notifications</h2>
     <p class="mat-card-subtitle">Notifications are a special type of data sent from Signal K and displayed in the
       notification menu. They are meant to alert or inform operators. Set server
@@ -12,15 +13,16 @@
       [(ngModel)]="notificationConfig.disableNotifications"
       [ngModelOptions]="{standalone: true}"
       color="primary">
-        Disable All Notifications</mat-slide-toggle>
+        Disable Notifications</mat-slide-toggle>
+        <br/><br/>
     <mat-accordion>
-      <mat-expansion-panel expanded="true">
+      <mat-expansion-panel expanded="false">
         <mat-expansion-panel-header>
           <mat-panel-title>
-            Messages
+            Notification Filters
           </mat-panel-title>
           <mat-panel-description>
-            Control what messages the server will send
+            Enable notification messages per severity level
           </mat-panel-description>
         </mat-expansion-panel-header>
         <mat-checkbox [(ngModel)]="notificationConfig.devices.showNormalState" [ngModelOptions]="{standalone: true}">Show Devices Informational notifications</mat-checkbox>
@@ -28,23 +30,23 @@
       <mat-expansion-panel expanded="false">
         <mat-expansion-panel-header>
           <mat-panel-title>
-            Audio
+            Audio Prompts
           </mat-panel-title>
           <mat-panel-description>
-            Configure sound options
+            Disable alarm audio notification method per severity levels
           </mat-panel-description>
         </mat-expansion-panel-header>
-        <mat-checkbox [(ngModel)]="notificationConfig.sound.disableSound" [ngModelOptions]="{standalone: true}">Disable All Audio notification</mat-checkbox>
+        <mat-checkbox [(ngModel)]="notificationConfig.sound.disableSound" [ngModelOptions]="{standalone: true}">Disable <b>All Audio</b> prompts</mat-checkbox>
         <br/>
-        <mat-checkbox [(ngModel)]="notificationConfig.sound.muteNormal" [ngModelOptions]="{standalone: true}">Disable <b>Information</b> notifications</mat-checkbox>
+        <mat-checkbox [(ngModel)]="notificationConfig.sound.muteNormal" [ngModelOptions]="{standalone: true}">Disable <b>Information</b> severity</mat-checkbox>
         <br/>
-        <mat-checkbox [(ngModel)]="notificationConfig.sound.muteAlert" [ngModelOptions]="{standalone: true}">Disable <b>Alert Severity</b> notifications</mat-checkbox>
+        <mat-checkbox [(ngModel)]="notificationConfig.sound.muteAlert" [ngModelOptions]="{standalone: true}">Disable <b>Alert</b> severity</mat-checkbox>
         <br/>
-        <mat-checkbox [(ngModel)]="notificationConfig.sound.muteWarning" [ngModelOptions]="{standalone: true}">Disable <b>Warning</b> notifications</mat-checkbox>
+        <mat-checkbox [(ngModel)]="notificationConfig.sound.muteWarning" [ngModelOptions]="{standalone: true}">Disable <b>Warning</b> severity</mat-checkbox>
         <br/>
-        <mat-checkbox [(ngModel)]="notificationConfig.sound.muteAlarm" [ngModelOptions]="{standalone: true}">Disable <b>Alarm Severity</b> notifications</mat-checkbox>
+        <mat-checkbox [(ngModel)]="notificationConfig.sound.muteAlarm" [ngModelOptions]="{standalone: true}">Disable <b>Alarm</b> severity</mat-checkbox>
         <br/>
-        <mat-checkbox [(ngModel)]="notificationConfig.sound.muteEmergency" [ngModelOptions]="{standalone: true}">Disable <b>Emergency Severity</b> notifications</mat-checkbox>
+        <mat-checkbox [(ngModel)]="notificationConfig.sound.muteEmergency" [ngModelOptions]="{standalone: true}">Disable <b>Emergency</b> severity</mat-checkbox>
       </mat-expansion-panel>
     </mat-accordion>
     <div class="formActionFooter">

--- a/src/app/settings/general/general.component.html
+++ b/src/app/settings/general/general.component.html
@@ -13,9 +13,8 @@
     </mat-checkbox>
     <br/><br/>
     <h2>Notifications</h2>
-    <p class="mat-card-subtitle">Notifications are a special type of data sent from Signal K and displayed in the
-      notification menu. They are meant to alert or inform operators. Set server
-      notification preferences such as types of messages to display and audio prompts.</p>
+    <p class="mat-card-subtitle">Signal K data state notifications messages meant to
+      inform operators. Notifications are visible in the notifications menu.</p>
     <mat-slide-toggle
       name="disableNotifications"
       [(ngModel)]="notificationConfig.disableNotifications"
@@ -27,31 +26,31 @@
       <mat-expansion-panel expanded="false">
         <mat-expansion-panel-header>
           <mat-panel-title>
-            Notification Filters
+            State
           </mat-panel-title>
           <mat-panel-description>
-            Enable notification messages per severity level
+            Filter notification messages per severity levels
           </mat-panel-description>
         </mat-expansion-panel-header>
         <mat-checkbox
           name="showNormalState"
           [(ngModel)]="notificationConfig.devices.showNormalState">
-          Show <b>Normal</b> state notifications
+          Show <b>Normal</b> severity
         </mat-checkbox>
       </mat-expansion-panel>
       <mat-expansion-panel expanded="false">
         <mat-expansion-panel-header>
           <mat-panel-title>
-            Audio Prompts
+            Sound
           </mat-panel-title>
           <mat-panel-description>
-            Disable alarm audio notification method per severity levels
+            Disable audio prompt per severity levels
           </mat-panel-description>
         </mat-expansion-panel-header>
         <mat-checkbox
           name="=disableSound"
           [(ngModel)]="notificationConfig.sound.disableSound">
-          Disable <b>All Audio</b> prompts
+          Disable <b>All</b>
         </mat-checkbox>
         <br/>
         <mat-checkbox

--- a/src/app/settings/general/general.component.ts
+++ b/src/app/settings/general/general.component.ts
@@ -1,5 +1,5 @@
 import { cloneDeep } from 'lodash-es';
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ViewChild } from '@angular/core';
 import { INotificationConfig } from '../../core/interfaces/app-settings.interfaces';
 import { AppService } from '../../core/services/app-service';
 import { AppSettingsService } from '../../core/services/app-settings.service';
@@ -8,7 +8,7 @@ import { MatDivider } from '@angular/material/divider';
 import { MatAccordion, MatExpansionPanel, MatExpansionPanelHeader, MatExpansionPanelTitle, MatExpansionPanelDescription } from '@angular/material/expansion';
 import { MatSlideToggle } from '@angular/material/slide-toggle';
 import { MatCheckbox, MatCheckboxChange } from '@angular/material/checkbox';
-import { FormsModule } from '@angular/forms';
+import { FormsModule, NgForm } from '@angular/forms';
 
 
 @Component({
@@ -30,7 +30,7 @@ import { FormsModule } from '@angular/forms';
     ],
 })
 export class SettingsGeneralComponent implements OnInit {
-
+  @ViewChild('generalForm') generalForm: NgForm;
   public notificationConfig: INotificationConfig;
   public autoNightModeConfig: boolean;
   public enableHighContrast: boolean = null;
@@ -47,32 +47,14 @@ export class SettingsGeneralComponent implements OnInit {
   }
 
   public saveAllSettings():void {
-    try {
-      this.saveNotificationsSettings();
-      this.saveAutoNightMode();
-      this.app.sendSnackbarNotification("General settings saved", 5000, false);
-      this.enableHighContrast ? this.settings.setThemeName("high-contrast") : this.settings.setThemeName("modernDark")
-
-    } catch (error) {
-      this.app.sendSnackbarNotification("Error saving settings: " + error, 5000, false);
+    this.settings.setNotificationConfig(cloneDeep(this.notificationConfig));
+    if (this.app.validateAutoNightModeSupported()) {
+      this.app.autoNightModeConfig = this.autoNightModeConfig;
+    } else {
+      this.app.autoNightModeConfig = this.autoNightModeConfig = false;
     }
-
-  }
-
-  public saveNotificationsSettings(): void {
-    this.settings.setNotificationConfig(this.notificationConfig);
-  }
-
-  public saveAutoNightMode() {
-    this.app.autoNightModeConfig = this.autoNightModeConfig;
-  }
-
-  public isAutoNightPathSupported(event):void {
-    if (event.checked) {
-      if (!this.app.validateAutoNightModeSupported()) {
-        this.autoNightModeConfig = false;
-      }
-    }
+    this.enableHighContrast ? this.settings.setThemeName("high-contrast") : this.settings.setThemeName("modernDark")
+    this.generalForm.form.markAsPristine();
   }
 
   setTheme(e: MatCheckboxChange) {

--- a/src/app/settings/general/general.component.ts
+++ b/src/app/settings/general/general.component.ts
@@ -3,7 +3,6 @@ import { Component, OnInit } from '@angular/core';
 import { INotificationConfig } from '../../core/interfaces/app-settings.interfaces';
 import { AppService } from '../../core/services/app-service';
 import { AppSettingsService } from '../../core/services/app-settings.service';
-import { NotificationsService } from '../../core/services/notifications.service';
 import { MatButton } from '@angular/material/button';
 import { MatDivider } from '@angular/material/divider';
 import { MatAccordion, MatExpansionPanel, MatExpansionPanelHeader, MatExpansionPanelTitle, MatExpansionPanelDescription } from '@angular/material/expansion';
@@ -37,7 +36,6 @@ export class SettingsGeneralComponent implements OnInit {
   public enableHighContrast: boolean = null;
 
   constructor(
-    private notifications: NotificationsService,
     private app: AppService,
     private settings: AppSettingsService,
   ) { }
@@ -52,11 +50,11 @@ export class SettingsGeneralComponent implements OnInit {
     try {
       this.saveNotificationsSettings();
       this.saveAutoNightMode();
-      this.notifications.sendSnackbarNotification("General settings saved", 5000, false);
+      this.app.sendSnackbarNotification("General settings saved", 5000, false);
       this.enableHighContrast ? this.settings.setThemeName("high-contrast") : this.settings.setThemeName("modernDark")
 
     } catch (error) {
-      this.notifications.sendSnackbarNotification("Error saving settings: " + error, 5000, false);
+      this.app.sendSnackbarNotification("Error saving settings: " + error, 5000, false);
     }
 
   }

--- a/src/app/settings/general/general.component.ts
+++ b/src/app/settings/general/general.component.ts
@@ -5,8 +5,8 @@ import { AppService } from '../../core/services/app-service';
 import { AppSettingsService } from '../../core/services/app-settings.service';
 import { MatButton } from '@angular/material/button';
 import { MatDivider } from '@angular/material/divider';
-import { MatAccordion, MatExpansionPanel, MatExpansionPanelHeader, MatExpansionPanelTitle, MatExpansionPanelDescription } from '@angular/material/expansion';
-import { MatSlideToggle } from '@angular/material/slide-toggle';
+import { MatExpansionModule, MatExpansionPanel } from '@angular/material/expansion';
+import { MatSlideToggleChange, MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatCheckbox, MatCheckboxChange } from '@angular/material/checkbox';
 import { FormsModule, NgForm } from '@angular/forms';
 
@@ -19,21 +19,20 @@ import { FormsModule, NgForm } from '@angular/forms';
     imports: [
         FormsModule,
         MatCheckbox,
-        MatSlideToggle,
-        MatAccordion,
-        MatExpansionPanel,
-        MatExpansionPanelHeader,
-        MatExpansionPanelTitle,
-        MatExpansionPanelDescription,
+        MatSlideToggleModule,
+        MatExpansionModule,
         MatDivider,
         MatButton,
     ],
 })
 export class SettingsGeneralComponent implements OnInit {
   @ViewChild('generalForm') generalForm: NgForm;
+  @ViewChild('statePanel') statePanel: MatExpansionPanel;
+  @ViewChild('soundPanel') soundPanel: MatExpansionPanel;
   public notificationConfig: INotificationConfig;
   public autoNightModeConfig: boolean;
   public enableHighContrast: boolean = null;
+  public notificationDisabledExpandPanel: boolean = false;
 
   constructor(
     private app: AppService,
@@ -58,7 +57,15 @@ export class SettingsGeneralComponent implements OnInit {
     this.app.sendSnackbarNotification("General configuration saved", 5000, false);
   }
 
-  setTheme(e: MatCheckboxChange) {
+  public setTheme(e: MatCheckboxChange) {
     this.enableHighContrast = e.checked;
+  }
+
+  public togglePanel(e: MatSlideToggleChange): void {
+    if(e.checked) {
+      this.notificationDisabledExpandPanel = false;
+      this.statePanel.close();
+      this.soundPanel.close();
+    }
   }
 }

--- a/src/app/settings/general/general.component.ts
+++ b/src/app/settings/general/general.component.ts
@@ -55,6 +55,7 @@ export class SettingsGeneralComponent implements OnInit {
     }
     this.enableHighContrast ? this.settings.setThemeName("high-contrast") : this.settings.setThemeName("modernDark")
     this.generalForm.form.markAsPristine();
+    this.app.sendSnackbarNotification("General configuration saved", 5000, false);
   }
 
   setTheme(e: MatCheckboxChange) {

--- a/src/app/settings/general/general.component.ts
+++ b/src/app/settings/general/general.component.ts
@@ -1,3 +1,4 @@
+import { cloneDeep } from 'lodash-es';
 import { Component, OnInit } from '@angular/core';
 import { INotificationConfig } from '../../core/interfaces/app-settings.interfaces';
 import { AppService } from '../../core/services/app-service';
@@ -42,7 +43,7 @@ export class SettingsGeneralComponent implements OnInit {
   ) { }
 
   ngOnInit() {
-    this.notificationConfig = this.settings.getNotificationConfig();
+    this.notificationConfig = cloneDeep(this.settings.getNotificationConfig());
     this.autoNightModeConfig = this.app.autoNightMode;
     this.enableHighContrast = (this.settings.getThemeName() == "high-contrast") ? true : false;
   }

--- a/src/app/settings/signalk/signalk.component.ts
+++ b/src/app/settings/signalk/signalk.component.ts
@@ -1,5 +1,6 @@
 import { ViewChild, ElementRef, Component, OnInit, OnDestroy } from '@angular/core';
 import { Subscription } from 'rxjs';
+import { AppService } from '../../core/services/app-service';
 import { AppSettingsService } from '../../core/services/app-settings.service';
 import { IConnectionConfig } from "../../core/interfaces/app-settings.interfaces";
 import { SignalKConnectionService, IEndpointStatus } from '../../core/services/signalk-connection.service';
@@ -7,7 +8,6 @@ import { IDeltaUpdate, SignalKDataService } from '../../core/services/signalk-da
 import { SignalKDeltaService, IStreamStatus } from '../../core/services/signalk-delta.service';
 import { AuthenticationService, IAuthorizationToken } from '../../core/services/authentication.service';
 import { SignalkRequestsService } from '../../core/services/signalk-requests.service';
-import { NotificationsService } from '../../core/services/notifications.service';
 import { ModalUserCredentialComponent } from '../../modal-user-credential/modal-user-credential.component';
 import { HttpErrorResponse } from '@angular/common/http';
 import { compare } from 'compare-versions';
@@ -24,6 +24,7 @@ import { MatDialog } from '@angular/material/dialog';
 import Chart from 'chart.js/auto';
 import 'chartjs-adapter-date-fns';
 import ChartStreaming from '@robloche/chartjs-plugin-streaming';
+
 
 
 @Component({
@@ -79,7 +80,7 @@ export class SettingsSignalkComponent implements OnInit, OnDestroy {
   constructor(
     public dialog: MatDialog,
     private appSettingsService: AppSettingsService,
-    private notificationsService: NotificationsService,
+    private appService: AppService,
     private signalKDataService: SignalKDataService,
     private signalKConnectionService: SignalKConnectionService,
     private signalkRequestsService: SignalkRequestsService,
@@ -200,13 +201,13 @@ export class SettingsSignalkComponent implements OnInit, OnDestroy {
           this.openUserCredentialModal("Sign in failed: Incorrect user/password. Enter valid credentials");
           console.log("[Setting-SignalK Component] Sign in failed: " + error.error.message);
         } else if (error.status == 404) {
-          this.notificationsService.sendSnackbarNotification("Sign in failed: Login API not found", 5000, false);
+          this.appService.sendSnackbarNotification("Sign in failed: Login API not found", 5000, false);
           console.log("[Setting-SignalK Component] Sign in failed: " + error.error.message);
         } else if (error.status == 0) {
-          this.notificationsService.sendSnackbarNotification("Sign in failed: Cannot reach server at Signal K URL", 5000, false);
+          this.appService.sendSnackbarNotification("Sign in failed: Cannot reach server at Signal K URL", 5000, false);
           console.log("[Setting-SignalK Component] Sign in failed: Cannot reach server at Signal K URL:" + error.message);
         } else {
-          this.notificationsService.sendSnackbarNotification("Unknown authentication failure: " + JSON.stringify(error), 5000, false);
+          this.appService.sendSnackbarNotification("Unknown authentication failure: " + JSON.stringify(error), 5000, false);
           console.log("[Setting-SignalK Component] Unknown login error response: " + JSON.stringify(error));
         }
       });
@@ -297,7 +298,7 @@ export class SettingsSignalkComponent implements OnInit, OnDestroy {
     if(e.checked) {
       let version = this.signalKConnectionService.serverVersion$.getValue();
       if (!compare(version, '1.46.2', ">=")) {
-        this.notificationsService.sendSnackbarNotification("Configuration sharing requires Signal K version 1.46.2 or better",0);
+        this.appService.sendSnackbarNotification("Configuration sharing requires Signal K version 1.46.2 or better",0);
         this.connectionConfig.useSharedConfig = false;
         return;
       }

--- a/src/app/settings/units/units.component.ts
+++ b/src/app/settings/units/units.component.ts
@@ -1,8 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { UntypedFormGroup, UntypedFormControl, FormsModule, ReactiveFormsModule }    from '@angular/forms';
 import { AppSettingsService } from '../../core/services/app-settings.service';
-import { NotificationsService } from '../../core/services/notifications.service';
-
+import { AppService } from '../../core/services/app-service';
 import { IUnitDefaults, UnitsService, IUnit } from '../../core/services/units.service';
 import { MatButton } from '@angular/material/button';
 import { MatDivider } from '@angular/material/divider';
@@ -30,7 +29,7 @@ export class SettingsUnitsComponent implements OnInit {
   constructor(
     private units: UnitsService,
     private appSettingsService: AppSettingsService,
-    private notificationsService: NotificationsService,
+    private appService: AppService,
     ) { }
 
   ngOnInit() {
@@ -64,7 +63,7 @@ export class SettingsUnitsComponent implements OnInit {
 
   submitConfig() {
     this.appSettingsService.setDefaultUnits(this.formUnitMaster.value);
-    this.notificationsService.sendSnackbarNotification("Default units configuration saved", 5000, false);
+    this.appService.sendSnackbarNotification("Default units configuration saved", 5000, false);
   }
 
 }

--- a/src/app/widgets/widget-boolean-switch/widget-boolean-switch.component.ts
+++ b/src/app/widgets/widget-boolean-switch/widget-boolean-switch.component.ts
@@ -3,13 +3,14 @@ import { Subscription } from 'rxjs';
 import { ResizedEvent, AngularResizeEventModule } from 'angular-resize-event';
 
 import { SignalkRequestsService } from '../../core/services/signalk-requests.service';
-import { NotificationsService } from '../../core/services/notifications.service';
+import { AppService } from '../../core/services/app-service';
 import { BaseWidgetComponent } from '../../base-widget/base-widget.component';
 import { IDynamicControl, IWidgetPath } from '../../core/interfaces/widgets-interface';
 import { SvgBooleanLightComponent } from '../svg-boolean-light/svg-boolean-light.component';
 import { SvgBooleanButtonComponent } from '../svg-boolean-button/svg-boolean-button.component';
 import { SvgBooleanSwitchComponent } from '../svg-boolean-switch/svg-boolean-switch.component';
 import { NgFor, NgIf } from '@angular/common';
+
 
 
 @Component({
@@ -36,7 +37,7 @@ export class WidgetBooleanSwitchComponent extends BaseWidgetComponent implements
 
   constructor(
     private signalkRequestsService: SignalkRequestsService,
-    private notification: NotificationsService
+    private appService: AppService
     ) {
       super();
 
@@ -99,7 +100,7 @@ export class WidgetBooleanSwitchComponent extends BaseWidgetComponent implements
           } else {
             errMsg += requestResult.statusCode + " - " +requestResult.statusCodeDescription;
           }
-          this.notification.sendSnackbarNotification(errMsg, 0);
+          this.appService.sendSnackbarNotification(errMsg, 0);
         }
       }
     });

--- a/src/app/widgets/widget-button/widget-button.component.ts
+++ b/src/app/widgets/widget-button/widget-button.component.ts
@@ -2,8 +2,8 @@ import { Component, OnInit, OnChanges, OnDestroy, AfterViewChecked, ViewChild, E
 import { Subscription } from 'rxjs';
 
 import { SignalkRequestsService } from '../../core/services/signalk-requests.service';
-import { NotificationsService } from '../../core/services/notifications.service';
 import { BaseWidgetComponent } from '../../base-widget/base-widget.component';
+import { AppService } from '../../core/services/app-service';
 
 
 @Component({
@@ -38,7 +38,7 @@ export class WidgetButtonComponent extends BaseWidgetComponent implements OnInit
 
   constructor(
     private signalkRequestsService: SignalkRequestsService,
-    private notification: NotificationsService
+    private appService: AppService
     ) {
       super();
 
@@ -145,7 +145,7 @@ export class WidgetButtonComponent extends BaseWidgetComponent implements OnInit
           } else {
             errMsg += requestResult.statusCode + " - " +requestResult.statusCodeDescription;
           }
-          this.notification.sendSnackbarNotification(errMsg, 0);
+          this.appService.sendSnackbarNotification(errMsg, 0);
         }
       }
     });

--- a/src/app/widgets/widget-login/widget-login.component.ts
+++ b/src/app/widgets/widget-login/widget-login.component.ts
@@ -2,10 +2,10 @@ import { Component, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { AuthenticationService } from "../../core/services/authentication.service";
 import { AppSettingsService } from '../../core/services/app-settings.service';
-import { NotificationsService } from '../../core/services/notifications.service';
 import { ModalUserCredentialComponent } from '../../modal-user-credential/modal-user-credential.component';
 import { IConnectionConfig } from "../../core/interfaces/app-settings.interfaces";
 import { HttpErrorResponse } from '@angular/common/http';
+import { AppService } from '../../core/services/app-service';
 
 
 @Component({
@@ -20,7 +20,7 @@ export class WidgetLoginComponent implements OnInit {
   constructor(
     public dialog: MatDialog,
     private auth: AuthenticationService,
-    private notificationsService: NotificationsService,
+    private appService: AppService,
     private appSettingsService: AppSettingsService,
   ) { }
 
@@ -61,13 +61,13 @@ export class WidgetLoginComponent implements OnInit {
         this.openUserCredentialModal("Sign in failed: Invalide user/password. Enter valide credentials");
         console.log("[Setting-SignalK Component] Sign in failed: " + error.error.message);
       } else if (error.status == 404) {
-        this.notificationsService.sendSnackbarNotification("Sign in failed: Login API not found at URL. See connection detail status in Configuration/Settings", 5000, false);
+        this.appService.sendSnackbarNotification("Sign in failed: Login API not found at URL. See connection detail status in Configuration/Settings", 5000, false);
         console.log("[Setting-SignalK Component] Sign in failed: " + error.error.message);
       } else if (error.status == 0) {
-        this.notificationsService.sendSnackbarNotification("Sign in failed: Cannot reach server at Signal K URL. See connection detail status in Configuration/Settings", 5000, false);
+        this.appService.sendSnackbarNotification("Sign in failed: Cannot reach server at Signal K URL. See connection detail status in Configuration/Settings", 5000, false);
         console.log("[Setting-SignalK Component] Sign in failed: Cannot reach server at Signal K URL:" + error.message);
       } else {
-        this.notificationsService.sendSnackbarNotification("Unknown authentication failure: " + JSON.stringify(error), 5000, false);
+        this.appService.sendSnackbarNotification("Unknown authentication failure: " + JSON.stringify(error), 5000, false);
         console.log("[Setting-SignalK Component] Unknown login error response: " + JSON.stringify(error));
       }
     });

--- a/src/main.ts
+++ b/src/main.ts
@@ -175,9 +175,7 @@ bootstrapApplication(AppComponent, {
       provide: MAT_TOOLTIP_DEFAULT_OPTIONS,
       useValue: {
         showDelay: 1500,
-        hideDelay: 0,
-        touchendHideDelay: 1000,
-        positionAtOrigin: true,
+        hideDelay: 0
       },
     },
     AuthenticationService,

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,7 +19,7 @@ import { MatGridListModule } from '@angular/material/grid-list';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatSelectModule } from '@angular/material/select';
-import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatTooltipModule, MAT_TOOLTIP_DEFAULT_OPTIONS } from '@angular/material/tooltip';
 import { MatButtonModule } from '@angular/material/button';
 import { MatMenuModule } from '@angular/material/menu';
 import { provideAnimations } from '@angular/platform-browser/animations';
@@ -169,6 +169,15 @@ bootstrapApplication(AppComponent, {
         appearance: "outline",
         floatLabel: "always",
         subscriptSizing: "dynamic",
+      },
+    },
+    {
+      provide: MAT_TOOLTIP_DEFAULT_OPTIONS,
+      useValue: {
+        showDelay: 1500,
+        hideDelay: 0,
+        touchendHideDelay: 1000,
+        positionAtOrigin: true,
       },
     },
     AuthenticationService,

--- a/src/tsconfig.app.json
+++ b/src/tsconfig.app.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../out-tsc/app",
     "baseUrl": "./",
-    "types": [],
+    "types": ["node"],
   },
   "files": [
     "main.ts",


### PR DESCRIPTION
Rewrite of notification Service, Menu and related service dependency.

Fixes empty menu notification. Reduced service dependency.

Now uses SK state and method notification properties and publishes notifications updates to SK instead of using a local notifiaction management system. This increases KIP/SK integration.

KIP now requires SK Alarm Silencer plugin to clear and silence alar - required to update notifications.

Issue: Zones also use a local service and so Zones notifications cannot be silenced or cleared until Zones are rebuilt to use ZK integrated Zones.