### PR TITLE
fix: Chrome scrolbar issue with MDC touch-target

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mxtommy/kip",
-  "version": "2.10.0-beta.3",
+  "version": "2.10.0-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mxtommy/kip",
-      "version": "2.10.0-beta.3",
+      "version": "2.10.0-beta.4",
       "license": "MIT",
       "devDependencies": {
         "@angular-devkit/build-angular": "^17.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mxtommy/kip",
-  "version": "2.10.0-beta.2",
+  "version": "2.10.0-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mxtommy/kip",
-      "version": "2.10.0-beta.2",
+      "version": "2.10.0-beta.3",
       "license": "MIT",
       "devDependencies": {
         "@angular-devkit/build-angular": "^17.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mxtommy/kip",
-  "version": "2.10.0-beta.2",
+  "version": "2.10.0-beta.3",
   "description": "An advanced and versatile marine instrumentation package to display Signal K data.",
   "license": "MIT",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mxtommy/kip",
-  "version": "2.10.0-beta.3",
+  "version": "2.10.0-beta.4",
   "description": "An advanced and versatile marine instrumentation package to display Signal K data.",
   "license": "MIT",
   "author": {

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -86,17 +86,17 @@
 
 .menuBarButtonGroups .menuBarNavButtons {
   width: 99%;
-  height: 46px;
+  height: 48px;
 }
 
 .menuBarButtonGroups .menuBarAlarmsButton {
   width: 25%;
-  height: 46px;
+  height: 48px;
 }
 
 .menuBarButtonGroups .menuBarSettingsButton {
   width: 25%;
-  height: 46px;
+  height: 48px;
 }
 
 .menu-items-with-icons {

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -86,14 +86,17 @@
 
 .menuBarButtonGroups .menuBarNavButtons {
   width: 99%;
+  height: 46px;
 }
 
 .menuBarButtonGroups .menuBarAlarmsButton {
   width: 25%;
+  height: 46px;
 }
 
 .menuBarButtonGroups .menuBarSettingsButton {
   width: 25%;
+  height: 46px;
 }
 
 .menu-items-with-icons {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -71,7 +71,6 @@ body {
   touch-action: none;
 }
 
-
 .ng-valid[required], .ng-valid.required  {
     border-left: 5px solid #42A948; /* green */
   }


### PR DESCRIPTION
Enlarged navbar button to support MDC control new touch-tagert of 46px applied to buttons to improve touch device control touch area. This is causing scrollbar to appear as the touch area of the navbar buttons overflows to the buttom of the screen.