### PR TITLE
Feat: SK-Zones-definition-integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mxtommy/kip",
-  "version": "2.10.0-beta.4",
+  "version": "2.10.0-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mxtommy/kip",
-      "version": "2.10.0-beta.4",
+      "version": "2.10.0-beta.5",
       "license": "MIT",
       "devDependencies": {
         "@angular-devkit/build-angular": "^17.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mxtommy/kip",
-  "version": "2.10.0-beta.4",
+  "version": "2.10.0-beta.5",
   "description": "An advanced and versatile marine instrumentation package to display Signal K data.",
   "license": "MIT",
   "author": {

--- a/src/app/alarm-menu/alarm-menu.component.html
+++ b/src/app/alarm-menu/alarm-menu.component.html
@@ -15,7 +15,7 @@
   <mat-menu #alarmMenu="matMenu" focusFirstItem>
     <ng-template matMenuContent>
       @for(menuItem of menuNotifications$ | async; track menuItem) {
-        @if(menuItem.value.state !== "normal") {
+        @if(menuItem.value.state !== "normal" && menuItem.value.state !== "nominal") {
           <button mat-menu-item
             [mat-menu-trigger-for]="actions"
             [matMenuTriggerData]="menuItem">

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -58,8 +58,6 @@ export class AppComponent implements OnInit, OnDestroy {
     public authenticationService: AuthenticationService,
     private deltaService: SignalKDeltaService,
     private appService: AppService,
-    // below services are needed: first service instantiation after Init Service
-    private signalKDeltaService: SignalKDeltaService, // needs SignalKDataService & NotificationsService & SignalKConnectionService
     ) {}
 
 

--- a/src/app/base-widget/base-widget.component.ts
+++ b/src/app/base-widget/base-widget.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, inject } from '@angular/core';
 import { Observable, Observer, Subscription, delayWhen, map, retryWhen, sampleTime, tap, throwError, timeout, timer } from 'rxjs';
-import { SignalKDataService, IPathData } from '../core/services/signalk-data.service';
+import { SignalKDataService, IPathData } from '../core/services/data.service';
 import { UnitsService } from '../core/services/units.service';
 import { ITheme, IWidget, IWidgetSvcConfig } from '../core/interfaces/widgets-interface';
 import { cloneDeep, merge } from 'lodash-es';
@@ -249,7 +249,7 @@ export abstract class BaseWidgetComponent {
       this.dataSubscription.unsubscribe();
       // Cleanup KIP's pathRegister
       Object.keys(this.widgetProperties.config.paths).forEach(pathKey => {
-        this.signalKDataService.unsubscribePath(this.widgetProperties.uuid, this.widgetProperties.config.paths[pathKey].path);
+        this.signalKDataService.unsubscribePath(this.widgetProperties.config.paths[pathKey].path);
         }
       );
       this.dataSubscription = undefined;

--- a/src/app/base-widget/base-widget.component.ts
+++ b/src/app/base-widget/base-widget.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, inject } from '@angular/core';
 import { Observable, Observer, Subscription, delayWhen, map, retryWhen, sampleTime, tap, throwError, timeout, timer } from 'rxjs';
-import { SignalKDataService, IPathData } from '../core/services/data.service';
+import { DataService, IPathData } from '../core/services/data.service';
 import { UnitsService } from '../core/services/units.service';
 import { ITheme, IWidget, IWidgetSvcConfig } from '../core/interfaces/widgets-interface';
 import { cloneDeep, merge } from 'lodash-es';
@@ -25,7 +25,7 @@ export abstract class BaseWidgetComponent {
   /** Single Observable Subscription object for all data paths */
   private dataSubscription: Subscription = undefined;
   /** Signal K data stream service to obtain/observe server data */
-  protected signalKDataService = inject(SignalKDataService);
+  protected DataService = inject(DataService);
   /** Unit conversion service to convert a wide range of numerical data formats */
   protected unitsService = inject(UnitsService);
 
@@ -81,7 +81,7 @@ export abstract class BaseWidgetComponent {
       } else {
         this.dataStream.push({
           pathName: pathKey,
-          observable: this.signalKDataService.subscribePath(this.widgetProperties.config.paths[pathKey].path, this.widgetProperties.config.paths[pathKey].source)
+          observable: this.DataService.subscribePath(this.widgetProperties.config.paths[pathKey].path, this.widgetProperties.config.paths[pathKey].source)
         });
       }
     })
@@ -140,7 +140,7 @@ export abstract class BaseWidgetComponent {
             with: () =>
               throwError(() => {
                   console.log(timeoutErrorMsg + path);
-                  this.signalKDataService.timeoutPathObservable(path, pathType)
+                  this.DataService.timeoutPathObservable(path, pathType)
                 }
               )
           }),
@@ -171,7 +171,7 @@ export abstract class BaseWidgetComponent {
             with: () =>
               throwError(() => {
                   console.log(timeoutErrorMsg + path);
-                  this.signalKDataService.timeoutPathObservable(path, pathType)
+                  this.DataService.timeoutPathObservable(path, pathType)
                 }
               )
           }),
@@ -249,7 +249,7 @@ export abstract class BaseWidgetComponent {
       this.dataSubscription.unsubscribe();
       // Cleanup KIP's pathRegister
       Object.keys(this.widgetProperties.config.paths).forEach(pathKey => {
-        this.signalKDataService.unsubscribePath(this.widgetProperties.config.paths[pathKey].path);
+        this.DataService.unsubscribePath(this.widgetProperties.config.paths[pathKey].path);
         }
       );
       this.dataSubscription = undefined;

--- a/src/app/base-widget/base-widget.component.ts
+++ b/src/app/base-widget/base-widget.component.ts
@@ -81,7 +81,7 @@ export abstract class BaseWidgetComponent {
       } else {
         this.dataStream.push({
           pathName: pathKey,
-          observable: this.signalKDataService.subscribePath(this.widgetProperties.uuid, this.widgetProperties.config.paths[pathKey].path, this.widgetProperties.config.paths[pathKey].source)
+          observable: this.signalKDataService.subscribePath(this.widgetProperties.config.paths[pathKey].path, this.widgetProperties.config.paths[pathKey].source)
         });
       }
     })

--- a/src/app/base-widget/base-widget.component.ts
+++ b/src/app/base-widget/base-widget.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, inject } from '@angular/core';
 import { Observable, Observer, Subscription, delayWhen, map, retryWhen, sampleTime, tap, throwError, timeout, timer } from 'rxjs';
-import { SignalKDataService, pathRegistrationValue } from '../core/services/signalk-data.service';
+import { SignalKDataService, IPathData } from '../core/services/signalk-data.service';
 import { UnitsService } from '../core/services/units.service';
 import { ITheme, IWidget, IWidgetSvcConfig } from '../core/interfaces/widgets-interface';
 import { cloneDeep, merge } from 'lodash-es';
@@ -8,7 +8,7 @@ import { cloneDeep, merge } from 'lodash-es';
 
 interface IWidgetDataStream {
   pathName: string;
-  observable: Observable<pathRegistrationValue>;
+  observable: Observable<IPathData>;
 };
 
 @Component({
@@ -100,7 +100,7 @@ export abstract class BaseWidgetComponent {
    * @return {*}
    * @memberof BaseWidgetComponent
    */
-  protected observeDataStream(pathName: string, subscribeNextFunction: ((value) => void))  {
+  protected observeDataStream(pathName: string, subscribeNextFunction: ((value: IPathData) => void))  {
     if (this.dataStream === undefined) {
       this.createDataObservable();
     }
@@ -202,8 +202,8 @@ export abstract class BaseWidgetComponent {
     }
   }
 
-  private buildObserver(pathKey: string, subscribeNextFunction: ((value) => void)): Observer<pathRegistrationValue> {
-    const observer: Observer<pathRegistrationValue> = {
+  private buildObserver(pathKey: string, subscribeNextFunction: ((value: IPathData) => void)): Observer<IPathData> {
+    const observer: Observer<IPathData> = {
       next: (value) => subscribeNextFunction(value),
       error: err => console.error('[Widget] Observer got an error: ' + err),
       complete: () => console.log('[Widget] Observer got a complete notification: ' + pathKey),

--- a/src/app/core/interfaces/app-interfaces.ts
+++ b/src/app/core/interfaces/app-interfaces.ts
@@ -6,7 +6,6 @@
  *********************************************************************************/
 
 import { ISignalKMetadata, TState, TMethod } from "./signalk-interfaces";
-import { IZoneState } from './app-settings.interfaces';
 
 /**
  * An App data structure that represents the values (ie. sensor data)
@@ -40,7 +39,7 @@ import { IZoneState } from './app-settings.interfaces';
  *
  * @memberof app-interfaces
  */
- export interface IPathData {
+ export interface ISkPathData {
   path: string;
   pathValue: any;
   defaultSource?: string; // default source
@@ -49,10 +48,10 @@ import { IZoneState } from './app-settings.interfaces';
       timestamp: string;
       sourceValue: any;
     }
-  }
+  };
   meta?: ISignalKMetadata;
   type: string;
-  state: IZoneState;
+  state: TState;
 }
 
 /**

--- a/src/app/core/interfaces/app-interfaces.ts
+++ b/src/app/core/interfaces/app-interfaces.ts
@@ -5,7 +5,7 @@
  * For external data interfaces, such as Signal K, see signalk-interfaces file.
  *********************************************************************************/
 
-import { ISignalKMetadata, TState, TMethod } from "./signalk-interfaces";
+import { ISkMetadata, TState } from "./signalk-interfaces";
 
 /**
  * An App data structure that represents the values (ie. sensor data)
@@ -49,7 +49,7 @@ import { ISignalKMetadata, TState, TMethod } from "./signalk-interfaces";
       sourceValue: any;
     }
   };
-  meta?: ISignalKMetadata;
+  meta?: ISkMetadata;
   type: string;
   state: TState;
 }
@@ -59,13 +59,13 @@ import { ISignalKMetadata, TState, TMethod } from "./signalk-interfaces";
  * as an interface to access meta data subset extracted from internal App
  * paths data source.
  *
- * Use by: modal-path-selection (consumer), setting-zones (consumer) and Signal K (internal data source) service
+ * Use by: modal-path-selection (consumer) and Signal K (internal data source) service
  *
  * @memberof app-interfaces
  */
  export interface IPathMetaData {
   path: string;
-  meta?: ISignalKMetadata;
+  meta?: ISkMetadata;
 }
 
 export interface IDefaultSource {
@@ -77,5 +77,5 @@ export interface IMeta {
   /** Optional SK context representing the root node emitting the value. Empty context should assume the message is from Self. Other contexts can be from AIS, DCS and other types of remote emitting sources configured */
   context: string,
   path: string;
-  meta: ISignalKMetadata;
+  meta: ISkMetadata;
 }

--- a/src/app/core/interfaces/app-interfaces.ts
+++ b/src/app/core/interfaces/app-interfaces.ts
@@ -42,24 +42,24 @@ import { ISkMetadata, TState } from "./signalk-interfaces";
  export interface ISkPathData {
   path: string;
   pathValue: any;
+  pathTimestamp: string;
+  type: string;
+  state: TState;
   defaultSource?: string; // default source
   sources: {
     [sourceName: string]: { // per source data
-      timestamp: string;
+      sourceTimestamp: string;
       sourceValue: any;
     }
   };
   meta?: ISkMetadata;
-  type: string;
-  state: TState;
 }
 
 /**
- * An App data structure that represents all meta values of a path. Used
- * as an interface to access meta data subset extracted from internal App
- * paths data source.
+ * An App data structure that represents meta values of a path.
  *
- * Use by: modal-path-selection (consumer) and Signal K (internal data source) service
+ * Use by: modal-path-selection (consumer), Zones component, and Signal K (internal
+ * data source) service
  *
  * @memberof app-interfaces
  */

--- a/src/app/core/interfaces/app-settings.interfaces.ts
+++ b/src/app/core/interfaces/app-settings.interfaces.ts
@@ -57,7 +57,7 @@ export interface INotificationConfig {
     disableSound: boolean;
     muteNormal: boolean;
     muteNominal: boolean;
-    muteWarning: boolean;
+    muteWarn: boolean;
     muteAlert: boolean;
     muteAlarm: boolean;
     muteEmergency: boolean;

--- a/src/app/core/interfaces/app-settings.interfaces.ts
+++ b/src/app/core/interfaces/app-settings.interfaces.ts
@@ -51,10 +51,12 @@ export interface INotificationConfig {
   devices: {
     disableDevices: boolean;
     showNormalState: boolean;
+    showNominalState: boolean;
   },
   sound: {
     disableSound: boolean;
     muteNormal: boolean;
+    muteNominal: boolean;
     muteWarning: boolean;
     muteAlert: boolean;
     muteAlarm: boolean;

--- a/src/app/core/interfaces/app-settings.interfaces.ts
+++ b/src/app/core/interfaces/app-settings.interfaces.ts
@@ -19,7 +19,6 @@ export interface IConfig {
   widget: IWidgetConfig;
   layout: ILayoutConfig;
   theme: IThemeConfig;
-  zones: IZonesConfig;
 }
 
 export interface IAppConfig {
@@ -43,10 +42,6 @@ export interface ILayoutConfig {
   rootSplits: string[];
 }
 
-export interface IZonesConfig {
-  zones: Array<IZone>;
-}
-
 export interface INotificationConfig {
   disableNotifications: boolean;
   menuGrouping: boolean;
@@ -65,20 +60,6 @@ export interface INotificationConfig {
     muteAlarm: boolean;
     muteEmergency: boolean;
   },
-}
-export interface IZone {
-  uuid: string;
-  path: string;
-  unit: string;
-  upper: number;
-  lower: number;
-  state: IZoneState;
-}
-
-export enum IZoneState {
-  normal = 0,
-  warning = 1,
-  alarm = 2,
 }
 
 export interface ISignalKUrl {

--- a/src/app/core/interfaces/signalk-interfaces.ts
+++ b/src/app/core/interfaces/signalk-interfaces.ts
@@ -192,7 +192,7 @@ export interface ISignalKMetadata {
   zones?: ISkZone[];
 }
 
-interface ISkZone {
+export interface ISkZone {
   state: TState;
   lower?: number;
   upper?: number;

--- a/src/app/core/interfaces/signalk-interfaces.ts
+++ b/src/app/core/interfaces/signalk-interfaces.ts
@@ -8,12 +8,12 @@
  */
 
 // Metadata, Notification and Stream Subscription type restrictions.
-const states = ["nominal", "normal", "alert", "warn", "alarm", "emergency"] as ["nominal", "normal", "alert", "warn", "alarm", "emergency"];
+const states = ["normal", "nominal", "alert", "warn", "alarm", "emergency"] as ["normal", "nominal", "alert", "warn", "alarm", "emergency"];
 export type TState = typeof states[number];
 
 export enum States {
-  Nominal = "nominal",
   Normal = "normal",
+  Nominal = "nominal",
   Alert = "alert",
   Warn = "warn",
   Alarm = "alarm",
@@ -189,12 +189,14 @@ export interface ISignalKMetadata {
   warnMethod?: TMethod[];
   alarmMethod?: TMethod[];
   emergencyMethod?: TMethod[];
-  zones?: {             //This provides a series of hints to the consumer which can be used to properly set a range on a display gauge and also color sectors of a gauge to indicate normal or dangerous operating conditions.
-    state: TState;
-    lower?: number;
-    upper?: number;
-    message?: string;
-  }[]
+  zones?: ISkZone[];
+}
+
+interface ISkZone {
+  state: TState;
+  lower?: number;
+  upper?: number;
+  message?: string;
 }
 
 /**

--- a/src/app/core/interfaces/signalk-interfaces.ts
+++ b/src/app/core/interfaces/signalk-interfaces.ts
@@ -167,10 +167,10 @@ export interface ISignalKDataValueUpdate {
  */
  export interface ISignalKMeta {
   path: string; // not in the spec but always present in the data
-  value: ISignalKMetadata;
+  value: ISkMetadata;
 }
 
-export interface ISignalKMetadata {
+export interface ISkMetadata {
   displayName?: string;
   shortName?: string;
   longName?: string;

--- a/src/app/core/services/app-initNetwork.service.ts
+++ b/src/app/core/services/app-initNetwork.service.ts
@@ -17,7 +17,7 @@ import { SignalKConnectionService } from "./signalk-connection.service";
 import { AuthenticationService } from './authentication.service';
 import { DefaultConnectionConfig } from '../../../default-config/config.blank.const';
 import { Subscription } from 'rxjs';
-import { SignalKDataService } from './signalk-data.service';
+import { SignalKDataService } from './data.service';
 
 const configFileVersion = 9; // used to change the Signal K configuration storage file name (ie. 9.0.0.json) that contains the configuration definitions. Applies only to remote storage.
 

--- a/src/app/core/services/app-initNetwork.service.ts
+++ b/src/app/core/services/app-initNetwork.service.ts
@@ -1,3 +1,5 @@
+import { SignalKDeltaService } from './signalk-delta.service';
+import { DatasetService } from './data-set.service';
 import { StorageService } from './storage.service';
 /**
 * This Service uses the APP_INITIALIZER feature to dynamically load
@@ -15,6 +17,7 @@ import { SignalKConnectionService } from "./signalk-connection.service";
 import { AuthenticationService } from './authentication.service';
 import { DefaultConnectionConfig } from '../../../default-config/config.blank.const';
 import { Subscription } from 'rxjs';
+import { SignalKDataService } from './signalk-data.service';
 
 const configFileVersion = 9; // used to change the Signal K configuration storage file name (ie. 9.0.0.json) that contains the configuration definitions. Applies only to remote storage.
 
@@ -28,7 +31,9 @@ export class AppNetworkInitService implements OnDestroy {
     private connection: SignalKConnectionService,
     private auth: AuthenticationService,
     private router: Router,
-    private storage: StorageService, // early boot up for AppSetting svc
+    private delta: SignalKDeltaService, // Init to get data before app starts
+    private data: SignalKDataService, // Init to get data before app starts
+    private storage: StorageService, // Init to get data before app starts
   )
   {
     this.loggedInSubscription = this.auth.isLoggedIn$.subscribe((isLoggedIn) => {

--- a/src/app/core/services/app-initNetwork.service.ts
+++ b/src/app/core/services/app-initNetwork.service.ts
@@ -17,7 +17,7 @@ import { SignalKConnectionService } from "./signalk-connection.service";
 import { AuthenticationService } from './authentication.service';
 import { DefaultConnectionConfig } from '../../../default-config/config.blank.const';
 import { Subscription } from 'rxjs';
-import { SignalKDataService } from './data.service';
+import { DataService } from './data.service';
 
 const configFileVersion = 9; // used to change the Signal K configuration storage file name (ie. 9.0.0.json) that contains the configuration definitions. Applies only to remote storage.
 const CONNECTION_CONFIG_KEY = 'connectionConfig';
@@ -33,7 +33,7 @@ export class AppNetworkInitService implements OnDestroy {
     private auth: AuthenticationService,
     private router: Router,
     private delta: SignalKDeltaService, // Init to get data before app starts
-    private data: SignalKDataService, // Init to get data before app starts
+    private data: DataService, // Init to get data before app starts
     private storage: StorageService, // Init to get data before app starts
   )
   {

--- a/src/app/core/services/app-service.ts
+++ b/src/app/core/services/app-service.ts
@@ -61,7 +61,7 @@ export class AppService implements OnDestroy {
 
                 const connConf: IConnectionConfig = this.settings.getConnectionConfig(); // get app UUUID
 
-                this.autoNightModePathSubscription = this.sk.subscribePath(connConf.kipUUID, modePath, 'default').subscribe(mode => {
+                this.autoNightModePathSubscription = this.sk.subscribePath(modePath, 'default').subscribe(mode => {
                   if (mode.value == 'night' && this.sunValue != mode.value) {
                     this.sunValue = mode.value;
                     this.settings.setThemeName('nightMode');

--- a/src/app/core/services/app-service.ts
+++ b/src/app/core/services/app-service.ts
@@ -3,7 +3,7 @@ import { Observable, Subject, Subscription } from 'rxjs';
 import { IStreamStatus, SignalKDeltaService } from './signalk-delta.service';
 import { IConnectionConfig } from '../interfaces/app-settings.interfaces';
 import { AppSettingsService } from './app-settings.service';
-import { SignalKDataService } from './signalk-data.service';
+import { SignalKDataService } from './data.service';
 
 const modePath: string = 'self.environment.mode';
 

--- a/src/app/core/services/app-service.ts
+++ b/src/app/core/services/app-service.ts
@@ -3,7 +3,7 @@ import { Observable, Subject, Subscription } from 'rxjs';
 import { IStreamStatus, SignalKDeltaService } from './signalk-delta.service';
 import { IConnectionConfig } from '../interfaces/app-settings.interfaces';
 import { AppSettingsService } from './app-settings.service';
-import { SignalKDataService } from './data.service';
+import { DataService } from './data.service';
 
 const modePath: string = 'self.environment.mode';
 
@@ -33,7 +33,7 @@ export class AppService implements OnDestroy {
   constructor(
     private settings: AppSettingsService,
     private delta: SignalKDeltaService,
-    private sk: SignalKDataService,
+    private data: DataService,
   ) {
     this.autoNightMode = this.settings.getAutoNightMode();
     this.autoNightModeObserver();
@@ -51,7 +51,7 @@ export class AppService implements OnDestroy {
           this.autoNightModeSubscription = autoNightMode.subscribe(mode => {
             this.autoNightMode = mode;
             if (mode) {
-              if (this.sk.getPathObject(modePath) !== null) {
+              if (this.data.getPathObject(modePath) !== null) {
 
                 // capture none nightMode theme name changes
                 this.autoNightModeThemeSubscription = this.settings.getThemeNameAsO().subscribe(theme => {
@@ -61,7 +61,7 @@ export class AppService implements OnDestroy {
 
                 const connConf: IConnectionConfig = this.settings.getConnectionConfig(); // get app UUUID
 
-                this.autoNightModePathSubscription = this.sk.subscribePath(modePath, 'default').subscribe(mode => {
+                this.autoNightModePathSubscription = this.data.subscribePath(modePath, 'default').subscribe(mode => {
                   if (mode.value == 'night' && this.sunValue != mode.value) {
                     this.sunValue = mode.value;
                     this.settings.setThemeName('nightMode');
@@ -79,7 +79,7 @@ export class AppService implements OnDestroy {
   }
 
   public validateAutoNightModeSupported(): boolean {
-    if (!this.sk.getPathObject(modePath)) {
+    if (!this.data.getPathObject(modePath)) {
       this.sendSnackbarNotification("Dependency Error: self.environment.mode path was not found. To enable Automatic Night Mode, verify that the following Signal K requirements are met: 1) The Derived Data plugin is installed and enabled. 2) The plugin's Sun:Sets environment.sun parameter is checked.", 0);
       return false;
     }

--- a/src/app/core/services/app-service.ts
+++ b/src/app/core/services/app-service.ts
@@ -61,12 +61,12 @@ export class AppService implements OnDestroy {
 
                 const connConf: IConnectionConfig = this.settings.getConnectionConfig(); // get app UUUID
 
-                this.autoNightModePathSubscription = this.data.subscribePath(modePath, 'default').subscribe(mode => {
-                  if (mode.value == 'night' && this.sunValue != mode.value) {
-                    this.sunValue = mode.value;
+                this.autoNightModePathSubscription = this.data.subscribePath(modePath, 'default').subscribe(newValue => {
+                  if (newValue.data.value == 'night' && this.sunValue != newValue.data.value) {
+                    this.sunValue = newValue.data.value;
                     this.settings.setThemeName('nightMode');
-                  } else if (mode.value == 'day' && this.sunValue != mode.value) {
-                    this.sunValue = mode.value;
+                  } else if (newValue.data.value == 'day' && this.sunValue != newValue.data.value) {
+                    this.sunValue = newValue.data.value;
                     this.settings.setThemeName(this.dayTheme);
                   }
                 });

--- a/src/app/core/services/authentication.service.ts
+++ b/src/app/core/services/authentication.service.ts
@@ -25,6 +25,7 @@ export class AuthenticationService implements OnDestroy {
   private _authToken$ = new BehaviorSubject<IAuthorizationToken>(null);
   public authToken$ = this._authToken$.asObservable();
   private connectionEndpointSubscription: Subscription = null;
+  private authTokenSubscription: Subscription = null;
 
   // Network connection
   private loginUrl = null;
@@ -59,7 +60,7 @@ export class AuthenticationService implements OnDestroy {
    }
 
     // Token Subject subscription to handle token expiration and renewal
-    this._authToken$.pipe(
+    this.authTokenSubscription = this._authToken$.pipe(
       filter((token: IAuthorizationToken) => (!!token && token.expiry !== null)),
         map((token: IAuthorizationToken) => token.expiry),
         switchMap((expiry: number) => timer(this.getTokenExpirationDate(expiry, tokenRenewalBuffer))),
@@ -281,5 +282,6 @@ export class AuthenticationService implements OnDestroy {
 
   ngOnDestroy(): void {
     this.connectionEndpointSubscription?.unsubscribe();
+    this.authTokenSubscription?.unsubscribe();
   }
 }

--- a/src/app/core/services/data-set.service.ts
+++ b/src/app/core/services/data-set.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Subscription, Observable, ReplaySubject, MonoTypeOperatorFunction, interval, withLatestFrom } from 'rxjs';
 import { AppSettingsService } from './app-settings.service';
-import { SignalKDataService, pathRegistrationValue } from './signalk-data.service';
+import { SignalKDataService, IPathData } from './signalk-data.service';
 import { UUID } from'../../utils/uuid'
 import { cloneDeep } from 'lodash-es';
 
@@ -157,13 +157,13 @@ export class DatasetService {
     console.log(`[Dataset Service] Path: ${configuration.path}, Scale: ${configuration.timeScaleFormat}, Period: ${configuration.period}, Datapoints: ${newDataSourceConfig.maxDataPoints}`);
 
     // Emit at a regular interval using the last value. We use this and not sampleTime() to make sure that if there is no new data, we still send the last know value. This is to prevent dataset blanks that look ugly on the chart
-    function sampleInterval<pathRegistrationValue>(period: number): MonoTypeOperatorFunction<pathRegistrationValue> {
+    function sampleInterval<IPathData>(period: number): MonoTypeOperatorFunction<IPathData> {
       return (source) => interval(period).pipe(withLatestFrom(source, (_, value) => value));
     };
 
     // Subscribe to path data, update historicalData/stats and sends new values to Observers
     dataSource.pathObserverSubscription = this.signalk.subscribePath(configuration.uuid, configuration.path, configuration.pathSource).pipe(sampleInterval(newDataSourceConfig.sampleTime)).subscribe(
-      (newValue: pathRegistrationValue) => {
+      (newValue: IPathData) => {
         if (newValue.value === null) return; // we don't need null values
 
         // Keep the array to specified size before adding new value

--- a/src/app/core/services/data-set.service.ts
+++ b/src/app/core/services/data-set.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Subscription, Observable, ReplaySubject, MonoTypeOperatorFunction, interval, withLatestFrom } from 'rxjs';
 import { AppSettingsService } from './app-settings.service';
-import { DataService, IPathData } from './data.service';
+import { DataService, IPathUpdate } from './data.service';
 import { UUID } from'../../utils/uuid'
 import { cloneDeep } from 'lodash-es';
 
@@ -163,14 +163,14 @@ export class DatasetService {
 
     // Subscribe to path data, update historicalData/stats and sends new values to Observers
     dataSource.pathObserverSubscription = this.data.subscribePath(configuration.path, configuration.pathSource).pipe(sampleInterval(newDataSourceConfig.sampleTime)).subscribe(
-      (newValue: IPathData) => {
-        if (newValue.value === null) return; // we don't need null values
+      (newValue: IPathUpdate) => {
+        if (newValue.data.value === null) return; // we don't need null values
 
         // Keep the array to specified size before adding new value
         if (dataSource.maxDataPoints == dataSource.historicalData.length) {
           dataSource.historicalData.shift();
         }
-        dataSource.historicalData.push(newValue.value);
+        dataSource.historicalData.push(newValue.data.value);
 
         // Add new datapoint to historicalData
         const datapoint: IDatasetServiceDatapoint = this.updateDataset(dataSource, configuration.baseUnit);

--- a/src/app/core/services/data-set.service.ts
+++ b/src/app/core/services/data-set.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Subscription, Observable, ReplaySubject, MonoTypeOperatorFunction, interval, withLatestFrom } from 'rxjs';
 import { AppSettingsService } from './app-settings.service';
-import { SignalKDataService, IPathData } from './data.service';
+import { DataService, IPathData } from './data.service';
 import { UUID } from'../../utils/uuid'
 import { cloneDeep } from 'lodash-es';
 
@@ -51,7 +51,7 @@ export class DatasetService {
   private _svcDataSource: IDatasetServiceDataSource[] = [];
   private _svcSubjectObserverRegistry: IDatasetServiceObserverRegistration[] = [];
 
-  constructor(private appSettings: AppSettingsService, private signalk: SignalKDataService) {
+  constructor(private appSettings: AppSettingsService, private data: DataService) {
     this._svcDatasetConfigs = appSettings.getDataSets();
     this.startAll();
   }
@@ -162,7 +162,7 @@ export class DatasetService {
     };
 
     // Subscribe to path data, update historicalData/stats and sends new values to Observers
-    dataSource.pathObserverSubscription = this.signalk.subscribePath(configuration.path, configuration.pathSource).pipe(sampleInterval(newDataSourceConfig.sampleTime)).subscribe(
+    dataSource.pathObserverSubscription = this.data.subscribePath(configuration.path, configuration.pathSource).pipe(sampleInterval(newDataSourceConfig.sampleTime)).subscribe(
       (newValue: IPathData) => {
         if (newValue.value === null) return; // we don't need null values
 
@@ -244,7 +244,7 @@ export class DatasetService {
       uuid: uuid,
       path: path,
       pathSource: source,
-      baseUnit: this.signalk.getPathUnitType(path),
+      baseUnit: this.data.getPathUnitType(path),
       timeScaleFormat: timeScaleFormat,
       period: period,
       label: label,
@@ -267,7 +267,7 @@ export class DatasetService {
   public edit(datasetConfig: IDatasetServiceDatasetConfig): void {
     this.stop(datasetConfig.uuid);
     console.log(`[Dataset Service] Updating Dataset: ${datasetConfig.uuid}`);
-    datasetConfig.baseUnit = this.signalk.getPathUnitType(datasetConfig.path);
+    datasetConfig.baseUnit = this.data.getPathUnitType(datasetConfig.path);
     this._svcDatasetConfigs.splice(this._svcDatasetConfigs.findIndex(conf => conf.uuid === datasetConfig.uuid), 1, datasetConfig);
 
     this.start(datasetConfig.uuid);

--- a/src/app/core/services/data-set.service.ts
+++ b/src/app/core/services/data-set.service.ts
@@ -162,7 +162,7 @@ export class DatasetService {
     };
 
     // Subscribe to path data, update historicalData/stats and sends new values to Observers
-    dataSource.pathObserverSubscription = this.signalk.subscribePath(configuration.uuid, configuration.path, configuration.pathSource).pipe(sampleInterval(newDataSourceConfig.sampleTime)).subscribe(
+    dataSource.pathObserverSubscription = this.signalk.subscribePath(configuration.path, configuration.pathSource).pipe(sampleInterval(newDataSourceConfig.sampleTime)).subscribe(
       (newValue: IPathData) => {
         if (newValue.value === null) return; // we don't need null values
 

--- a/src/app/core/services/data-set.service.ts
+++ b/src/app/core/services/data-set.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Subscription, Observable, ReplaySubject, MonoTypeOperatorFunction, interval, withLatestFrom } from 'rxjs';
 import { AppSettingsService } from './app-settings.service';
-import { SignalKDataService, IPathData } from './signalk-data.service';
+import { SignalKDataService, IPathData } from './data.service';
 import { UUID } from'../../utils/uuid'
 import { cloneDeep } from 'lodash-es';
 

--- a/src/app/core/services/data.service.spec.ts
+++ b/src/app/core/services/data.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed, inject } from '@angular/core/testing';
 
-import { SignalKDataService } from './signalk-data.service';
+import { SignalKDataService } from './data.service';
 
 describe('SignalKDataService', () => {
   beforeEach(() => {

--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -89,7 +89,7 @@ export class SignalKDataService implements OnDestroy {
   private _skData: ISkPathData[] = []; // Local array of paths containing received Signal K Data and used to source Observers
   private _pathRegister: IPathRegistration[] = []; // List of paths used by Kip (Widgets or App (Notifications and such))
 
-  constructor(private deltaService: SignalKDeltaService) {
+  constructor(private delta: SignalKDeltaService) {
     // Emit Delta message update counter every second
     setInterval(() => {
       if (this._deltaUpdatesCounter !== null) {
@@ -100,17 +100,17 @@ export class SignalKDataService implements OnDestroy {
     }, 1000);
 
     // Observer of Delta service data path updates
-    this._deltaServicePathSubscription = this.deltaService.subscribeDataPathsUpdates().subscribe((dataPath: IPathValueData) => {
+    this._deltaServicePathSubscription = this.delta.subscribeDataPathsUpdates().subscribe((dataPath: IPathValueData) => {
       this.updatePathData(dataPath);
     });
 
     // Observer of Delta service Metadata updates
-    this._deltaServiceMetaSubscription = this.deltaService.subscribeMetadataUpdates().subscribe((deltaMeta: IMeta) => {
+    this._deltaServiceMetaSubscription = this.delta.subscribeMetadataUpdates().subscribe((deltaMeta: IMeta) => {
       this.setMeta(deltaMeta);
     })
 
     // Observer router of Delta service Notification updates
-    this._deltaServiceNotificationSubscription = this.deltaService.subscribeNotificationsUpdates().subscribe((msg: ISignalKDataValueUpdate) => {
+    this._deltaServiceNotificationSubscription = this.delta.subscribeNotificationsUpdates().subscribe((msg: ISignalKDataValueUpdate) => {
       // Replace "notifications." with "self." to search for the path in skData
       const cleanedPath = msg.path.replace('notifications.', 'self.');
 
@@ -128,7 +128,7 @@ export class SignalKDataService implements OnDestroy {
     });
 
     // Observer of vessel Self URN updates
-    this._deltaServiceSelfUrnSubscription = this.deltaService.subscribeSelfUpdates().subscribe(self => {
+    this._deltaServiceSelfUrnSubscription = this.delta.subscribeSelfUpdates().subscribe(self => {
       this.setSelfUrn(self);
     });
   }
@@ -152,8 +152,8 @@ export class SignalKDataService implements OnDestroy {
     this._isReset.next(true);
   }
 
-  public unsubscribePath(uuid, path) {
-    this._pathRegister.splice(this._pathRegister.findIndex(registration => registration.path === path && registration.uuid === uuid), 1);
+  public unsubscribePath(path: string): void {
+    this._pathRegister.splice(this._pathRegister.findIndex(registration => registration.path === path), 1);
   }
 
   public subscribePath(uuid: string, path: string, source: string): Observable<IPathData> {

--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -45,13 +45,12 @@ const isRfc3339StringDate = (date: Date | string): boolean => {
  * @interface pathRegistration
  */
 interface IPathRegistration {
-  uuid: string;
   path: string;
   source: string;
   _pathValue$: BehaviorSubject<any>;
   _pathState$: BehaviorSubject<TState>;
   pathData$: BehaviorSubject<IPathData>; // pathValue and pathState combined subject for Observers ie: widgets
-  _pathMeta$: BehaviorSubject<ISignalKMetadata>;
+  pathMeta$: BehaviorSubject<ISignalKMetadata>;
 }
 
 export interface IDeltaUpdate {
@@ -156,10 +155,10 @@ export class SignalKDataService implements OnDestroy {
     this._pathRegister.splice(this._pathRegister.findIndex(registration => registration.path === path), 1);
   }
 
-  public subscribePath(uuid: string, path: string, source: string): Observable<IPathData> {
+  public subscribePath(path: string, source: string): Observable<IPathData> {
     // TODO: check if we still need UUIDs for registration. Maybe we can just use the path.
     // See if already have a Subject for this path and return it.
-    const entry = this._pathRegister.find(entry => (entry.path == path) && (entry.uuid == uuid));
+    const entry = this._pathRegister.find(entry => entry.path == path);
     if (entry) { // exists
       return entry.pathData$;
     }
@@ -181,13 +180,12 @@ export class SignalKDataService implements OnDestroy {
     }
 
     let newRegister: IPathRegistration  = {
-      uuid: uuid,
       path: path,
       source: source,
       _pathValue$: new BehaviorSubject<any>(currentValue),
       _pathState$: new BehaviorSubject<TState>(state),
       pathData$: new BehaviorSubject<IPathData>({ value: currentValue, state: state }),
-      _pathMeta$: new BehaviorSubject<ISignalKMetadata>(dataPath?.meta || null)
+      pathMeta$: new BehaviorSubject<ISignalKMetadata>(dataPath?.meta || null)
     };
 
     // Combine the latest values and state of the path
@@ -348,7 +346,7 @@ export class SignalKDataService implements OnDestroy {
         }) - 1);
       }
       this._pathRegister.filter(registration => registration.path === metaPath).forEach(
-        registration => registration._pathMeta$.next(pathObject.meta)
+        registration => registration.pathMeta$.next(pathObject.meta)
       );
     }
   }
@@ -473,7 +471,7 @@ export class SignalKDataService implements OnDestroy {
 
   public getPathMeta(path: string): Observable<ISignalKMetadata> {
     const registration = this._pathRegister.find(registration => registration.path == path);
-    return registration?._pathMeta$.asObservable() || of(null);
+    return registration?.pathMeta$.asObservable() || of(null);
   }
 
   public IsResetService(): Observable<boolean> {

--- a/src/app/core/services/notifications.service.ts
+++ b/src/app/core/services/notifications.service.ts
@@ -2,18 +2,18 @@
  * This Service handles app notifications sent by the Signal K server.
  */
 import { Injectable, OnDestroy } from '@angular/core';
-import { BehaviorSubject, Observable, Subject, Subscription } from 'rxjs';
+import { BehaviorSubject, Observable, Subscription } from 'rxjs';
 
 import { AppSettingsService } from "./app-settings.service";
 import { INotificationConfig } from '../interfaces/app-settings.interfaces';
 import { DefaultNotificationConfig } from '../../../default-config/config.blank.notification.const';
 import { SignalkRequestsService } from './signalk-requests.service';
+import { SignalKDataService } from './signalk-data.service';
 import { Howl } from 'howler';
 import { isEqual } from 'lodash-es';
 import { UUID } from '../../utils/uuid';
 import { TMethod, ISignalKDataValueUpdate, ISignalKMetadata, ISignalKNotification, States, Methods } from '../interfaces/signalk-interfaces';
 import { IMeta } from '../interfaces/app-interfaces';
-import { SignalKDataService } from './signalk-data.service';
 
 
 const alarmTrack = {
@@ -29,8 +29,6 @@ export interface INotification {
   value?: ISignalKNotification;
   meta?: ISignalKMetadata;
 }
-
-
 
 /**
  * Alarm information, some stats used
@@ -105,7 +103,7 @@ export class NotificationsService implements OnDestroy {
         this.updateNotificationsState(); //see if any we need to start playing again
       }
     });
-
+    //TODO: tie data-service restart to this
     // Observer of server connection status to reset notifications on SK reconnect
     // this.deltaService.streamEndpoint$.subscribe((streamStatus: IStreamStatus) => {
     //   if (streamStatus.operation === 2) {
@@ -125,8 +123,6 @@ export class NotificationsService implements OnDestroy {
     this.notificationMetaStreamSubscription = this.dataService.getNotificationMeta().subscribe((meta: IMeta) => {
       this.processNotificationDeltaMeta(meta);
     });
-
-
   }
 
   private stopNotificationStream() {
@@ -164,7 +160,7 @@ export class NotificationsService implements OnDestroy {
       this.updateNotificationsState();
       this.notifications$.next(this._notifications);
     } else {
-      console.log("[Notification Service] Notification to update not found: " + msg.path);
+      console.log("[Notification Service] Update path not found for: " + msg.path);
     }
   }
 
@@ -176,7 +172,7 @@ export class NotificationsService implements OnDestroy {
       this.updateNotificationsState();
       this.notifications$.next(this._notifications);
     } else {
-      console.log("[Notification Service] Notification to delete not found: " + path);
+      console.log("[Notification Service] Notification to delete not found for: " + path);
     }
   }
 

--- a/src/app/core/services/notifications.service.ts
+++ b/src/app/core/services/notifications.service.ts
@@ -7,12 +7,11 @@ import { BehaviorSubject, Observable, Subject, Subscription } from 'rxjs';
 import { AppSettingsService } from "./app-settings.service";
 import { INotificationConfig } from '../interfaces/app-settings.interfaces';
 import { DefaultNotificationConfig } from '../../../default-config/config.blank.notification.const';
-import { SignalKDeltaService, IStreamStatus } from './signalk-delta.service';
 import { SignalkRequestsService } from './signalk-requests.service';
 import { Howl } from 'howler';
 import { isEqual } from 'lodash-es';
 import { UUID } from '../../utils/uuid';
-import { TMethod, ISignalKDataValueUpdate, ISignalKMetadata, ISignalKNotification, States, Methods, TState } from '../interfaces/signalk-interfaces';
+import { TMethod, ISignalKDataValueUpdate, ISignalKMetadata, ISignalKNotification, States, Methods } from '../interfaces/signalk-interfaces';
 import { IMeta } from '../interfaces/app-interfaces';
 import { SignalKDataService } from './signalk-data.service';
 

--- a/src/app/core/services/notifications.service.ts
+++ b/src/app/core/services/notifications.service.ts
@@ -83,12 +83,12 @@ export class NotificationsService implements OnDestroy {
   private lastEmittedValue: IAlarmInfo = null;
 
   constructor(
-    private appSettingsService: AppSettingsService,
+    private settings: AppSettingsService,
     private dataService: SignalKDataService,
     private requests: SignalkRequestsService
     ) {
     // Observer of Notification Service configuration changes
-    this.notificationSettingsSubscription = this.appSettingsService.getNotificationServiceConfigAsO().subscribe((config: INotificationConfig) => {
+    this.notificationSettingsSubscription = this.settings.getNotificationServiceConfigAsO().subscribe((config: INotificationConfig) => {
       this._notificationConfig = config;
       this.reset();
       this.notificationConfig$.next(config); // push to observers
@@ -187,7 +187,8 @@ export class NotificationsService implements OnDestroy {
         continue;
       }
 
-      if (alarm.value['state'] === States.Normal && !this._notificationConfig.devices.showNormalState) {
+      if ((alarm.value['state'] === States.Normal && !this._notificationConfig.devices.showNormalState) ||
+          (alarm.value['state'] === States.Nominal && !this._notificationConfig.devices.showNominalState)) {
         continue;
       }
 

--- a/src/app/core/services/notifications.service.ts
+++ b/src/app/core/services/notifications.service.ts
@@ -105,7 +105,7 @@ export class NotificationsService implements OnDestroy {
       }
     });
 
-    this.dataService.IsResetService().subscribe(reset => {
+    this.dataService.isResetService().subscribe(reset => {
         reset ? this.reset() : null;
       });
 

--- a/src/app/core/services/notifications.service.ts
+++ b/src/app/core/services/notifications.service.ts
@@ -56,7 +56,8 @@ interface IAlarmSeverities {
 export class NotificationsService implements OnDestroy {
   private static readonly ALARM_SEVERITIES: IAlarmSeverities = {
     normal: { sound: 0, visual: 0 },
-    alert: { sound: 1, visual: 1 },
+    nominal: { sound: 0, visual: 0 },
+    alert: { sound: 1, visual: 0 },
     warn: { sound: 2, visual: 1 },
     alarm: { sound: 3, visual: 2 },
     emergency: { sound: 4, visual: 2 },
@@ -103,13 +104,10 @@ export class NotificationsService implements OnDestroy {
         this.updateNotificationsState(); //see if any we need to start playing again
       }
     });
-    //TODO: tie data-service restart to this
-    // Observer of server connection status to reset notifications on SK reconnect
-    // this.deltaService.streamEndpoint$.subscribe((streamStatus: IStreamStatus) => {
-    //   if (streamStatus.operation === 2) {
-    //     this.reset();
-    //   }
-    // });
+
+    this.dataService.IsResetService().subscribe(reset => {
+        reset ? this.reset() : null;
+      });
 
     // Init audio player
     this.howlPlayer = this.getPlayer(1000);

--- a/src/app/core/services/notifications.service.ts
+++ b/src/app/core/services/notifications.service.ts
@@ -8,11 +8,11 @@ import { AppSettingsService } from "./app-settings.service";
 import { INotificationConfig } from '../interfaces/app-settings.interfaces';
 import { DefaultNotificationConfig } from '../../../default-config/config.blank.notification.const';
 import { SignalkRequestsService } from './signalk-requests.service';
-import { SignalKDataService } from './data.service';
+import { DataService } from './data.service';
 import { Howl } from 'howler';
 import { isEqual } from 'lodash-es';
 import { UUID } from '../../utils/uuid';
-import { TMethod, ISignalKDataValueUpdate, ISignalKMetadata, ISignalKNotification, States, Methods } from '../interfaces/signalk-interfaces';
+import { TMethod, ISignalKDataValueUpdate, ISkMetadata, ISignalKNotification, States, Methods } from '../interfaces/signalk-interfaces';
 import { IMeta } from '../interfaces/app-interfaces';
 
 
@@ -27,7 +27,7 @@ const alarmTrack = {
 export interface INotification {
   path: string;
   value?: ISignalKNotification;
-  meta?: ISignalKMetadata;
+  meta?: ISkMetadata;
 }
 
 /**
@@ -85,7 +85,7 @@ export class NotificationsService implements OnDestroy {
 
   constructor(
     private settings: AppSettingsService,
-    private data: SignalKDataService,
+    private data: DataService,
     private requests: SignalkRequestsService
     ) {
     // Observer of Notification Service configuration changes

--- a/src/app/core/services/notifications.service.ts
+++ b/src/app/core/services/notifications.service.ts
@@ -65,6 +65,7 @@ export class NotificationsService implements OnDestroy {
   private _notificationSettingsSubscription: Subscription = null;
   private _notificationDataStreamSubscription: Subscription = null;
   private _notificationMetaStreamSubscription: Subscription = null;
+  private _resetServiceSubscription: Subscription = null;
 
   private _notificationConfig: INotificationConfig;
   private _notificationConfig$: BehaviorSubject<INotificationConfig> = new BehaviorSubject<INotificationConfig>(DefaultNotificationConfig);
@@ -84,7 +85,7 @@ export class NotificationsService implements OnDestroy {
 
   constructor(
     private settings: AppSettingsService,
-    private dataService: SignalKDataService,
+    private data: SignalKDataService,
     private requests: SignalkRequestsService
     ) {
     // Observer of Notification Service configuration changes
@@ -105,7 +106,7 @@ export class NotificationsService implements OnDestroy {
       }
     });
 
-    this.dataService.isResetService().subscribe(reset => {
+    this._resetServiceSubscription = this.data.isResetService().subscribe(reset => {
         reset ? this.reset() : null;
       });
 
@@ -114,11 +115,11 @@ export class NotificationsService implements OnDestroy {
    }
 
   private startNotificationStream() {
-    this._notificationDataStreamSubscription = this.dataService.getNotificationMsg().subscribe((msg: ISignalKDataValueUpdate) => {
+    this._notificationDataStreamSubscription = this.data.getNotificationMsg().subscribe((msg: ISignalKDataValueUpdate) => {
       this.processNotificationDeltaMsg(msg);
     });
 
-    this._notificationMetaStreamSubscription = this.dataService.getNotificationMeta().subscribe((meta: IMeta) => {
+    this._notificationMetaStreamSubscription = this.data.getNotificationMeta().subscribe((meta: IMeta) => {
       this.processNotificationDeltaMeta(meta);
     });
   }
@@ -390,5 +391,9 @@ export class NotificationsService implements OnDestroy {
 
   ngOnDestroy(): void {
     this._notificationSettingsSubscription?.unsubscribe();
+    this._resetServiceSubscription?.unsubscribe();
+    this._notificationConfig$.complete();
+    this._notifications$.complete();
+    this._alarmsInfo$.complete();
   }
 }

--- a/src/app/core/services/notifications.service.ts
+++ b/src/app/core/services/notifications.service.ts
@@ -8,7 +8,7 @@ import { AppSettingsService } from "./app-settings.service";
 import { INotificationConfig } from '../interfaces/app-settings.interfaces';
 import { DefaultNotificationConfig } from '../../../default-config/config.blank.notification.const';
 import { SignalkRequestsService } from './signalk-requests.service';
-import { SignalKDataService } from './signalk-data.service';
+import { SignalKDataService } from './data.service';
 import { Howl } from 'howler';
 import { isEqual } from 'lodash-es';
 import { UUID } from '../../utils/uuid';
@@ -62,25 +62,25 @@ export class NotificationsService implements OnDestroy {
     alarm: { sound: 3, visual: 2 },
     emergency: { sound: 4, visual: 2 },
   };
-  private notificationSettingsSubscription: Subscription = null;
-  private notificationDataStreamSubscription: Subscription = null;
-  private notificationMetaStreamSubscription: Subscription = null;
+  private _notificationSettingsSubscription: Subscription = null;
+  private _notificationDataStreamSubscription: Subscription = null;
+  private _notificationMetaStreamSubscription: Subscription = null;
 
   private _notificationConfig: INotificationConfig;
-  public notificationConfig$: BehaviorSubject<INotificationConfig> = new BehaviorSubject<INotificationConfig>(DefaultNotificationConfig);
+  private _notificationConfig$: BehaviorSubject<INotificationConfig> = new BehaviorSubject<INotificationConfig>(DefaultNotificationConfig);
 
   private _notifications: INotification[] = []; // local array of Alarms with path as index key
-  private notifications$ = new BehaviorSubject<INotification[] | null>(null);
-  private alarmsInfo$: BehaviorSubject<IAlarmInfo> = new BehaviorSubject<IAlarmInfo>({audioSev: 0, visualSev: 0, alarmCount: 0, isMuted: false});
+  private _notifications$ = new BehaviorSubject<INotification[] | null>(null);
+  private _alarmsInfo$: BehaviorSubject<IAlarmInfo> = new BehaviorSubject<IAlarmInfo>({audioSev: 0, visualSev: 0, alarmCount: 0, isMuted: false});
 
   // sounds properties
-  private howlPlayer: Howl;
-  private activeAlarmSoundtrack: number = null;
-  private activeHowlId: number = null;
-  private isHowlIdMuted: boolean = false;
+  private _howlPlayer: Howl;
+  private _activeAlarmSoundtrack: number = null;
+  private _activeHowlId: number = null;
+  private _isHowlIdMuted: boolean = false;
 
   // Notification acknowledge timeouts references
-  private lastEmittedValue: IAlarmInfo = null;
+  private _lastEmittedValue: IAlarmInfo = null;
 
   constructor(
     private settings: AppSettingsService,
@@ -88,14 +88,14 @@ export class NotificationsService implements OnDestroy {
     private requests: SignalkRequestsService
     ) {
     // Observer of Notification Service configuration changes
-    this.notificationSettingsSubscription = this.settings.getNotificationServiceConfigAsO().subscribe((config: INotificationConfig) => {
+    this._notificationSettingsSubscription = this.settings.getNotificationServiceConfigAsO().subscribe((config: INotificationConfig) => {
       this._notificationConfig = config;
       this.reset();
-      this.notificationConfig$.next(config); // push to observers
-      if (this._notificationConfig.disableNotifications && !this.notificationDataStreamSubscription?.closed) {
+      this._notificationConfig$.next(config); // push to observers
+      if (this._notificationConfig.disableNotifications && !this._notificationDataStreamSubscription?.closed) {
         this.stopNotificationStream();
       }
-      if (!this._notificationConfig.disableNotifications && (this.notificationDataStreamSubscription === null || this.notificationDataStreamSubscription?.closed)) {
+      if (!this._notificationConfig.disableNotifications && (this._notificationDataStreamSubscription === null || this._notificationDataStreamSubscription?.closed)) {
           this.startNotificationStream();
       }
       if (this._notificationConfig.sound.disableSound) {
@@ -110,22 +110,22 @@ export class NotificationsService implements OnDestroy {
       });
 
     // Init audio player
-    this.howlPlayer = this.getPlayer(1000);
+    this._howlPlayer = this.getPlayer(1000);
    }
 
   private startNotificationStream() {
-    this.notificationDataStreamSubscription = this.dataService.getNotificationMsg().subscribe((msg: ISignalKDataValueUpdate) => {
+    this._notificationDataStreamSubscription = this.dataService.getNotificationMsg().subscribe((msg: ISignalKDataValueUpdate) => {
       this.processNotificationDeltaMsg(msg);
     });
 
-    this.notificationMetaStreamSubscription = this.dataService.getNotificationMeta().subscribe((meta: IMeta) => {
+    this._notificationMetaStreamSubscription = this.dataService.getNotificationMeta().subscribe((meta: IMeta) => {
       this.processNotificationDeltaMeta(meta);
     });
   }
 
   private stopNotificationStream() {
-  this.notificationDataStreamSubscription?.unsubscribe();
-  this.notificationMetaStreamSubscription?.unsubscribe();
+  this._notificationDataStreamSubscription?.unsubscribe();
+  this._notificationMetaStreamSubscription?.unsubscribe();
   this.reset();
   }
 
@@ -135,20 +135,20 @@ export class NotificationsService implements OnDestroy {
   private reset() {
     this._notifications = [];
     this.updateNotificationsState();
-    this.notifications$.next([]);
+    this._notifications$.next([]);
   }
 
   /**
    * Returns a notification Observable of notification or null.
    */
   public observe(): Observable<INotification[] | null> {
-    return this.notifications$.asObservable();
+    return this._notifications$.asObservable();
   }
 
   private addValue(msg: ISignalKDataValueUpdate) {
     this._notifications.push({ path: msg.path, value: msg.value });
     this.updateNotificationsState();
-    this.notifications$.next(this._notifications);
+    this._notifications$.next(this._notifications);
   }
 
   private updateValue(msg: ISignalKDataValueUpdate) {
@@ -156,7 +156,7 @@ export class NotificationsService implements OnDestroy {
     if (notificationToUpdate) {
       notificationToUpdate.value = {...msg.value};
       this.updateNotificationsState();
-      this.notifications$.next(this._notifications);
+      this._notifications$.next(this._notifications);
     } else {
       console.log("[Notification Service] Update path not found for: " + msg.path);
     }
@@ -168,7 +168,7 @@ export class NotificationsService implements OnDestroy {
       // this._notifications.splice(index, 1);
       delete notification.value;
       this.updateNotificationsState();
-      this.notifications$.next(this._notifications);
+      this._notifications$.next(this._notifications);
     } else {
       console.log("[Notification Service] Notification to delete not found for: " + path);
     }
@@ -206,12 +206,12 @@ export class NotificationsService implements OnDestroy {
       audioSev: audioSev,
       visualSev: visualSev,
       alarmCount: activeNotifications,
-      isMuted: this.isHowlIdMuted
+      isMuted: this._isHowlIdMuted
     };
 
-    if (!isEqual(newValue, this.lastEmittedValue)) {
-      this.alarmsInfo$.next(newValue);
-      this.lastEmittedValue = newValue;
+    if (!isEqual(newValue, this._lastEmittedValue)) {
+      this._alarmsInfo$.next(newValue);
+      this._lastEmittedValue = newValue;
     }
   }
 
@@ -253,7 +253,7 @@ export class NotificationsService implements OnDestroy {
     } else {
       this._notifications.push({path: metaDelta.path, meta: metaDelta.meta});
     }
-    this.notifications$.next(this._notifications);
+    this._notifications$.next(this._notifications);
   }
 
   /**
@@ -317,7 +317,7 @@ export class NotificationsService implements OnDestroy {
   }
 
   public observerNotificationInfo() {
-    return this.alarmsInfo$.asObservable();
+    return this._alarmsInfo$.asObservable();
   }
 
   /**
@@ -325,7 +325,7 @@ export class NotificationsService implements OnDestroy {
    * @param track track ID to play. See const for definition
    */
   getPlayer(track: number): Howl {
-    this.activeAlarmSoundtrack = track;
+    this._activeAlarmSoundtrack = track;
     const player = new Howl({
         src: ['assets/' + alarmTrack[track] + '.mp3'],
         autoplay: false,
@@ -339,8 +339,8 @@ export class NotificationsService implements OnDestroy {
         },
         onplayerror: function() {
           console.log("player locked");
-          this.howlPlayer.once('unlock', function() {
-            this.howlPlayer.play();
+          this._howlPlayer.once('unlock', function() {
+            this._howlPlayer.play();
           });
         }
       });
@@ -353,8 +353,8 @@ export class NotificationsService implements OnDestroy {
   * @param state sound muted boolean state
   */
   mutePlayer(state) {
-    this.howlPlayer.mute(state, this.activeHowlId);
-    this.isHowlIdMuted = state;
+    this._howlPlayer.mute(state, this._activeHowlId);
+    this._isHowlIdMuted = state;
     this.updateNotificationsState(); //make sure to push updated info tro alarm menu
   }
 
@@ -363,19 +363,19 @@ export class NotificationsService implements OnDestroy {
    * @param trackId track to play
    */
    playAlarm(trackId: number) {
-    if (this.activeAlarmSoundtrack == trackId) {   // same track, do nothing
+    if (this._activeAlarmSoundtrack == trackId) {   // same track, do nothing
       return;
     }
     if (trackId == 1000) {   // Stop track
-      if (this.howlPlayer) {
-        this.howlPlayer.stop();
+      if (this._howlPlayer) {
+        this._howlPlayer.stop();
       }
-      this.activeAlarmSoundtrack = 1000;
+      this._activeAlarmSoundtrack = 1000;
       return;
     }
-    this.howlPlayer.stop();
-    this.howlPlayer = this.getPlayer(trackId);
-    this.activeHowlId = this.howlPlayer.play();
+    this._howlPlayer.stop();
+    this._howlPlayer = this.getPlayer(trackId);
+    this._activeHowlId = this._howlPlayer.play();
   }
 
   /**
@@ -385,10 +385,10 @@ export class NotificationsService implements OnDestroy {
    * @memberof NotificationsService
    */
   public observeNotificationConfiguration(): Observable<INotificationConfig> {
-    return this.notificationConfig$.asObservable();
+    return this._notificationConfig$.asObservable();
   }
 
   ngOnDestroy(): void {
-    this.notificationSettingsSubscription?.unsubscribe();
+    this._notificationSettingsSubscription?.unsubscribe();
   }
 }

--- a/src/app/core/services/signalk-data.service.ts
+++ b/src/app/core/services/signalk-data.service.ts
@@ -75,7 +75,8 @@ export class SignalKDataService implements OnDestroy {
   private _deltaUpdatesSubject: ReplaySubject<IDeltaUpdate> = new ReplaySubject(60);
   private _deltaUpdatesCounterTimer = null;
 
-  // Path Delta data
+  // Full skData copy for data-browser component
+  private _isSkDataFullTreeActive: boolean = false;
   private _skDataObservable$ = new BehaviorSubject<ISkPathData[]>([]);
 
   // Zones
@@ -321,9 +322,8 @@ export class SignalKDataService implements OnDestroy {
       }
     );
 
-    // TODO: this is bad. check to only create if subscribed to
-    // push it to paths observer
-    this._skDataObservable$.next(this._skData);
+    // Push full tree if data-browser is observing
+    this._isSkDataFullTreeActive ? this._skDataObservable$.next(this._skData) : null;
   }
 
   private setMeta(meta: IMeta): void {
@@ -383,8 +383,17 @@ export class SignalKDataService implements OnDestroy {
     return paths; // copy it....
   }
 
-  public getSkDataObservable(): Observable<ISkPathData[]> {
+  public startSkDataFullTree(): Observable<ISkPathData[]> {
+    this._isSkDataFullTreeActive = true;
+    this._skDataObservable$.next(this._skData);
     return this._skDataObservable$.asObservable();
+  }
+
+  public stopSkDataFullTree(): void {
+    if (!this._skDataObservable$.observed) {
+      this._isSkDataFullTreeActive = false;
+      this._skDataObservable$.next(null);
+    }
   }
 
   public getPathsAndMetaByType(valueType: string, selfOnly?: boolean): IPathMetaData[] { //TODO(David): See how we should handle string and boolean type value. We should probably return error and not search for it, plus remove from the Units UI.

--- a/src/app/core/services/signalk-data.service.ts
+++ b/src/app/core/services/signalk-data.service.ts
@@ -206,7 +206,7 @@ export class SignalKDataService implements OnDestroy {
 
   private setSelfUrn(value: string) {
     if ((value != "" || value != null) && value != this._selfUrn) {
-      console.debug('[Signal K Data Service] Setting self to: ' + value);
+      console.log('[Data Service] Setting self to: ' + value);
       this._selfUrn = value;
     }
   }
@@ -317,7 +317,7 @@ export class SignalKDataService implements OnDestroy {
           item._pathValue$.next(this._skData[pathIndex].sources[item.source].sourceValue);
         } else {
           //we're looking for a source we don't know about. Error out to console
-          console.error(`[Signal K Data Service] Failed updating zone state. Source unknown or not defined for path: ${item.source}`);
+          console.error(`[Data Service] Failed updating zone state. Source unknown or not defined for path: ${item.source}`);
         }
       }
     );
@@ -471,14 +471,14 @@ export class SignalKDataService implements OnDestroy {
     return this._skNotificationMeta$.asObservable();
   }
 
-public getPathMeta(path: string): Observable<ISignalKMetadata> {
-  const registration = this._pathRegister.find(registration => registration.path == path);
-  return registration?._pathMeta$.asObservable() || of(null);
-}
+  public getPathMeta(path: string): Observable<ISignalKMetadata> {
+    const registration = this._pathRegister.find(registration => registration.path == path);
+    return registration?._pathMeta$.asObservable() || of(null);
+  }
 
-public IsResetService(): Observable<boolean> {
-  return this._isReset.asObservable();
-}
+  public IsResetService(): Observable<boolean> {
+    return this._isReset.asObservable();
+  }
 
   ngOnDestroy(): void {
     this._defaultUnitsSub?.unsubscribe();

--- a/src/app/core/services/signalk-data.service.ts
+++ b/src/app/core/services/signalk-data.service.ts
@@ -333,16 +333,12 @@ export class SignalKDataService implements OnDestroy {
     } else {
       const { context, path, meta: metaProp } = meta;
       const metaPath = this.setPathContext(context, path);
-      const pathObject = this._skData.find(pathObject => pathObject.path === metaPath);
+      let pathObject = this._skData.find(pathObject => pathObject.path === metaPath);
 
       if (pathObject) {
         pathObject.meta = merge(pathObject.meta, metaProp);
-
-        this._pathRegister.filter(registration => registration.path === metaPath).forEach(
-          registration => registration.pathMeta$.next(pathObject.meta)
-        );
       } else { // not in our list yet. The Meta update came before the Source update.
-        this._skData.push({
+        pathObject = this._skData.at(this._skData.push({
           path: metaPath,
           pathValue: undefined,
           defaultSource: undefined,
@@ -350,11 +346,11 @@ export class SignalKDataService implements OnDestroy {
           meta: metaProp,
           type: undefined,
           state: States.Normal
-        });
-        metaProp.zones ? this._pathRegister.filter(registration => registration.path === metaPath).forEach(
-          registration => registration.pathMeta$.next(metaProp)
-        ) : null;
+        }) - 1);
       }
+      this._pathRegister.filter(registration => registration.path === metaPath).forEach(
+        registration => registration.pathMeta$.next(pathObject.meta)
+      );
     }
   }
 

--- a/src/app/core/services/signalk-delta.service.ts
+++ b/src/app/core/services/signalk-delta.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, NgZone } from '@angular/core';
-import { BehaviorSubject, delay, Observable , retryWhen, Subject, tap } from 'rxjs';
+import { BehaviorSubject, delay, Observable , retryWhen, Subject, takeUntil, tap } from 'rxjs';
 import { webSocket, WebSocketSubject } from 'rxjs/webSocket';
 
 import { ISignalKDataValueUpdate, ISignalKDeltaMessage, ISignalKMeta, ISignalKUpdateMessage } from '../interfaces/signalk-interfaces';
@@ -60,6 +60,12 @@ export class SignalKDeltaService {
   // Token
   private authToken: IAuthorizationToken = null;
 
+  // Subject that emits a value to automatically unsubscribe when the service is destroyed
+  private _destroyed$ = new Subject<void>();
+
+  // Array to store the timeout IDs
+  private timeoutIds: NodeJS.Timeout[] = [];
+
   constructor(
     private server: SignalKConnectionService,
     private auth: AuthenticationService,
@@ -67,7 +73,9 @@ export class SignalKDeltaService {
     )
     {
       // Monitor Connection Service Endpoint Status
-      this.server.serverServiceEndpoint$.subscribe((endpointStatus: IEndpointStatus) => {
+      this.server.serverServiceEndpoint$
+        .pipe(takeUntil(this._destroyed$))
+        .subscribe((endpointStatus: IEndpointStatus) => {
         let reason: string = null;
         if (endpointStatus.operation === 2) {
           reason = "New endpoint";
@@ -82,67 +90,68 @@ export class SignalKDeltaService {
             this.closeWS(reason);
           }
 
-          setTimeout(() => {   // need a delay so WebSocket Close Observer has time to complete before connecting again.
-            this.connectWS(reason);
-          }, 250);
+          this.timeoutIds.push(setTimeout(() => { this.connectWS(reason) }, 250)); // need a delay so WebSocket Close Observer has time to complete before connecting again.
 
         } else {
           if (this.socketWS$ && endpointStatus.operation !== 1 && this.streamEndpoint.operation !== 4) {
             this.closeWS(reason);
           }
         }
-      });
+        });
 
       // Monitor Token changes
-      this.auth.authToken$.subscribe((token: IAuthorizationToken) => {
-        if (this.authToken != token) { // When token changes, reconnect WebSocket with new token
-          this.authToken = token;
+      this.auth.authToken$
+        .pipe(takeUntil(this._destroyed$))
+        .subscribe((token: IAuthorizationToken) => {
+          if (this.authToken != token) { // When token changes, reconnect WebSocket with new token
+            this.authToken = token;
 
-          let reason: string = null;
-          if (token) {
-            reason = "New token";
-          } else {
-            reason = "Deleted Token";
+            let reason: string = null;
+            if (token) {
+              reason = "New token";
+            } else {
+              reason = "Deleted Token";
+            }
+
+            // Only if the socket is in Connected or Connecting state.
+            if (this.socketWS$ && (this.streamEndpoint.operation === 2 || this.streamEndpoint.operation === 1) ) {
+              this.closeWS(reason);
+              this.timeoutIds.push(setTimeout(() => { this.connectWS(reason) }, 250)); // need a delay so WebSocket Close Observer has time to complete before connecting again.
+            }
           }
-
-          // Only if the socket is in Connected or Connecting state.
-          if (this.socketWS$ && (this.streamEndpoint.operation === 2 || this.streamEndpoint.operation === 1) ) {
-            this.closeWS(reason);
-
-            setTimeout(() => {   // need a delay so WebSocket Close Observer has time to complete before connecting again.
-              this.connectWS(reason);
-            }, 250);
-          }
-        }
-      });
+        });
 
       // WebSocket Open Event Handling
-      this.socketWSOpenEvent$.subscribe( event => {
-          this.streamEndpoint.message = "Connected";
-          this.streamEndpoint.operation = 2;
-          if (this.authToken) {
-            console.log("[Delta Service] WebSocket connected with Authorization Token")
-          } else {
-            console.log("[Delta Service] WebSocket connected without Authorization Token");
+      this.socketWSOpenEvent$
+        .pipe(takeUntil(this._destroyed$))
+        .subscribe( event => {
+            this.streamEndpoint.message = "Connected";
+            this.streamEndpoint.operation = 2;
+            if (this.authToken) {
+              console.log("[Delta Service] WebSocket connected with Authorization Token")
+            } else {
+              console.log("[Delta Service] WebSocket connected without Authorization Token");
+            }
+            this.streamEndpoint$.next(this.streamEndpoint);
           }
-          this.streamEndpoint$.next(this.streamEndpoint);
-        }
-     );
+        );
 
       // WebSocket closed Event Handling
-      this.socketWSCloseEvent$.subscribe( event => {
-        if(event.wasClean) {
-          this.streamEndpoint.message = "WebSocket closed";
-          this.streamEndpoint.operation = 0;
-          console.log('[Delta Service] WebSocket closed');
-        } else {
-          console.log('[Delta Service] WebSocket terminated due to socket error');
-          this.streamEndpoint.message = "WebSocket error";
-          this.streamEndpoint.operation = 3;
-          console.log('[Delta Service] WebSocket closed');
-        }
-        this.streamEndpoint$.next(this.streamEndpoint);
-      });
+      this.socketWSCloseEvent$
+        .pipe(takeUntil(this._destroyed$))
+        .subscribe( event => {
+          if(event.wasClean) {
+            this.streamEndpoint.message = "WebSocket closed";
+            this.streamEndpoint.operation = 0;
+            console.log('[Delta Service] WebSocket closed');
+          } else {
+            console.log('[Delta Service] WebSocket terminated due to socket error');
+            this.streamEndpoint.message = "WebSocket error";
+            this.streamEndpoint.operation = 3;
+            console.log('[Delta Service] WebSocket closed');
+          }
+          this.streamEndpoint$.next(this.streamEndpoint);
+        });
     }
 
   /**
@@ -211,82 +220,83 @@ export class SignalKDeltaService {
   *
   * `*** Do not pre-stringify the msg param ***`
   */
-  public publishDelta(msg: any) {
+  public publishDelta(msg: any): void {
     if (this.socketWS$) {
       console.log("[Delta Service] WebSocket sending message");
       this.socketWS$.next(msg);
     } else {
-      setTimeout((): void => {
-        console.log("[Delta Service] WebSocket retry sending message");
-        this.socketWS$.next(msg);
-      }, 1000);
+      this.timeoutIds.push(setTimeout(() => {
+        if (this.socketWS$) {
+          console.log("[Delta Service] WebSocket retry sending message");
+          this.socketWS$.next(msg);
+        }
+       }, 1000));
       console.log("[Delta Service] No WebSocket present to send message");
     }
   }
 
   private processWebsocketMessage(message: ISignalKDeltaMessage) {
-    // We check updates first as it is by far the most frequent
     if (message.updates) {
-      this.parseUpdates(message.updates, message.context); // process update
+      this.parseUpdates(message.updates, message.context);
+      return;
+    }
 
-    } else if (message.requestId) {
-      this._skRequests$.next(message); // is a Request/response, send to signalk-request service.
+    if (message.requestId) {
+      this._skRequests$.next(message);
+      return;
+    }
 
-    } else if (message.errorMessage) {
-      console.warn("[Delta Service] Service received stream error message: " + message.errorMessage); // server error message ie. socket failed or closing, sk bug, sk restarted, etc.
+    if (message.errorMessage) {
+      console.warn("[Delta Service] Service received stream error message: " + message.errorMessage);
+      return;
+    }
 
-    } else if (message.self) {
+    if (message.self) {
       this._selfUrn = message.self;
       this._vesselSelfUrn$.next(message.self);
-      this.server.setServerInfo(message.name, message.version, message.roles); // is server Hello message
-
-    } else { // not in our list of message types....
-      console.warn("[Delta Service] Unknown message type. Message content:" + message);
+      this.server.setServerInfo(message.name, message.version, message.roles);
+      return;
     }
+
+    console.warn("[Delta Service] Unknown message type. Message content:" + message);
   }
 
   private parseUpdates(updates: ISignalKUpdateMessage[], context: string): void {
     if (context != this._selfUrn) {    // remove non self root nodes
-      return
+      return;
     }
-    for (const update of updates) {
+
+    updates.forEach(update => {
       if (update.meta !== undefined) {
         // Meta message update
-        for (const meta of update.meta) {
-            this.parseSkMeta(meta, context);
-        }
-
+        update.meta.forEach(meta => this.parseSkMeta(meta, context));
       } else {
         // Source value updates
-        for (let item of update.values) {
-          if (item.path.startsWith("notifications.")) {  // It's is a notification message, pass to notification service
+        update.values.forEach(item => {
+          if (item.path.startsWith("notifications.")) {  // It's a notification message, pass to notification service
             this._skNotificationsMsg$.next(item);
-
           } else {
-            // It's a path value source update. Check if it's an Object. NOTE: null represents an undefined object and so is an object it's self, but in SK it should be handled as a value to mean: the path/source exists, but no value can ge generated. Ie. a depth sensor that can't read bottom depth in very deep water will send null.
+            // It's a path value source update.
             if ((typeof(item.value) == 'object') && (item.value !== null)) {
-              const keys = Object.keys(item.value);
-              for (let i = 0; i < keys.length; i++) {
+              Object.keys(item.value).forEach(key => {
                 const dataPath: IPathValueData = {
                   context: context,
-                  path: `${item.path}.${keys[i]}`,
+                  path: `${item.path}.${key}`,
                   source: update.$source,
                   timestamp: update.timestamp,
-                  value: item.value[keys[i]],
+                  value: item.value[key],
                 };
-                if (update.$source == "defaults") { // defaults are SK special ship description values that have no path. Removing first dot so it attaches to self properly
-                  if (item.path == "") {
-                    dataPath.path = dataPath.path.slice(1);
-                  }
-                }
-                if (context != this._selfUrn) { // data from non self root nodes may have no path. Removing first dot so it attaches to external root node context properly
-                  if (item.path == "") {
-                    dataPath.path = dataPath.path.slice(1);
-                  }
-                }
-                this._skValue$.next(dataPath);
-              }
 
+                if (update.$source == "defaults" && item.path == "") { // defaults are SK special ship description values that have no path. Removing first dot so it attaches to self properly
+                  dataPath.path = dataPath.path.slice(1);
+                }
+
+                if (context != this._selfUrn && item.path == "") { // data from non self root nodes may have no path. Removing first dot so it attaches to external root node context properly
+                  dataPath.path = dataPath.path.slice(1);
+                }
+
+                this._skValue$.next(dataPath);
+              });
             } else {
               // It's a Primitive type or a null value
               const dataPath: IPathValueData = {
@@ -299,30 +309,26 @@ export class SignalKDeltaService {
               this._skValue$.next(dataPath);
             }
           }
-        }
+        });
       }
-    }
+    });
   }
 
   private parseSkMeta(metadata: ISignalKMeta, context: string) {
-    let meta: IMeta = null;
-    // does meta have one with properties for each one?
     if (metadata.value.properties !== undefined) {
       Object.keys(metadata.value.properties).forEach(key => {
-        meta = {
+        this._skMetadata$.next({
           context: context,
           path: `${metadata.path}.${key}`,
           meta: metadata.value.properties[key],
-        };
-        this._skMetadata$.next(meta);
-      })
+        });
+      });
     } else {
-      meta = {
+      this._skMetadata$.next({
         context: context,
         path: metadata.path,
         meta: metadata.value,
-      };
-      this._skMetadata$.next(meta);
+      });
     }
   }
 
@@ -359,7 +365,14 @@ export class SignalKDeltaService {
   * @memberof SignalKDeltaService
   */
   OnDestroy(): void {
+    // Emit a value to automatically unsubscribe from all observables
+    this._destroyed$.next();
+    this._destroyed$.complete();
+
+    // Clear all the timeouts
+    this.timeoutIds.forEach(timeoutId => clearTimeout(timeoutId));
+
+    // Close the WebSocket connection
     this.closeWS("App terminated");
   }
-
- }
+}

--- a/src/app/core/services/signalk-delta.service.ts
+++ b/src/app/core/services/signalk-delta.service.ts
@@ -262,9 +262,9 @@ export class SignalKDeltaService {
   }
 
   private parseUpdates(updates: ISignalKUpdateMessage[], context: string): void {
-    if (context != this._selfUrn) {    // remove non self root nodes
-      return;
-    }
+    // if (context != this._selfUrn) {    // remove non self root nodes
+    //   return;
+    // }
 
     updates.forEach(update => {
       if (update.meta !== undefined) {
@@ -291,7 +291,7 @@ export class SignalKDeltaService {
                   dataPath.path = dataPath.path.slice(1);
                 }
 
-                if (context != this._selfUrn && item.path == "") { // data from non self root nodes may have no path. Removing first dot so it attaches to external root node context properly
+                if (context != this._selfUrn && item.path == "") { // data from non self root nodes (other vessel, atoms, stations, buoy, etc.) may have no path. Removing first dot so it attaches to external root node context properly
                   dataPath.path = dataPath.path.slice(1);
                 }
 

--- a/src/app/core/services/signalk-delta.service.ts
+++ b/src/app/core/services/signalk-delta.service.ts
@@ -250,9 +250,9 @@ export class SignalKDeltaService {
   }
 
   private parseUpdates(updates: ISignalKUpdateMessage[], context: string): void {
-    // if (context != this.selfUrn) {    // remove non self root nodes
-    //   return
-    // }
+    if (context != this.selfUrn) {    // remove non self root nodes
+      return
+    }
     for (const update of updates) {
       if (update.meta !== undefined) {
         // Meta message update

--- a/src/app/core/services/signalk-delta.service.ts
+++ b/src/app/core/services/signalk-delta.service.ts
@@ -63,7 +63,7 @@ export class SignalKDeltaService {
   constructor(
     private server: SignalKConnectionService,
     private auth: AuthenticationService,
-    private zones: NgZone
+    private zones: NgZone // NgZone to run outside Angular zone - NOT to be confused with SK zones
     )
     {
       // Monitor Connection Service Endpoint Status

--- a/src/app/core/services/units.service.ts
+++ b/src/app/core/services/units.service.ts
@@ -1,4 +1,4 @@
-import { SignalKDataService } from './data.service';
+import { DataService } from './data.service';
 import { Injectable } from '@angular/core';
 import Qty from 'js-quantities';
 
@@ -143,7 +143,7 @@ export class UnitsService {
 
   constructor(
     private AppSettingsService: AppSettingsService,
-    private skData: SignalKDataService
+    private data: DataService
     ) {
       this._defaultUnitsSub = this.AppSettingsService.getDefaultUnitsAsO().subscribe(
         appSettings => {
@@ -339,7 +339,7 @@ export class UnitsService {
    * @return conversions Full list array or subset of list array
    */
   public getConversionsForPath(path: string): { default: string, conversions: IUnitGroup[] } {
-    const pathUnitType = this.skData.getPathUnitType(path);
+    const pathUnitType = this.data.getPathUnitType(path);
     let defaultUnit: string = "unitless";
 
     if (pathUnitType === null) {

--- a/src/app/core/services/units.service.ts
+++ b/src/app/core/services/units.service.ts
@@ -1,3 +1,4 @@
+import { SignalKDataService } from './signalk-data.service';
 import { Injectable } from '@angular/core';
 import Qty from 'js-quantities';
 
@@ -30,15 +31,14 @@ export interface IUnitDefaults {
 @Injectable()
 
 export class UnitsService {
-  defaultUnits: IUnitDefaults;
-  defaultUnitsSub: Subscription;
+  _defaultUnitsSub: Subscription;
 
   /**
    * Definition of available Kip units to be used for conversion.
    * Measure property has to match one Unit Conversion Function for proper operation.
    * Description is human readable property.
    */
-  conversionList: IUnitGroup[] = [
+  private _conversionList: IUnitGroup[] = [
     { group: 'Unitless', units: [
       { measure: 'unitless', description: "As-Is numeric value" }
     ] },
@@ -139,12 +139,15 @@ export class UnitsService {
       { measure: 'longitudeSec', description: "Longitude in seconds" },
     ] },
   ];
+  private _defaultUnits: IUnitDefaults = null;
 
-  constructor(  private AppSettingsService: AppSettingsService,
+  constructor(
+    private AppSettingsService: AppSettingsService,
+    private skData: SignalKDataService
     ) {
-      this.defaultUnitsSub = this.AppSettingsService.getDefaultUnitsAsO().subscribe(
-        newDefaults => {
-          this.defaultUnits = newDefaults;
+      this._defaultUnitsSub = this.AppSettingsService.getDefaultUnitsAsO().subscribe(
+        appSettings => {
+          this._defaultUnits = appSettings;
         }
       );
   }
@@ -297,6 +300,7 @@ export class UnitsService {
     let num: number = +value; // sometime we get strings here. Weird! Lazy patch.
     return this.unitConversionFunctions[unit](num);
   }
+
   /**
    * Returns the list KIP default unit conversion settings applied before presentation.
    * See KIP's Units Settings configuration.
@@ -309,7 +313,7 @@ export class UnitsService {
    * @memberof UnitsService
    */
   public getDefaults(): IUnitDefaults {
-    return this.defaultUnits;
+    return this._defaultUnits;
   }
 
   /**
@@ -321,6 +325,46 @@ export class UnitsService {
    * @memberof UnitsService
    */
   public getConversions(): IUnitGroup[] {
-    return this.conversionList;
+    return this._conversionList;
+  }
+
+  /**
+   * Obtain a list of possible Kip value type conversions for a given path. ie,.: Speed conversion group
+   * (kph, Knots, etc.). The conversion list will be trimmed to only the conversions for the group in question.
+   * If a default value type (provided by server) for a path cannot be found,
+   * the full list is returned and with 'unitless' as the default. Same goes if the value type exists,
+   * but Kip does not handle it...yet.
+   *
+   * @param path The Signal K path of the value
+   * @return conversions Full list array or subset of list array
+   */
+  public getConversionsForPath(path: string): { default: string, conversions: IUnitGroup[] } {
+    const pathUnitType = this.skData.getPathUnitType(path);
+    let defaultUnit: string = "unitless";
+
+    if (pathUnitType === null) {
+      return { default: 'unitless', conversions: this._conversionList };
+    } else {
+      const groupList = this._conversionList.filter(unitGroup => {
+        if (unitGroup.group == 'Position' && (path.includes('position.latitude') || path.includes('position.longitude'))) {
+          return true;
+        }
+
+        const unitExists = unitGroup.units.find(unit => unit.measure == pathUnitType);
+        if (unitExists) {
+          defaultUnit = this._defaultUnits[unitGroup.group];
+          return true;
+        }
+
+        return false;
+      });
+
+      if (groupList.length > 0) {
+        return { default: defaultUnit, conversions: groupList };
+      }
+
+      console.log("[Units Service] Unit type: " + pathUnitType + ", found for path: " + path + "\nbut Kip does not support it.");
+      return { default: 'unitless', conversions: this._conversionList };
+    }
   }
 }

--- a/src/app/core/services/units.service.ts
+++ b/src/app/core/services/units.service.ts
@@ -1,4 +1,4 @@
-import { SignalKDataService } from './signalk-data.service';
+import { SignalKDataService } from './data.service';
 import { Injectable } from '@angular/core';
 import Qty from 'js-quantities';
 

--- a/src/app/data-browser-row/data-browser-row.component.ts
+++ b/src/app/data-browser-row/data-browser-row.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnInit, ViewEncapsulation, Inject } from '@angular/core';
 import { MatDialog, MatDialogRef, MAT_DIALOG_DATA, MatDialogTitle, MatDialogContent, MatDialogActions, MatDialogClose } from '@angular/material/dialog';
 
-import { SignalKDataService } from '../core/services/data.service';
+import { DataService } from '../core/services/data.service';
 import { UnitsService } from '../core/services/units.service';
 import { MatCell } from '@angular/material/table';
 import { MatButton } from '@angular/material/button';
@@ -29,7 +29,7 @@ export class DataBrowserRowComponent implements OnInit {
   selectedUnit: string = "unitless"
 
   constructor(
-    private signalKDataService: SignalKDataService,
+    private DataService: DataService,
     private unitsService: UnitsService,
     public dialog: MatDialog
   ) {

--- a/src/app/data-browser-row/data-browser-row.component.ts
+++ b/src/app/data-browser-row/data-browser-row.component.ts
@@ -37,7 +37,7 @@ export class DataBrowserRowComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.units = this.signalKDataService.getConversionsForPath(this.path);
+    this.units = this.unitsService.getConversionsForPath(this.path);
     this.selectedUnit = this.units.default;
   }
 

--- a/src/app/data-browser-row/data-browser-row.component.ts
+++ b/src/app/data-browser-row/data-browser-row.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnInit, ViewEncapsulation, Inject } from '@angular/core';
 import { MatDialog, MatDialogRef, MAT_DIALOG_DATA, MatDialogTitle, MatDialogContent, MatDialogActions, MatDialogClose } from '@angular/material/dialog';
 
-import { SignalKDataService } from '../core/services/signalk-data.service';
+import { SignalKDataService } from '../core/services/data.service';
 import { UnitsService } from '../core/services/units.service';
 import { MatCell } from '@angular/material/table';
 import { MatButton } from '@angular/material/button';

--- a/src/app/data-browser/data-browser.component.ts
+++ b/src/app/data-browser/data-browser.component.ts
@@ -4,7 +4,7 @@ import { MatTableDataSource, MatTable, MatColumnDef, MatHeaderCellDef, MatHeader
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
 
-import { SignalKDataService } from '../core/services/signalk-data.service';
+import { SignalKDataService } from '../core/services/data.service';
 import { ISkPathData } from "../core/interfaces/app-interfaces";
 import { DataBrowserRowComponent } from '../data-browser-row/data-browser-row.component';
 import { NgFor, KeyValuePipe } from '@angular/common';

--- a/src/app/data-browser/data-browser.component.ts
+++ b/src/app/data-browser/data-browser.component.ts
@@ -41,7 +41,7 @@ export class DataBrowserComponent implements OnInit, AfterViewInit, OnDestroy {
 
   ngOnInit() {
     this.dataTableTimer = setTimeout(()=>{
-      this.pathsSubscription = this.signalKDataService.getSkDataObservable().subscribe((paths: ISkPathData[]) => {
+      this.pathsSubscription = this.signalKDataService.startSkDataFullTree().subscribe((paths: ISkPathData[]) => {
         this.tableData.data = paths;
       })}, 0); // set timeout to make it async otherwise delays page load
   }
@@ -93,6 +93,9 @@ export class DataBrowserComponent implements OnInit, AfterViewInit, OnDestroy {
 
   ngOnDestroy(): void {
     clearTimeout(this.dataTableTimer);
+    this.tableData.data = null
+    this.tableData = null;
     this.pathsSubscription?.unsubscribe();
+    this.signalKDataService.stopSkDataFullTree();
   }
 }

--- a/src/app/data-browser/data-browser.component.ts
+++ b/src/app/data-browser/data-browser.component.ts
@@ -5,7 +5,7 @@ import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
 
 import { SignalKDataService } from '../core/services/signalk-data.service';
-import { IPathData } from "../core/interfaces/app-interfaces";
+import { ISkPathData } from "../core/interfaces/app-interfaces";
 import { DataBrowserRowComponent } from '../data-browser-row/data-browser-row.component';
 import { NgFor, KeyValuePipe } from '@angular/common';
 import { MatInput } from '@angular/material/input';
@@ -28,7 +28,7 @@ export class DataBrowserComponent implements OnInit, AfterViewInit, OnDestroy {
   private dataTableTimer: NodeJS.Timeout = null;
 
   public pageSize: number = 10;
-  public tableData = new MatTableDataSource<IPathData>([]);
+  public tableData = new MatTableDataSource<ISkPathData>([]);
   public displayedColumns: string[] = ['path', 'defaultSource'];
 
   constructor(
@@ -41,7 +41,7 @@ export class DataBrowserComponent implements OnInit, AfterViewInit, OnDestroy {
 
   ngOnInit() {
     this.dataTableTimer = setTimeout(()=>{
-      this.pathsSubscription = this.signalKDataService.getSkDataObservable().subscribe((paths: IPathData[]) => {
+      this.pathsSubscription = this.signalKDataService.getSkDataObservable().subscribe((paths: ISkPathData[]) => {
         this.tableData.data = paths;
       })}, 0); // set timeout to make it async otherwise delays page load
   }
@@ -63,7 +63,7 @@ export class DataBrowserComponent implements OnInit, AfterViewInit, OnDestroy {
     }
   }
 
-  public trackByPath(index: number, item: IPathData): string {
+  public trackByPath(index: number, item: ISkPathData): string {
     return `${item.path}`;
   }
 

--- a/src/app/data-browser/data-browser.component.ts
+++ b/src/app/data-browser/data-browser.component.ts
@@ -4,7 +4,7 @@ import { MatTableDataSource, MatTable, MatColumnDef, MatHeaderCellDef, MatHeader
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
 
-import { SignalKDataService } from '../core/services/data.service';
+import { DataService } from '../core/services/data.service';
 import { ISkPathData } from "../core/interfaces/app-interfaces";
 import { DataBrowserRowComponent } from '../data-browser-row/data-browser-row.component';
 import { NgFor, KeyValuePipe } from '@angular/common';
@@ -32,7 +32,7 @@ export class DataBrowserComponent implements OnInit, AfterViewInit, OnDestroy {
   public displayedColumns: string[] = ['path', 'defaultSource'];
 
   constructor(
-    private signalKDataService: SignalKDataService,
+    private dataService: DataService,
     private cdRef: ChangeDetectorRef) { }
 
   public onResize(event) {
@@ -41,7 +41,7 @@ export class DataBrowserComponent implements OnInit, AfterViewInit, OnDestroy {
 
   ngOnInit() {
     this.dataTableTimer = setTimeout(()=>{
-      this.pathsSubscription = this.signalKDataService.startSkDataFullTree().subscribe((paths: ISkPathData[]) => {
+      this.pathsSubscription = this.dataService.startSkDataFullTree().subscribe((paths: ISkPathData[]) => {
         this.tableData.data = paths;
       })}, 0); // set timeout to make it async otherwise delays page load
   }
@@ -96,6 +96,6 @@ export class DataBrowserComponent implements OnInit, AfterViewInit, OnDestroy {
     this.tableData.data = null
     this.tableData = null;
     this.pathsSubscription?.unsubscribe();
-    this.signalKDataService.stopSkDataFullTree();
+    this.dataService.stopSkDataFullTree();
   }
 }

--- a/src/app/settings/config/config.component.html
+++ b/src/app/settings/config/config.component.html
@@ -421,30 +421,6 @@
             </mat-action-row>
           </mat-expansion-panel>
         </form>
-        <br />
-        <form (ngSubmit)="rawConfigSave('IZonesConfig')">
-          <mat-expansion-panel>
-            <mat-expansion-panel-header>Zones</mat-expansion-panel-header>
-            <mat-form-field class="config-size">
-              <textarea
-                class="textheight"
-                matInput
-                placeholder="Raw Layout JSON configuration"
-                wrap="off"
-                autocomplete="off"
-                autocorrect="off"
-                spellcheck="false"
-                [(ngModel)]="jsonZonesConfig"
-                [ngModelOptions]="{name: 'zonesConfig', updateOn: 'submit'}"
-              ></textarea>
-            </mat-form-field>
-            <mat-action-row>
-              <button mat-raised-button type="submit" color="accent">
-                Save Edits
-              </button>
-            </mat-action-row>
-          </mat-expansion-panel>
-        </form>
       </div>
     </div>
   </div>

--- a/src/app/settings/config/config.component.ts
+++ b/src/app/settings/config/config.component.ts
@@ -5,7 +5,7 @@ import { UntypedFormBuilder, UntypedFormGroup, Validators, FormsModule, Reactive
 import { AuthenticationService, IAuthorizationToken } from '../../core/services/authentication.service';
 import { AppService } from '../../core/services/app-service';
 import { AppSettingsService } from '../../core/services/app-settings.service';
-import { IConfig, IAppConfig, IConnectionConfig, IWidgetConfig, ILayoutConfig, IThemeConfig, IZonesConfig } from '../../core/interfaces/app-settings.interfaces';
+import { IConfig, IAppConfig, IConnectionConfig, IWidgetConfig, ILayoutConfig, IThemeConfig } from '../../core/interfaces/app-settings.interfaces';
 import { StorageService } from '../../core/services/storage.service';
 import { cloneDeep } from 'lodash-es';
 import { HttpErrorResponse } from '@angular/common/http';
@@ -59,7 +59,6 @@ export class SettingsConfigComponent implements OnInit, OnDestroy{
   public liveWidgetConfig: IWidgetConfig;
   public liveLayoutConfig: ILayoutConfig;
   public liveThemeConfig: IThemeConfig;
-  public liveZonesConfig: IZonesConfig;
   public showRawEditor = false;
 
   constructor(
@@ -188,7 +187,6 @@ export class SettingsConfigComponent implements OnInit, OnDestroy{
         this.appSettingsService.replaceConfig("widgetConfig", conf.widget, false);
         this.appSettingsService.replaceConfig("layoutConfig", conf.layout, false);
         this.appSettingsService.replaceConfig("themeConfig", conf.theme, false);
-        this.appSettingsService.replaceConfig("zonesConfig", conf.zones, true);
       }
     }
   }
@@ -283,14 +281,6 @@ export class SettingsConfigComponent implements OnInit, OnDestroy{
         this.appSettingsService.replaceConfig('themeConfig', this.liveThemeConfig, true);
         }
         break;
-
-      case "IZonesConfig":
-        if (this.hasToken && !this.isTokenTypeDevice) {
-          this.storageSvc.patchConfig(configType, this.liveZonesConfig);
-        } else {
-        this.appSettingsService.replaceConfig("zonesConfig", this.liveZonesConfig, true);
-        }
-        break;
     }
   }
 
@@ -312,19 +302,6 @@ export class SettingsConfigComponent implements OnInit, OnDestroy{
     this.liveWidgetConfig = this.appSettingsService.getWidgetConfig();
     this.liveLayoutConfig = this.appSettingsService.getLayoutConfig();
     this.liveThemeConfig = this.appSettingsService.getThemeConfig();
-    this.liveZonesConfig = this.appSettingsService.getZonesConfig();
-  }
-
-  get jsonZonesConfig() {
-    return JSON.stringify(this.liveZonesConfig, null, 2);
-  }
-
-  set jsonZonesConfig(v) {
-    try{
-      this.liveZonesConfig = JSON.parse(v);}
-    catch(error) {
-      console.log(`JSON syntax error: ${error}`);
-    };
   }
 
   get jsonThemeConfig() {
@@ -403,7 +380,6 @@ export class SettingsConfigComponent implements OnInit, OnDestroy{
       "widget": this.appSettingsService.getWidgetConfig(),
       "layout": this.appSettingsService.getLayoutConfig(),
       "theme": this.appSettingsService.getThemeConfig(),
-      "zones": this.appSettingsService.getZonesConfig(),
     };
     return localConfig;
   }
@@ -414,7 +390,6 @@ export class SettingsConfigComponent implements OnInit, OnDestroy{
       "widget": this.appSettingsService.loadConfigFromLocalStorage('widgetConfig'),
       "layout": this.appSettingsService.loadConfigFromLocalStorage('layoutConfig'),
       "theme": this.appSettingsService.loadConfigFromLocalStorage('themeConfig'),
-      "zones": this.appSettingsService.loadConfigFromLocalStorage('zonesConfig'),
     };
     return localConfig;
   }

--- a/src/app/settings/datasets/datasets.component.ts
+++ b/src/app/settings/datasets/datasets.component.ts
@@ -5,7 +5,7 @@ import { MatTableDataSource, MatTable, MatColumnDef, MatHeaderCellDef, MatHeader
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
 
-import { SignalKDataService } from '../../core/services/signalk-data.service';
+import { SignalKDataService } from '../../core/services/data.service';
 import { DatasetService, IDatasetServiceDatasetConfig } from '../../core/services/data-set.service';
 import { FilterSelfPipe } from '../../core/pipes/filter-self.pipe';
 import { MatCheckbox } from '@angular/material/checkbox';

--- a/src/app/settings/datasets/datasets.component.ts
+++ b/src/app/settings/datasets/datasets.component.ts
@@ -5,7 +5,7 @@ import { MatTableDataSource, MatTable, MatColumnDef, MatHeaderCellDef, MatHeader
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
 
-import { SignalKDataService } from '../../core/services/data.service';
+import { DataService } from '../../core/services/data.service';
 import { DatasetService, IDatasetServiceDatasetConfig } from '../../core/services/data-set.service';
 import { FilterSelfPipe } from '../../core/pipes/filter-self.pipe';
 import { MatCheckbox } from '@angular/material/checkbox';
@@ -157,7 +157,7 @@ export class SettingsDatasetsModalComponent implements OnInit {
   public filterSelfPaths:boolean = true;
 
   constructor(
-    private SignalKDataService: SignalKDataService,
+    private SignalKDataService: DataService,
     public dialogRef:MatDialogRef<SettingsDatasetsModalComponent>,
     @Inject(MAT_DIALOG_DATA) public dataset: IDatasetServiceDatasetConfig
     ) { }

--- a/src/app/settings/general/general.component.html
+++ b/src/app/settings/general/general.component.html
@@ -13,8 +13,10 @@
     </mat-checkbox>
     <br/><br/>
     <h2>Notifications</h2>
-    <p class="mat-card-subtitle">Signal K data state notifications messages meant to
-      inform operators. Notifications are visible in the notifications menu.</p>
+    <p class="mat-card-subtitle">Notifications are integral to Signal K's data state messaging
+      framework. They are designed to provide operators with important information, enabling
+      them to take appropriate actions. In KIP, notifications are presented as Notifications menu items and
+      accompanied by audio prompts for enhanced user interaction.</p>
     <mat-slide-toggle
       name="disableNotifications"
       [(ngModel)]="notificationConfig.disableNotifications"
@@ -28,56 +30,62 @@
         [disabled]="notificationConfig.disableNotifications">
         <mat-expansion-panel-header>
           <mat-panel-title>
-            State
+            Notifications Menu
           </mat-panel-title>
           <mat-panel-description>
-            Filter notification messages per severity levels
+            Show or hide menu items based on their state
           </mat-panel-description>
         </mat-expansion-panel-header>
         <mat-checkbox
           name="showNormalState"
           [(ngModel)]="notificationConfig.devices.showNormalState">
-          Show <b>Normal</b> severity
+          Show <b>Normal</b> state
+        </mat-checkbox>
+        <br/>
+        <mat-checkbox
+          name="showNormalState"
+          [(ngModel)]="notificationConfig.devices.showNominalState">
+          Show <b>Nominal</b> state
         </mat-checkbox>
       </mat-expansion-panel>
       <mat-expansion-panel #soundPanel
         [disabled]="notificationConfig.disableNotifications">
         <mat-expansion-panel-header>
           <mat-panel-title>
-            Sound
+            Audio Prompts
           </mat-panel-title>
           <mat-panel-description>
-            Disable audio prompt per severity levels
+            Mute and unmute data state audio prompts
           </mat-panel-description>
         </mat-expansion-panel-header>
         <mat-checkbox
           name="=disableSound"
           [(ngModel)]="notificationConfig.sound.disableSound">
-          Disable <b>All</b>
+          Mute <b>all Notifications</b>
         </mat-checkbox>
         <br/>
         <mat-checkbox
         name="muteAlert"
           [(ngModel)]="notificationConfig.sound.muteAlert">
-          Disable <b>Alert</b> severity
+          Mute <b>all Alert</b> state
         </mat-checkbox>
         <br/>
         <mat-checkbox
         name="muteWarning"
           [(ngModel)]="notificationConfig.sound.muteWarning">
-          Disable <b>Warning</b> severity
+          Mute <b>all Warning</b> state
         </mat-checkbox>
         <br/>
         <mat-checkbox
         name="muteAlarm"
           [(ngModel)]="notificationConfig.sound.muteAlarm">
-          Disable <b>Alarm</b> severity
+          Mute <b>all Alarm</b> state
         </mat-checkbox>
         <br/>
         <mat-checkbox
         name="muteEmergency"
           [(ngModel)]="notificationConfig.sound.muteEmergency">
-          Disable <b>Emergency</b> severity
+          Mute <b>all Emergency</b> state
         </mat-checkbox>
       </mat-expansion-panel>
     </mat-accordion>

--- a/src/app/settings/general/general.component.html
+++ b/src/app/settings/general/general.component.html
@@ -43,7 +43,7 @@
         </mat-checkbox>
         <br/>
         <mat-checkbox
-          name="showNormalState"
+          name="showNominalState"
           [(ngModel)]="notificationConfig.devices.showNominalState">
           Show <b>Nominal</b> state
         </mat-checkbox>
@@ -71,9 +71,9 @@
         </mat-checkbox>
         <br/>
         <mat-checkbox
-        name="muteWarning"
-          [(ngModel)]="notificationConfig.sound.muteWarning">
-          Mute <b>all Warning</b> state
+        name="muteWarn"
+          [(ngModel)]="notificationConfig.sound.muteWarn">
+          Mute <b>all Warn</b> state
         </mat-checkbox>
         <br/>
         <mat-checkbox

--- a/src/app/settings/general/general.component.html
+++ b/src/app/settings/general/general.component.html
@@ -66,25 +66,29 @@
         <br/>
         <mat-checkbox
         name="muteAlert"
-          [(ngModel)]="notificationConfig.sound.muteAlert">
+          [(ngModel)]="notificationConfig.sound.muteAlert"
+          [disabled]="notificationConfig.sound.disableSound">
           Mute <b>all Alert</b> state
         </mat-checkbox>
         <br/>
         <mat-checkbox
         name="muteWarn"
-          [(ngModel)]="notificationConfig.sound.muteWarn">
+          [(ngModel)]="notificationConfig.sound.muteWarn"
+          [disabled]="notificationConfig.sound.disableSound">
           Mute <b>all Warn</b> state
         </mat-checkbox>
         <br/>
         <mat-checkbox
         name="muteAlarm"
-          [(ngModel)]="notificationConfig.sound.muteAlarm">
+          [(ngModel)]="notificationConfig.sound.muteAlarm"
+          [disabled]="notificationConfig.sound.disableSound">
           Mute <b>all Alarm</b> state
         </mat-checkbox>
         <br/>
         <mat-checkbox
         name="muteEmergency"
-          [(ngModel)]="notificationConfig.sound.muteEmergency">
+          [(ngModel)]="notificationConfig.sound.muteEmergency"
+          [disabled]="notificationConfig.sound.disableSound">
           Mute <b>all Emergency</b> state
         </mat-checkbox>
       </mat-expansion-panel>

--- a/src/app/settings/signalk/signalk.component.ts
+++ b/src/app/settings/signalk/signalk.component.ts
@@ -4,7 +4,7 @@ import { AppService } from '../../core/services/app-service';
 import { AppSettingsService } from '../../core/services/app-settings.service';
 import { IConnectionConfig } from "../../core/interfaces/app-settings.interfaces";
 import { SignalKConnectionService, IEndpointStatus } from '../../core/services/signalk-connection.service';
-import { IDeltaUpdate, SignalKDataService } from '../../core/services/data.service';
+import { IDeltaUpdate, DataService } from '../../core/services/data.service';
 import { SignalKDeltaService, IStreamStatus } from '../../core/services/signalk-delta.service';
 import { AuthenticationService, IAuthorizationToken } from '../../core/services/authentication.service';
 import { SignalkRequestsService } from '../../core/services/signalk-requests.service';
@@ -81,7 +81,7 @@ export class SettingsSignalkComponent implements OnInit, OnDestroy {
     public dialog: MatDialog,
     private appSettingsService: AppSettingsService,
     private appService: AppService,
-    private signalKDataService: SignalKDataService,
+    private DataService: DataService,
     private signalKConnectionService: SignalKConnectionService,
     private signalkRequestsService: SignalkRequestsService,
     private deltaService: SignalKDeltaService,
@@ -130,7 +130,7 @@ export class SettingsSignalkComponent implements OnInit, OnDestroy {
     this.startChart();
 
     // Get WebSocket Delta update per seconds stats
-    this.signalkDeltaUpdatesStatsSubscription = this.signalKDataService.getSignalkDeltaUpdateStatistics().subscribe((update: IDeltaUpdate) => {
+    this.signalkDeltaUpdatesStatsSubscription = this.DataService.getSignalkDeltaUpdateStatistics().subscribe((update: IDeltaUpdate) => {
       this._chart.data.datasets[0].data.push({x: update.timestamp, y: update.value});
       if (this._chart.data.datasets[0].data.length > 60) {
         this._chart.data.datasets[0].data.shift();

--- a/src/app/settings/signalk/signalk.component.ts
+++ b/src/app/settings/signalk/signalk.component.ts
@@ -4,7 +4,7 @@ import { AppService } from '../../core/services/app-service';
 import { AppSettingsService } from '../../core/services/app-settings.service';
 import { IConnectionConfig } from "../../core/interfaces/app-settings.interfaces";
 import { SignalKConnectionService, IEndpointStatus } from '../../core/services/signalk-connection.service';
-import { IDeltaUpdate, SignalKDataService } from '../../core/services/signalk-data.service';
+import { IDeltaUpdate, SignalKDataService } from '../../core/services/data.service';
 import { SignalKDeltaService, IStreamStatus } from '../../core/services/signalk-delta.service';
 import { AuthenticationService, IAuthorizationToken } from '../../core/services/authentication.service';
 import { SignalkRequestsService } from '../../core/services/signalk-requests.service';

--- a/src/app/settings/zones/zones.component.html
+++ b/src/app/settings/zones/zones.component.html
@@ -75,8 +75,8 @@
     <div class="paginator">
       <mat-paginator pageSize="5" [pageSizeOptions]="[5, 10, 25, 100]"></mat-paginator>
     </div>
-    <div class="formActionFooter">
+    <!-- <div class="formActionFooter">
       <mat-divider class="formActionDivider"></mat-divider>
       <button type="button" mat-raised-button color="accent" class="formActionButton" (click)="openZoneDialog()">Add</button>
-    </div>
+    </div> -->
 </div>

--- a/src/app/settings/zones/zones.component.html
+++ b/src/app/settings/zones/zones.component.html
@@ -8,34 +8,41 @@
       <input matInput (keyup)="applyFilter($event)" placeholder="Ex: navigation" value="" #input>
     </mat-form-field>
     <div class="mat-elevation-z8 full-width table-container">
+
+
       <mat-table class="full-display" [dataSource]="tableData" [trackBy]="trackByUuid" matSort matSortActive="path" matSortDirection="asc">
 
-        <!-- Path Column -->
         <ng-container matColumnDef="path">
+          <mat-header-cell class="dataHeader" *matHeaderCellDef mat-sort-header>Path</mat-header-cell>
+          <mat-cell class="dataCell" *matCellDef="let element" data-label="Path: "> {{element.path}} </mat-cell>
+        </ng-container>
+
+        <!-- Path Column -->
+        <!-- <ng-container matColumnDef="path">
           <mat-header-cell class="pathHeader" *matHeaderCellDef mat-sort-header>Path</mat-header-cell>
           <mat-cell class="pathCell" *matCellDef="let element" data-label="Path: "> {{element.path}} </mat-cell>
-        </ng-container>
+        </ng-container> -->
 
-        <!-- Unit Column -->
-        <ng-container matColumnDef="unit">
-          <mat-header-cell class="dataHeader" *matHeaderCellDef mat-sort-header>Unit</mat-header-cell>
-          <mat-cell class="dataCell" *matCellDef="let element" data-label="Unit: "> {{element.unit}} </mat-cell>
-        </ng-container>
+        <!-- message Column -->
+        <!-- <ng-container matColumnDef="message">
+          <mat-header-cell class="dataHeader" *matHeaderCellDef mat-sort-header>Message</mat-header-cell>
+          <mat-cell class="dataCell" *matCellDef="let element" data-label="Unit: "> {{element.message}} </mat-cell>
+        </ng-container> -->
 
         <!-- Lower Column -->
-        <ng-container matColumnDef="lower">
+        <!-- <ng-container matColumnDef="lower">
           <mat-header-cell class="dataHeader" *matHeaderCellDef mat-sort-header>Lower</mat-header-cell>
           <mat-cell class="dataCell" *matCellDef="let element" data-label="Lower: "> {{element.lower}} </mat-cell>
-        </ng-container>
+        </ng-container> -->
 
         <!-- Upper Column -->
-        <ng-container matColumnDef="upper">
+        <!-- <ng-container matColumnDef="upper">
           <mat-header-cell class="dataHeader" *matHeaderCellDef mat-sort-header>Upper</mat-header-cell>
           <mat-cell class="dataCell" *matCellDef="let element" data-label="Upper: "> {{element.upper}} </mat-cell>
-        </ng-container>
+        </ng-container> -->
 
         <!-- State Column -->
-        <ng-container matColumnDef="state">
+        <!-- <ng-container matColumnDef="state">
           <mat-header-cell class="dataHeader" *matHeaderCellDef mat-sort-header>State</mat-header-cell>
           <mat-cell class="dataCell" *matCellDef="let element" data-label="State: ">
             <div [ngSwitch]="element.state">
@@ -44,16 +51,16 @@
               <div *ngSwitchCase="2">Alarm</div>
             </div>
           </mat-cell>
-        </ng-container>
+        </ng-container> -->
 
         <!-- Action Column -->
-        <ng-container matColumnDef="actions">
+        <!-- <ng-container matColumnDef="actions">
           <mat-header-cell class="actionHeader" *matHeaderCellDef mat-sort-header>  </mat-header-cell>
           <mat-cell class="actionCell" *matCellDef="let element">
             <button mat-raised-button class="action-buttons" color="accent" (click)="openZoneDialog(element.uuid)">Edit</button>
             <button mat-raised-button color="accent" (click)="deleteZone(element.uuid)">Delete</button>
           </mat-cell>
-        </ng-container>
+        </ng-container> -->
 
         <!-- Table header -->
         <mat-header-row class="headerRow" *matHeaderRowDef="displayedColumns; sticky: true"></mat-header-row>

--- a/src/app/settings/zones/zones.component.html
+++ b/src/app/settings/zones/zones.component.html
@@ -1,8 +1,12 @@
 <div class="mat-typography">
   <h1>Zones Configuration</h1>
-    <p class="mat-card-subtitle">Use Zones to define the state of the data KIP receives for each path. For example,
-    zones can be used to indicate at what voltage a battery considered in normal, warn or critical state.
-    Once configured, each path's zone states will enable a visual state indicator and audio notification.</p>
+    <p class="mat-card-subtitle">Zones are defined with the <b>Edit Zones plugin</b> from
+      Signal K Server. They serve two primary functions: 1. Zones define data states per
+      path. For instance, you can use zones to specify the voltage levels at which a
+      battery enters a warning or critical state. Once configured in Signal K, these states
+      can be listed and acted upon in KIP's Notifications menu, and can trigger an audio prompt.
+      2. The range of each zone is used to visually indicate data states on KIP gauges
+      (where supported). This is done by drawing the zones color on the gauge.</p>
     <mat-form-field class="filter">
       <mat-label>Filter</mat-label>
       <input matInput (keyup)="applyFilter($event)" placeholder="Ex: navigation" value="" #input>
@@ -12,55 +16,35 @@
 
       <mat-table class="full-display" [dataSource]="tableData" [trackBy]="trackByUuid" matSort matSortActive="path" matSortDirection="asc">
 
+         <!-- Path Column -->
         <ng-container matColumnDef="path">
-          <mat-header-cell class="dataHeader" *matHeaderCellDef mat-sort-header>Path</mat-header-cell>
-          <mat-cell class="dataCell" *matCellDef="let element" data-label="Path: "> {{element.path}} </mat-cell>
-        </ng-container>
-
-        <!-- Path Column -->
-        <!-- <ng-container matColumnDef="path">
           <mat-header-cell class="pathHeader" *matHeaderCellDef mat-sort-header>Path</mat-header-cell>
           <mat-cell class="pathCell" *matCellDef="let element" data-label="Path: "> {{element.path}} </mat-cell>
-        </ng-container> -->
+        </ng-container>
 
-        <!-- message Column -->
-        <!-- <ng-container matColumnDef="message">
-          <mat-header-cell class="dataHeader" *matHeaderCellDef mat-sort-header>Message</mat-header-cell>
-          <mat-cell class="dataCell" *matCellDef="let element" data-label="Unit: "> {{element.message}} </mat-cell>
-        </ng-container> -->
+        <!-- state Column -->
+        <ng-container matColumnDef="zone.state">
+          <mat-header-cell class="dataHeader" *matHeaderCellDef mat-sort-header>State</mat-header-cell>
+          <mat-cell class="dataCell" *matCellDef="let element" data-label="State: "> {{element.zone.state}} </mat-cell>
+        </ng-container>
 
-        <!-- Lower Column -->
-        <!-- <ng-container matColumnDef="lower">
+        <!-- lower Column -->
+        <ng-container matColumnDef="zone.lower">
           <mat-header-cell class="dataHeader" *matHeaderCellDef mat-sort-header>Lower</mat-header-cell>
-          <mat-cell class="dataCell" *matCellDef="let element" data-label="Lower: "> {{element.lower}} </mat-cell>
-        </ng-container> -->
+          <mat-cell class="dataCell" *matCellDef="let element" data-label="Lower: "> {{element.zone.lower}} </mat-cell>
+        </ng-container>
 
         <!-- Upper Column -->
-        <!-- <ng-container matColumnDef="upper">
+        <ng-container matColumnDef="zone.upper">
           <mat-header-cell class="dataHeader" *matHeaderCellDef mat-sort-header>Upper</mat-header-cell>
-          <mat-cell class="dataCell" *matCellDef="let element" data-label="Upper: "> {{element.upper}} </mat-cell>
-        </ng-container> -->
+          <mat-cell class="dataCell" *matCellDef="let element" data-label="Upper: "> {{element.zone.upper}} </mat-cell>
+        </ng-container>
 
-        <!-- State Column -->
-        <!-- <ng-container matColumnDef="state">
-          <mat-header-cell class="dataHeader" *matHeaderCellDef mat-sort-header>State</mat-header-cell>
-          <mat-cell class="dataCell" *matCellDef="let element" data-label="State: ">
-            <div [ngSwitch]="element.state">
-              <div *ngSwitchCase="0">Normal</div>
-              <div *ngSwitchCase="1">Warning</div>
-              <div *ngSwitchCase="2">Alarm</div>
-            </div>
-          </mat-cell>
-        </ng-container> -->
-
-        <!-- Action Column -->
-        <!-- <ng-container matColumnDef="actions">
-          <mat-header-cell class="actionHeader" *matHeaderCellDef mat-sort-header>  </mat-header-cell>
-          <mat-cell class="actionCell" *matCellDef="let element">
-            <button mat-raised-button class="action-buttons" color="accent" (click)="openZoneDialog(element.uuid)">Edit</button>
-            <button mat-raised-button color="accent" (click)="deleteZone(element.uuid)">Delete</button>
-          </mat-cell>
-        </ng-container> -->
+        <!-- message Column -->
+        <ng-container matColumnDef="zone.message">
+          <mat-header-cell class="pathHeader" *matHeaderCellDef mat-sort-header>Message</mat-header-cell>
+          <mat-cell class="pathCell" *matCellDef="let element" data-label="Message: "> {{element.zone.message}} </mat-cell>
+        </ng-container>
 
         <!-- Table header -->
         <mat-header-row class="headerRow" *matHeaderRowDef="displayedColumns; sticky: true"></mat-header-row>
@@ -75,8 +59,4 @@
     <div class="paginator">
       <mat-paginator pageSize="5" [pageSizeOptions]="[5, 10, 25, 100]"></mat-paginator>
     </div>
-    <!-- <div class="formActionFooter">
-      <mat-divider class="formActionDivider"></mat-divider>
-      <button type="button" mat-raised-button color="accent" class="formActionButton" (click)="openZoneDialog()">Add</button>
-    </div> -->
 </div>

--- a/src/app/settings/zones/zones.component.ts
+++ b/src/app/settings/zones/zones.component.ts
@@ -34,7 +34,7 @@ export class SettingsZonesComponent implements OnInit, AfterViewInit, OnDestroy 
 
   tableData = new MatTableDataSource([]);
 
-  displayedColumns: string[] = ["path"];
+  displayedColumns: string[] = ["path", "zone.state", "zone.lower", "zone.upper", "zone.message"];
 
   zonesSub: Subscription;
 
@@ -47,10 +47,10 @@ export class SettingsZonesComponent implements OnInit, AfterViewInit, OnDestroy 
   ngOnInit() {
     this.zonesSub = this.data.startSkMetaFullTree().subscribe((metaArray: IPathMetaData[]) => {
       this.tableData.data = metaArray
-        .filter(meta => meta.meta && meta.meta.zones && meta.meta.zones.length > 0)
-        .map(meta => ({
-          path: meta.path,
-          zones: meta.meta.zones
+        .filter(item => item.meta && item.meta.zones && item.meta.zones.length > 0)
+        .flatMap(item => item.meta.zones.map(zone => {
+          const newItem = { path: item.path, zone: zone };
+          return newItem;
         }));
     });
   }

--- a/src/app/settings/zones/zones.component.ts
+++ b/src/app/settings/zones/zones.component.ts
@@ -8,7 +8,6 @@ import { MatSort, MatSortHeader } from '@angular/material/sort';
 
 import { AppSettingsService } from '../../core/services/app-settings.service';
 import { IPathMetaData } from "../../core/interfaces/app-interfaces";
-import { IZone } from "../../core/interfaces/app-settings.interfaces";
 import { UUID } from '../../utils/uuid';
 import { MatOption } from '@angular/material/core';
 import { MatSelect } from '@angular/material/select';
@@ -46,9 +45,9 @@ export class SettingsZonesComponent implements OnInit, AfterViewInit, OnDestroy 
     ) { }
 
   ngOnInit() {
-    this.zonesSub = this.appSettingsService.getZonesAsO().subscribe(zones => {
-      this.tableData.data = zones;
-    });
+    // this.zonesSub = this.appSettingsService.getZonesAsO().subscribe(zones => {
+    //   this.tableData.data = zones;
+    // });
   }
 
   ngAfterViewInit() {
@@ -58,7 +57,7 @@ export class SettingsZonesComponent implements OnInit, AfterViewInit, OnDestroy 
     this.cdRef.detectChanges();
   }
 
-  public trackByUuid(index: number, item: IZone): string {
+  public trackByUuid(index: number, item: any): string {
     return `${item.uuid}`;
   }
 
@@ -75,8 +74,8 @@ export class SettingsZonesComponent implements OnInit, AfterViewInit, OnDestroy 
     let dialogRef;
 
     if (uuid) {
-      const thisZone: IZone = cloneDeep(
-          this.tableData.data.find((zone: IZone) => {
+      const thisZone = cloneDeep(
+          this.tableData.data.find((zone) => {
           return zone.uuid === uuid;
           })
         );
@@ -91,7 +90,7 @@ export class SettingsZonesComponent implements OnInit, AfterViewInit, OnDestroy 
         });
     }
 
-    dialogRef.afterClosed().subscribe((zone: IZone) => {
+    dialogRef.afterClosed().subscribe((zone) => {
       if (zone === undefined || !zone) {
         return; //clicked Cancel, click outside the dialog, or navigated await from page using url bar.
       } else {
@@ -105,32 +104,32 @@ export class SettingsZonesComponent implements OnInit, AfterViewInit, OnDestroy 
     });
   }
 
-  public addZone(zone: IZone) {
-    let zones: IZone[] = this.appSettingsService.getZones();
-    zones.push(zone);
-    this.appSettingsService.saveZones(zones);
+  public addZone(zone: any) {
+    // let zones: [] = this.appSettingsService.getZones();
+    // zones.push(zone);
+    // this.appSettingsService.saveZones(zones);
   }
 
-  public editZone(zone: IZone) {
-    if (zone.uuid) { // is existing zone
-      const zones: IZone[] = this.appSettingsService.getZones();
-      const index = zones.findIndex(zones => zones.uuid === zone.uuid );
+  public editZone(zone) {
+    // if (zone.uuid) { // is existing zone
+    //   const zones: IZone[] = this.appSettingsService.getZones();
+    //   const index = zones.findIndex(zones => zones.uuid === zone.uuid );
 
-      if(index >= 0) {
-        zones.splice(index, 1, zone);
-        this.appSettingsService.saveZones(zones);
-      }
-    }
+    //   if(index >= 0) {
+    //     zones.splice(index, 1, zone);
+    //     this.appSettingsService.saveZones(zones);
+    //   }
+    // }
   }
 
   public deleteZone(uuid: string) {
-    let zones = this.appSettingsService.getZones();
-    //find index
-    let index = zones.findIndex(zone => zone.uuid === uuid);
-    if (index >= 0) {
-      zones.splice(index, 1);
-      this.appSettingsService.saveZones(zones);
-    }
+    // let zones = this.appSettingsService.getZones();
+    // //find index
+    // let index = zones.findIndex(zone => zone.uuid === uuid);
+    // if (index >= 0) {
+    //   zones.splice(index, 1);
+    //   this.appSettingsService.saveZones(zones);
+    // }
   }
 
   ngOnDestroy(): void {
@@ -184,7 +183,7 @@ export class DialogNewZone {
   }
 
   closeForm() {
-    let zone: IZone = {
+    let zone = {
       uuid: null,
       upper: this.zoneForm.get('upper').value,
       lower: this.zoneForm.get('lower').value,
@@ -209,7 +208,7 @@ export class DialogEditZone {
 
   constructor(
     public dialogRef: MatDialogRef<DialogEditZone>,
-    @Inject(MAT_DIALOG_DATA) public zone: IZone,
+    @Inject(MAT_DIALOG_DATA) public zone,
     ) { }
 
   closeForm() {

--- a/src/app/widget-config/dataset-chart-options/dataset-chart-options.component.ts
+++ b/src/app/widget-config/dataset-chart-options/dataset-chart-options.component.ts
@@ -4,7 +4,6 @@ import { ReactiveFormsModule, UntypedFormControl } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatSelectChange, MatSelectModule } from '@angular/material/select';
 import { DatasetService, IDatasetServiceDatasetConfig } from './../../core/services/data-set.service';
-import { SignalKDataService } from '../../core/services/data.service';
 import { IUnitGroup } from '../../core/services/units.service';
 
 @Component({
@@ -23,7 +22,6 @@ export class DatasetChartOptionsComponent implements OnInit {
 
   constructor(
     private datasetService: DatasetService,
-    private signalk: SignalKDataService,
     private units: UnitsService
   ) {}
 

--- a/src/app/widget-config/dataset-chart-options/dataset-chart-options.component.ts
+++ b/src/app/widget-config/dataset-chart-options/dataset-chart-options.component.ts
@@ -4,7 +4,7 @@ import { ReactiveFormsModule, UntypedFormControl } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatSelectChange, MatSelectModule } from '@angular/material/select';
 import { DatasetService, IDatasetServiceDatasetConfig } from './../../core/services/data-set.service';
-import { SignalKDataService } from './../../core/services/signalk-data.service';
+import { SignalKDataService } from '../../core/services/data.service';
 import { IUnitGroup } from '../../core/services/units.service';
 
 @Component({

--- a/src/app/widget-config/dataset-chart-options/dataset-chart-options.component.ts
+++ b/src/app/widget-config/dataset-chart-options/dataset-chart-options.component.ts
@@ -1,3 +1,4 @@
+import { UnitsService } from './../../core/services/units.service';
 import { Component, Input, OnInit } from '@angular/core';
 import { ReactiveFormsModule, UntypedFormControl } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -20,7 +21,11 @@ export class DatasetChartOptionsComponent implements OnInit {
   public availableDataSets: IDatasetServiceDatasetConfig[] = [];
   public unitList: {default?: string, conversions?: IUnitGroup[] } = {};
 
-  constructor(private datasetService: DatasetService, private signalk: SignalKDataService) {}
+  constructor(
+    private datasetService: DatasetService,
+    private signalk: SignalKDataService,
+    private units: UnitsService
+  ) {}
 
     ngOnInit(): void {
       this.availableDataSets = this.datasetService.list().sort();
@@ -35,9 +40,9 @@ export class DatasetChartOptionsComponent implements OnInit {
     private setPathUnits(uuid: string): void {
       this.convertUnitTo.enable();
       if (uuid) {
-        this.unitList = this.signalk.getConversionsForPath(this.datasetService.getDatasetConfig(uuid).path);
+        this.unitList = this.units.getConversionsForPath(this.datasetService.getDatasetConfig(uuid).path);
       } else {
-        this.unitList = this.signalk.getConversionsForPath('');
+        this.unitList = this.units.getConversionsForPath('');
       }
     }
 

--- a/src/app/widget-config/modal-widget-config/modal-widget-config.component.ts
+++ b/src/app/widget-config/modal-widget-config/modal-widget-config.component.ts
@@ -16,7 +16,7 @@ import { MatTabGroup, MatTab, MatTabLabel } from '@angular/material/tabs';
 import { BooleanMultiControlOptionsComponent } from '../boolean-multicontrol-options/boolean-multicontrol-options.component';
 import { DisplayChartOptionsComponent } from '../display-chart-options/display-chart-options.component';
 import { DatasetChartOptionsComponent } from '../dataset-chart-options/dataset-chart-options.component';
-import { IUnitGroup } from '../../core/services/units.service';
+import { IUnitGroup, UnitsService } from '../../core/services/units.service';
 import { SignalKDataService } from '../../core/services/signalk-data.service';
 import { DatasetService, IDatasetServiceDatasetConfig } from '../../core/services/data-set.service';
 import { IDynamicControl, IWidgetPath, IWidgetSvcConfig } from '../../core/interfaces/widgets-interface';
@@ -51,13 +51,13 @@ export class ModalWidgetConfigComponent implements OnInit {
     public dialogRef: MatDialogRef<ModalWidgetConfigComponent>,
     private fb : UntypedFormBuilder,
     private DatasetService: DatasetService,
-    private signalKDataService: SignalKDataService,
+    private units: UnitsService,
     @Inject(MAT_DIALOG_DATA) public widgetConfig: IWidgetSvcConfig
   ) { }
 
   ngOnInit() {
     this.availableDataSets = this.DatasetService.list().sort();
-    this.unitList = this.signalKDataService.getConversionsForPath(''); // array of Group or Groups: "angle", "speed", etc...
+    this.unitList = this.units.getConversionsForPath(''); // array of Group or Groups: "angle", "speed", etc...
     this.formMaster = this.generateFormGroups(this.widgetConfig);
     this.setFormOptions();
   }

--- a/src/app/widget-config/modal-widget-config/modal-widget-config.component.ts
+++ b/src/app/widget-config/modal-widget-config/modal-widget-config.component.ts
@@ -17,7 +17,6 @@ import { BooleanMultiControlOptionsComponent } from '../boolean-multicontrol-opt
 import { DisplayChartOptionsComponent } from '../display-chart-options/display-chart-options.component';
 import { DatasetChartOptionsComponent } from '../dataset-chart-options/dataset-chart-options.component';
 import { IUnitGroup, UnitsService } from '../../core/services/units.service';
-import { SignalKDataService } from '../../core/services/data.service';
 import { DatasetService, IDatasetServiceDatasetConfig } from '../../core/services/data-set.service';
 import { IDynamicControl, IWidgetPath, IWidgetSvcConfig } from '../../core/interfaces/widgets-interface';
 import { IAddNewPath, PathsOptionsComponent } from '../paths-options/paths-options.component';

--- a/src/app/widget-config/modal-widget-config/modal-widget-config.component.ts
+++ b/src/app/widget-config/modal-widget-config/modal-widget-config.component.ts
@@ -17,7 +17,7 @@ import { BooleanMultiControlOptionsComponent } from '../boolean-multicontrol-opt
 import { DisplayChartOptionsComponent } from '../display-chart-options/display-chart-options.component';
 import { DatasetChartOptionsComponent } from '../dataset-chart-options/dataset-chart-options.component';
 import { IUnitGroup, UnitsService } from '../../core/services/units.service';
-import { SignalKDataService } from '../../core/services/signalk-data.service';
+import { SignalKDataService } from '../../core/services/data.service';
 import { DatasetService, IDatasetServiceDatasetConfig } from '../../core/services/data-set.service';
 import { IDynamicControl, IWidgetPath, IWidgetSvcConfig } from '../../core/interfaces/widgets-interface';
 import { IAddNewPath, PathsOptionsComponent } from '../paths-options/paths-options.component';

--- a/src/app/widget-config/path-control-config/path-control-config.component.ts
+++ b/src/app/widget-config/path-control-config/path-control-config.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnInit, OnChanges, SimpleChange, OnDestroy } from '@angular/core';
-import { SignalKDataService } from '../../core/services/data.service';
+import { DataService } from '../../core/services/data.service';
 import { IPathMetaData } from "../../core/interfaces/app-interfaces";
 import { IUnitGroup, UnitsService } from '../../core/services/units.service';
 import { UntypedFormGroup, UntypedFormControl, Validators, ValidatorFn, AbstractControl, ValidationErrors, FormsModule, ReactiveFormsModule } from '@angular/forms';
@@ -42,7 +42,7 @@ export class ModalPathControlConfigComponent implements OnInit, OnChanges, OnDes
   public unitList: {default?: string, conversions?: IUnitGroup[] };
 
   constructor(
-    private signalKDataService: SignalKDataService,
+    private DataService: DataService,
     private units: UnitsService
     ) { }
 
@@ -97,7 +97,7 @@ export class ModalPathControlConfigComponent implements OnInit, OnChanges, OnDes
  }
 
   private getPaths(isOnlySef: boolean) {
-    this.availablePaths = this.signalKDataService.getPathsAndMetaByType(this.pathFormGroup.value.pathType, isOnlySef).sort();
+    this.availablePaths = this.DataService.getPathsAndMetaByType(this.pathFormGroup.value.pathType, isOnlySef).sort();
   }
 
   private filterPaths( value: string ): IPathMetaData[] {
@@ -114,7 +114,7 @@ export class ModalPathControlConfigComponent implements OnInit, OnChanges, OnDes
   }
 
   private enableFormFields(setValues?: boolean): void {
-    let pathObject = this.signalKDataService.getPathObject(this.pathFormGroup.controls['path'].value);
+    let pathObject = this.DataService.getPathObject(this.pathFormGroup.controls['path'].value);
     if (pathObject != null) {
       this.pathFormGroup.controls['sampleTime'].enable({onlySelf: true});
       if (this.pathFormGroup.controls['pathType'].value == 'number') { // convertUnitTo control not present unless pathType is number

--- a/src/app/widget-config/path-control-config/path-control-config.component.ts
+++ b/src/app/widget-config/path-control-config/path-control-config.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnInit, OnChanges, SimpleChange, OnDestroy } from '@angular/core';
 import { SignalKDataService } from '../../core/services/signalk-data.service';
 import { IPathMetaData } from "../../core/interfaces/app-interfaces";
-import { IUnitGroup } from '../../core/services/units.service';
+import { IUnitGroup, UnitsService } from '../../core/services/units.service';
 import { UntypedFormGroup, UntypedFormControl, Validators, ValidatorFn, AbstractControl, ValidationErrors, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { debounceTime, map, startWith } from 'rxjs/operators';
 import { Observable, Subscription } from 'rxjs'
@@ -42,7 +42,8 @@ export class ModalPathControlConfigComponent implements OnInit, OnChanges, OnDes
   public unitList: {default?: string, conversions?: IUnitGroup[] };
 
   constructor(
-    private signalKDataService: SignalKDataService
+    private signalKDataService: SignalKDataService,
+    private units: UnitsService
     ) { }
 
   ngOnInit() {
@@ -117,7 +118,7 @@ export class ModalPathControlConfigComponent implements OnInit, OnChanges, OnDes
     if (pathObject != null) {
       this.pathFormGroup.controls['sampleTime'].enable({onlySelf: true});
       if (this.pathFormGroup.controls['pathType'].value == 'number') { // convertUnitTo control not present unless pathType is number
-        this.unitList = this.signalKDataService.getConversionsForPath(this.pathFormGroup.controls['path'].value); // array of Group or Groups: "angle", "speed", etc...
+        this.unitList = this.units.getConversionsForPath(this.pathFormGroup.controls['path'].value); // array of Group or Groups: "angle", "speed", etc...
         if (setValues) {
           this.pathFormGroup.controls['convertUnitTo'].setValue(this.unitList.default, {onlySelf: true});
         }

--- a/src/app/widget-config/path-control-config/path-control-config.component.ts
+++ b/src/app/widget-config/path-control-config/path-control-config.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnInit, OnChanges, SimpleChange, OnDestroy } from '@angular/core';
-import { SignalKDataService } from '../../core/services/signalk-data.service';
+import { SignalKDataService } from '../../core/services/data.service';
 import { IPathMetaData } from "../../core/interfaces/app-interfaces";
 import { IUnitGroup, UnitsService } from '../../core/services/units.service';
 import { UntypedFormGroup, UntypedFormControl, Validators, ValidatorFn, AbstractControl, ValidationErrors, FormsModule, ReactiveFormsModule } from '@angular/forms';

--- a/src/app/widgets/gauge-steel/gauge-steel.component.ts
+++ b/src/app/widgets/gauge-steel/gauge-steel.component.ts
@@ -1,9 +1,9 @@
 import { UnitsService } from './../../core/services/units.service';
 import { Component, Input, AfterViewInit, OnChanges, SimpleChanges, ViewChild, ElementRef, OnDestroy, Renderer2 } from '@angular/core';
 import { ResizedEvent, AngularResizeEventModule } from 'angular-resize-event';
-import { IZone, IZoneState } from '../../core/interfaces/app-settings.interfaces';
 import { ITheme } from '../../core/interfaces/widgets-interface';
 import Qty from 'js-quantities';
+import { States } from '../../core/interfaces/signalk-interfaces';
 
 declare let steelseries: any; // 3rd party
 
@@ -59,7 +59,7 @@ export class GaugeSteelComponent implements AfterViewInit, OnChanges, OnDestroy 
   @Input('frameColor') frameColor: string;
   @Input('minValue') minValue: number;
   @Input('maxValue') maxValue: number;
-  @Input('zones') zones: IZone[];
+  @Input('zones') zones: Array<any>;
   @Input('title') title: string;
   @Input('units') units: string;
   @Input('value') value: number;
@@ -146,10 +146,10 @@ export class GaugeSteelComponent implements AfterViewInit, OnChanges, OnDestroy 
         upper = upper || this.maxValue;
         let color: string;
         switch (zone.state) {
-          case IZoneState.warning:
+          case States.Warn:
             color = this.theme.warn;
             break;
-          case IZoneState.alarm:
+          case States.Alarm:
             color = this.theme.warnDark;
             break;
           default:

--- a/src/app/widgets/widget-autopilot/widget-autopilot.component.ts
+++ b/src/app/widgets/widget-autopilot/widget-autopilot.component.ts
@@ -221,22 +221,22 @@ export class WidgetAutopilotComponent extends BaseWidgetComponent implements OnI
 
   startAllSubscriptions() {
     this.observeDataStream('apState', newValue => {
-        this.currentAPState = newValue.value;
+        this.currentAPState = newValue.data.value;
         this.SetKeyboardMode(this.currentAPState);
       }
     );
 
     this.observeDataStream('headingMag', newValue => {
-        if (newValue.value === null) {
+        if (newValue.data.value === null) {
           this.currentHeading = 0;
         } else {
-          this.currentHeading = newValue.value;
+          this.currentHeading = newValue.data.value;
         }
       }
     );
 
     this.observeDataStream('windAngleApparent', newValue => {
-        if (newValue.value === null) {
+        if (newValue.data.value === null) {
           this.currentAppWindAngle = null;
           return;
         }
@@ -244,28 +244,28 @@ export class WidgetAutopilotComponent extends BaseWidgetComponent implements OnI
         // -0 to -180 for port
         // need in 0-360
 
-        if (newValue.value < 0) {// stb
-          this.currentAppWindAngle = 360 + newValue.value; // adding a negative number subtracts it...
+        if (newValue.data.value < 0) {// stb
+          this.currentAppWindAngle = 360 + newValue.data.value; // adding a negative number subtracts it...
         } else {
-          this.currentAppWindAngle = newValue.value;
+          this.currentAppWindAngle = newValue.data.value;
         }
       }
     );
 
     this.observeDataStream('rudderAngle', newValue => {
-        if (newValue.value === null) {
+        if (newValue.data.value === null) {
           this.currentRudder = 0;
         } else {
-          this.currentRudder = newValue.value;
+          this.currentRudder = newValue.data.value;
         }
       }
     );
 
     this.observeDataStream('apTargetWindAngleApp', newValue => {
-        if (newValue.value === null) {
+        if (newValue.data.value === null) {
           this.currentAPTargetAppWind = 0;
         } else {
-          this.currentAPTargetAppWind = newValue.value;
+          this.currentAPTargetAppWind = newValue.data.value;
         }
       }
     );
@@ -286,9 +286,9 @@ export class WidgetAutopilotComponent extends BaseWidgetComponent implements OnI
     if (typeof(this.widgetProperties.config.paths['apNotifications'].path) != 'string') { return } // nothing to sub to...
     this.skApNotificationSub = this.DataService.subscribePath(this.widgetProperties.config.paths['apNotifications'].path, this.widgetProperties.config.paths['apNotifications'].source).subscribe(
       newValue => {
-          if (!newValue.value == null) {
-          this.setNotificationMessage(newValue.value);
-          console.log(newValue.value);
+          if (!newValue.data.value == null) {
+          this.setNotificationMessage(newValue.data.value);
+          console.log(newValue.data.value);
           }
         }
     );

--- a/src/app/widgets/widget-autopilot/widget-autopilot.component.ts
+++ b/src/app/widgets/widget-autopilot/widget-autopilot.component.ts
@@ -298,7 +298,7 @@ export class WidgetAutopilotComponent extends BaseWidgetComponent implements OnI
     if (this.skApNotificationSub !== null) {
       this.skApNotificationSub.unsubscribe();
       this.skApNotificationSub = null;
-      this.signalKDataService.unsubscribePath(this.widgetProperties.uuid, this.widgetProperties.config.paths['apNotifications'].path);
+      this.signalKDataService.unsubscribePath(this.widgetProperties.config.paths['apNotifications'].path);
     }
   }
 

--- a/src/app/widgets/widget-autopilot/widget-autopilot.component.ts
+++ b/src/app/widgets/widget-autopilot/widget-autopilot.component.ts
@@ -284,7 +284,7 @@ export class WidgetAutopilotComponent extends BaseWidgetComponent implements OnI
 
   subscribeAPNotification() {
     if (typeof(this.widgetProperties.config.paths['apNotifications'].path) != 'string') { return } // nothing to sub to...
-    this.skApNotificationSub = this.signalKDataService.subscribePath(this.widgetProperties.config.paths['apNotifications'].path, this.widgetProperties.config.paths['apNotifications'].source).subscribe(
+    this.skApNotificationSub = this.DataService.subscribePath(this.widgetProperties.config.paths['apNotifications'].path, this.widgetProperties.config.paths['apNotifications'].source).subscribe(
       newValue => {
           if (!newValue.value == null) {
           this.setNotificationMessage(newValue.value);
@@ -298,7 +298,7 @@ export class WidgetAutopilotComponent extends BaseWidgetComponent implements OnI
     if (this.skApNotificationSub !== null) {
       this.skApNotificationSub.unsubscribe();
       this.skApNotificationSub = null;
-      this.signalKDataService.unsubscribePath(this.widgetProperties.config.paths['apNotifications'].path);
+      this.DataService.unsubscribePath(this.widgetProperties.config.paths['apNotifications'].path);
     }
   }
 

--- a/src/app/widgets/widget-autopilot/widget-autopilot.component.ts
+++ b/src/app/widgets/widget-autopilot/widget-autopilot.component.ts
@@ -284,7 +284,7 @@ export class WidgetAutopilotComponent extends BaseWidgetComponent implements OnI
 
   subscribeAPNotification() {
     if (typeof(this.widgetProperties.config.paths['apNotifications'].path) != 'string') { return } // nothing to sub to...
-    this.skApNotificationSub = this.signalKDataService.subscribePath(this.widgetProperties.uuid, this.widgetProperties.config.paths['apNotifications'].path, this.widgetProperties.config.paths['apNotifications'].source).subscribe(
+    this.skApNotificationSub = this.signalKDataService.subscribePath(this.widgetProperties.config.paths['apNotifications'].path, this.widgetProperties.config.paths['apNotifications'].source).subscribe(
       newValue => {
           if (!newValue.value == null) {
           this.setNotificationMessage(newValue.value);

--- a/src/app/widgets/widget-boolean-switch/widget-boolean-switch.component.ts
+++ b/src/app/widgets/widget-boolean-switch/widget-boolean-switch.component.ts
@@ -72,7 +72,7 @@ export class WidgetBooleanSwitchComponent extends BaseWidgetComponent implements
       if (Object.prototype.hasOwnProperty.call(this.switchControls, key)) {
         const path = this.switchControls[key];
         this.observeDataStream(key, newValue => {
-            path.value = newValue.value;
+            path.value = newValue.data.value;
           }
         );
       }

--- a/src/app/widgets/widget-button/widget-button.component.ts
+++ b/src/app/widgets/widget-button/widget-button.component.ts
@@ -70,7 +70,7 @@ export class WidgetButtonComponent extends BaseWidgetComponent implements OnInit
     this.canvasButtonTxt = this.canvasBtnTxtElement.nativeElement.getContext('2d');
 
     this.observeDataStream('boolPath', newValue => {
-      this.state = newValue.value;
+      this.state = newValue.data.value;
       this.updateBtnCanvas();
       }
     );

--- a/src/app/widgets/widget-date-generic/widget-date-generic.component.ts
+++ b/src/app/widgets/widget-date-generic/widget-date-generic.component.ts
@@ -54,7 +54,7 @@ export class WidgetDateGenericComponent extends BaseWidgetComponent implements O
     this.validateConfig();
     this.getColors(this.widgetProperties.config.textColor);
     this.observeDataStream('gaugePath', newValue => {
-      this.dataValue = newValue.value;
+      this.dataValue = newValue.data.value;
       this.updateCanvas();
     });
 

--- a/src/app/widgets/widget-gauge-ng-linear/widget-gauge-ng-linear.component.ts
+++ b/src/app/widgets/widget-gauge-ng-linear/widget-gauge-ng-linear.component.ts
@@ -2,13 +2,13 @@ import { ViewChild, ElementRef, Component, OnInit, OnChanges, OnDestroy, SimpleC
 import { Subscription } from 'rxjs';
 import { ResizedEvent, AngularResizeEventModule } from 'angular-resize-event';
 
-import { IZone, IZoneState } from '../../core/interfaces/app-settings.interfaces';
 import { IDataHighlight } from '../../core/interfaces/widgets-interface';
 import { LinearGaugeOptions, LinearGauge, GaugesModule } from '@biacsics/ng-canvas-gauges';
 import { BaseWidgetComponent } from '../../base-widget/base-widget.component';
 import { AppSettingsService } from '../../core/services/app-settings.service';
 import { JsonPipe } from '@angular/common';
 import Qty from 'js-quantities';
+import { States } from '../../core/interfaces/signalk-interfaces';
 
 @Component({
     selector: 'app-widget-gauge-ng-linear',
@@ -31,7 +31,7 @@ export class WidgetGaugeNgLinearComponent extends BaseWidgetComponent implements
   public isGaugeVertical: Boolean = true;
 
   // Zones support
-  zones: Array<IZone> = [];
+  private zones = [];
   zonesSub: Subscription;
 
   constructor(private appSettingsService: AppSettingsService) {
@@ -77,10 +77,10 @@ export class WidgetGaugeNgLinearComponent extends BaseWidgetComponent implements
 
         // set colors for zone state
         switch (newValue.state) {
-          case IZoneState.warning:
+          case States.Warn:
             this.gaugeOptions.colorValueText = this.theme.warnDark;
             break;
-          case IZoneState.alarm:
+          case States.Alarm:
             this.gaugeOptions.colorValueText = this.theme.warnDark;
             break;
           default:
@@ -88,8 +88,6 @@ export class WidgetGaugeNgLinearComponent extends BaseWidgetComponent implements
         }
       }
     );
-
-    this.subscribeZones();
   }
 
   ngOnDestroy() {
@@ -103,14 +101,14 @@ export class WidgetGaugeNgLinearComponent extends BaseWidgetComponent implements
     }
   }
 
-  // Subscribe to Zones
-  subscribeZones() {
-    this.zonesSub = this.appSettingsService.getZonesAsO().subscribe(
-      zones => {
-        this.zones = zones;
-        this.updateGaugeConfig();
-      });
-  }
+  // TODO: fix for new meta zones
+  // subscribeZones() {
+  //   this.zonesSub = this.appSettingsService.getZonesAsO().subscribe(
+  //     zones => {
+  //       this.zones = zones;
+  //       this.updateGaugeConfig();
+  //     });
+  // }
 
   updateGaugeConfig(){
     let themePaletteColor = "";
@@ -190,10 +188,10 @@ export class WidgetGaugeNgLinearComponent extends BaseWidgetComponent implements
           upper = upper || this.widgetProperties.config.maxValue;
           let color: string;
           switch (zone.state) {
-            case IZoneState.warning:
+            case States.Warn:
               color = this.theme.warn;
               break;
-            case IZoneState.alarm:
+            case States.Alarm:
               color = this.theme.warnDark;
               break;
             default:

--- a/src/app/widgets/widget-gauge-ng-linear/widget-gauge-ng-linear.component.ts
+++ b/src/app/widgets/widget-gauge-ng-linear/widget-gauge-ng-linear.component.ts
@@ -67,9 +67,9 @@ export class WidgetGaugeNgLinearComponent extends BaseWidgetComponent implements
     this.validateConfig();
     this.setHighlights();
     this.observeDataStream('gaugePath', newValue => {
-      if (newValue.value === null) {newValue.value = 0}
+      if (newValue.data.value === null) {newValue.data.value = 0}
       let oldValue = this.dataValue;
-      let temp: any = this.formatWidgetNumberValue(newValue.value);
+      let temp: any = this.formatWidgetNumberValue(newValue.data.value);
 
       if (oldValue != (temp as number)) {
         this.dataValue = temp;

--- a/src/app/widgets/widget-gauge-ng-linear/widget-gauge-ng-linear.component.ts
+++ b/src/app/widgets/widget-gauge-ng-linear/widget-gauge-ng-linear.component.ts
@@ -7,7 +7,7 @@ import { LinearGaugeOptions, LinearGauge, GaugesModule } from '@biacsics/ng-canv
 import { BaseWidgetComponent } from '../../base-widget/base-widget.component';
 import { AppSettingsService } from '../../core/services/app-settings.service';
 import { JsonPipe } from '@angular/common';
-import { ISignalKMetadata, States } from '../../core/interfaces/signalk-interfaces';
+import { ISkMetadata, States } from '../../core/interfaces/signalk-interfaces';
 
 @Component({
     selector: 'app-widget-gauge-ng-linear',
@@ -30,7 +30,7 @@ export class WidgetGaugeNgLinearComponent extends BaseWidgetComponent implements
   public isGaugeVertical: Boolean = true;
 
   // Zones support
-  private meta: ISignalKMetadata = null;
+  private meta: ISkMetadata = null;
   private metaSub: Subscription;
 
   constructor(private appSettingsService: AppSettingsService) {
@@ -95,7 +95,7 @@ export class WidgetGaugeNgLinearComponent extends BaseWidgetComponent implements
       }
     );
 
-    this.metaSub = this.signalKDataService.getPathMeta(this.widgetProperties.config.paths['gaugePath'].path).subscribe((meta: ISignalKMetadata) => {
+    this.metaSub = this.DataService.getPathMeta(this.widgetProperties.config.paths['gaugePath'].path).subscribe((meta: ISkMetadata) => {
       if (meta) {
         this.meta = meta;
         meta.zones && this.setHighlights();

--- a/src/app/widgets/widget-gauge-ng-linear/widget-gauge-ng-linear.component.ts
+++ b/src/app/widgets/widget-gauge-ng-linear/widget-gauge-ng-linear.component.ts
@@ -112,47 +112,68 @@ export class WidgetGaugeNgLinearComponent extends BaseWidgetComponent implements
       this.gaugeOptions.highlightsWidth = 0;
     } else {
       const gaugeZonesHighligh: IDataHighlight = [];
-      this.meta.zones.forEach(zone => {
-          let lower: number = null;
-          let upper: number = null;
-          // Perform Units conversions on zone range
-          if (this.widgetProperties.config.paths["gaugePath"].convertUnitTo == "ratio") {
-            lower = zone.lower;
-            upper = zone.upper;
-          } else {
-            lower = this.unitsService.convertToUnit(this.widgetProperties.config.paths["gaugePath"].convertUnitTo, zone.lower);
-            upper = this.unitsService.convertToUnit(this.widgetProperties.config.paths["gaugePath"].convertUnitTo, zone.upper);
-          }
 
-          lower = lower || this.widgetProperties.config.minValue;
-          upper = upper || this.widgetProperties.config.maxValue;
-          let color: string;
-          switch (zone.state) {
-            case States.Emergency:
-              color = this.theme.warnDark;
-              break;
-            case States.Alarm:
-              color = this.theme.warnDark;
-              break;
-            case States.Warn:
-              color = this.theme.textWarnLight;
-              break;
-            case States.Alert:
-              color = this.theme.accentDark;
-              break;
-            case States.Nominal:
-              color = this.theme.primaryDark;
-              break;
-            default:
-              color = "rgba(0,0,0,0)";
-          }
+      // Sort zones based on lower value
+      const sortedZones = [...this.meta.zones].sort((a, b) => a.lower - b.lower);
 
+      for (const zone of sortedZones) {
+        let lower: number = null;
+        let upper: number = null;
+
+        let color: string;
+        switch (zone.state) {
+          case States.Emergency:
+            color = this.theme.warnDark;
+            break;
+          case States.Alarm:
+            color = this.theme.warnDark;
+            break;
+          case States.Warn:
+            color = this.theme.textWarnLight;
+            break;
+          case States.Alert:
+            color = this.theme.accentDark;
+            break;
+          case States.Nominal:
+            color = this.theme.primaryDark;
+            break;
+          default:
+            color = "rgba(0,0,0,0)";
+        }
+
+        // Perform Units conversions on zone range
+        if (this.widgetProperties.config.paths["gaugePath"].convertUnitTo == "ratio") {
+          lower = zone.lower;
+          upper = zone.upper;
+        } else {
+          lower = this.unitsService.convertToUnit(this.widgetProperties.config.paths["gaugePath"].convertUnitTo, zone.lower);
+          upper = this.unitsService.convertToUnit(this.widgetProperties.config.paths["gaugePath"].convertUnitTo, zone.upper);
+        }
+
+        // Skip zones that are completely outside the gauge range
+        if (upper < this.widgetProperties.config.minValue || lower > this.widgetProperties.config.maxValue) {
+          continue;
+        }
+
+        // If lower or upper are null, set them to minValue or maxValue
+        lower = lower !== null ? lower : this.widgetProperties.config.minValue;
+        upper = upper !== null ? upper : this.widgetProperties.config.maxValue;
+
+        // Ensure lower does not go below minValue
+        lower = Math.max(lower, this.widgetProperties.config.minValue);
+
+        // Ensure upper does not exceed maxValue
+        if (upper > this.widgetProperties.config.maxValue) {
+          upper = this.widgetProperties.config.maxValue;
           gaugeZonesHighligh.push({from: lower, to: upper, color: color});
-        // }
-      });
+          break;
+        }
+
+        gaugeZonesHighligh.push({from: lower, to: upper, color: color});
+      };
       //@ts-ignore - bug in highlights property definition
       this.gaugeOptions.highlights = JSON.stringify(gaugeZonesHighligh, null, 1);
-      this.gaugeOptions.highlightsWidth = 6;
+      this.gaugeOptions.highlightsWidth = 4;
     }
   }
 

--- a/src/app/widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component.ts
+++ b/src/app/widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component.ts
@@ -74,9 +74,9 @@ export class WidgetGaugeNgRadialComponent extends BaseWidgetComponent implements
     this.setHighlights();
 
     this.observeDataStream('gaugePath', newValue => {
-        if (newValue.value === null) {newValue.value = 0}
+        if (newValue.data.value === null) {newValue.data.value = 0}
         let oldValue = this.dataValue;
-        let temp: any = this.formatWidgetNumberValue(newValue.value);
+        let temp: any = this.formatWidgetNumberValue(newValue.data.value);
 
         if (oldValue != (temp as number)) {
           this.dataValue = temp;

--- a/src/app/widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component.ts
+++ b/src/app/widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component.ts
@@ -93,11 +93,7 @@ export class WidgetGaugeNgRadialComponent extends BaseWidgetComponent implements
             this.radialGauge.update(this.gaugeOptions);
             break;
           case States.Warn:
-            this.gaugeOptions.colorValueText = this.theme.warnDark;
-            this.radialGauge.update(this.gaugeOptions);
-            break;
-          case States.Alert:
-            this.gaugeOptions.colorValueText = this.theme.warnDark;
+            this.gaugeOptions.colorValueText = this.theme.textWarnLight;
             this.radialGauge.update(this.gaugeOptions);
             break;
           default:
@@ -411,7 +407,7 @@ export class WidgetGaugeNgRadialComponent extends BaseWidgetComponent implements
           let color: string;
           switch (zone.state) {
             case States.Emergency:
-              color = this.theme.textWarnDark;
+              color = this.theme.warnDark;
               break;
             case States.Alarm:
               color = this.theme.warnDark;

--- a/src/app/widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component.ts
+++ b/src/app/widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component.ts
@@ -6,7 +6,7 @@ import { IDataHighlight } from '../../core/interfaces/widgets-interface';
 import { GaugesModule, RadialGaugeOptions, RadialGauge } from '@biacsics/ng-canvas-gauges';
 import { AppSettingsService } from '../../core/services/app-settings.service';
 import { BaseWidgetComponent } from '../../base-widget/base-widget.component';
-import { ISignalKMetadata, States } from '../../core/interfaces/signalk-interfaces';
+import { ISkMetadata, States } from '../../core/interfaces/signalk-interfaces';
 
 @Component({
     selector: 'app-widget-gauge-ng-radial',
@@ -29,7 +29,7 @@ export class WidgetGaugeNgRadialComponent extends BaseWidgetComponent implements
   public unitName: string = null;
 
   // Zones support
-  private meta: ISignalKMetadata = null;
+  private meta: ISkMetadata = null;
   private metaSub: Subscription;
 
   constructor(private appSettingsService: AppSettingsService) {
@@ -102,7 +102,7 @@ export class WidgetGaugeNgRadialComponent extends BaseWidgetComponent implements
       }
     );
 
-    this.metaSub = this.signalKDataService.getPathMeta(this.widgetProperties.config.paths['gaugePath'].path).subscribe((meta: ISignalKMetadata) => {
+    this.metaSub = this.DataService.getPathMeta(this.widgetProperties.config.paths['gaugePath'].path).subscribe((meta: ISkMetadata) => {
       if (meta) {
         this.meta = meta;
         meta.zones && this.setHighlights();

--- a/src/app/widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component.ts
+++ b/src/app/widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component.ts
@@ -6,7 +6,7 @@ import { IDataHighlight } from '../../core/interfaces/widgets-interface';
 import { GaugesModule, RadialGaugeOptions, RadialGauge } from '@biacsics/ng-canvas-gauges';
 import { AppSettingsService } from '../../core/services/app-settings.service';
 import { BaseWidgetComponent } from '../../base-widget/base-widget.component';
-import { ISignalKMetadata, ISkZone, States } from '../../core/interfaces/signalk-interfaces';
+import { ISignalKMetadata, States } from '../../core/interfaces/signalk-interfaces';
 
 @Component({
     selector: 'app-widget-gauge-ng-radial',
@@ -81,8 +81,7 @@ export class WidgetGaugeNgRadialComponent extends BaseWidgetComponent implements
         if (oldValue != (temp as number)) {
           this.dataValue = temp;
         }
-        // TODO: Fix color to support all states
-        // set zone state colors
+        // Set value color: reduce color changes to only warn & alarm states else it too much flickering and not clean
         switch (newValue.state) {
           case States.Emergency:
             this.gaugeOptions.colorValueText = this.theme.warnDark;
@@ -103,7 +102,6 @@ export class WidgetGaugeNgRadialComponent extends BaseWidgetComponent implements
       }
     );
 
-    // TODO: Refactor to use new zones meta data
     this.metaSub = this.signalKDataService.getPathMeta(this.widgetProperties.config.paths['gaugePath'].path).subscribe((meta: ISignalKMetadata) => {
       if (meta) {
         this.meta = meta;

--- a/src/app/widgets/widget-gauge/widget-gauge.component.ts
+++ b/src/app/widgets/widget-gauge/widget-gauge.component.ts
@@ -54,10 +54,10 @@ export class WidgetGaugeComponent extends BaseWidgetComponent implements OnInit,
   ngOnInit() {
     this.validateConfig();
     this.observeDataStream('gaugePath', newValue => {
-        if (newValue.value == null) {
-          newValue.value = 0;
+        if (newValue.data.value == null) {
+          newValue.data.value = 0;
         }
-        this.dataValue = newValue.value
+        this.dataValue = newValue.data.value
       }
     );
 

--- a/src/app/widgets/widget-gauge/widget-gauge.component.ts
+++ b/src/app/widgets/widget-gauge/widget-gauge.component.ts
@@ -3,7 +3,6 @@ import { Component, OnInit, OnDestroy } from '@angular/core';
 import { BaseWidgetComponent } from '../../base-widget/base-widget.component';
 import { GaugeSteelComponent } from '../gauge-steel/gauge-steel.component';
 import { Subscription } from 'rxjs';
-import { IZone } from '../../core/interfaces/app-settings.interfaces';
 
 @Component({
     selector: 'app-widget-gauge',
@@ -15,7 +14,7 @@ import { IZone } from '../../core/interfaces/app-settings.interfaces';
 export class WidgetGaugeComponent extends BaseWidgetComponent implements OnInit, OnDestroy {
   dataValue: any = 0;
   private zonesSub: Subscription = null;
-  public zones: Array<IZone> = [];
+  public zones = [];
 
   constructor(private settings: AppSettingsService) {
     super();
@@ -57,17 +56,19 @@ export class WidgetGaugeComponent extends BaseWidgetComponent implements OnInit,
       }
     );
 
-    this.zonesSub = this.settings.getZonesAsO().subscribe(
-      zones => {
-        let myZones: IZone[] = [];
-        zones.forEach(zone => {
-          // get zones for our path
-          if (zone.path == this.widgetProperties.config.paths["gaugePath"].path) {
-            myZones.push(zone);
-          }
-        })
-        this.zones = myZones;
-      });
+
+    // TODO: fix for new meta zones
+    // this.zonesSub = this.settings.getZonesAsO().subscribe(
+    //   zones => {
+    //     let myZones: IZone[] = [];
+    //     zones.forEach(zone => {
+    //       // get zones for our path
+    //       if (zone.path == this.widgetProperties.config.paths["gaugePath"].path) {
+    //         myZones.push(zone);
+    //       }
+    //     })
+    //     this.zones = myZones;
+    //   });
   }
 
   ngOnDestroy() {

--- a/src/app/widgets/widget-gauge/widget-gauge.component.ts
+++ b/src/app/widgets/widget-gauge/widget-gauge.component.ts
@@ -3,6 +3,7 @@ import { Component, OnInit, OnDestroy } from '@angular/core';
 import { BaseWidgetComponent } from '../../base-widget/base-widget.component';
 import { GaugeSteelComponent } from '../gauge-steel/gauge-steel.component';
 import { Subscription } from 'rxjs';
+import { ISignalKMetadata } from '../../core/interfaces/signalk-interfaces';
 
 @Component({
     selector: 'app-widget-gauge',
@@ -13,8 +14,12 @@ import { Subscription } from 'rxjs';
 })
 export class WidgetGaugeComponent extends BaseWidgetComponent implements OnInit, OnDestroy {
   dataValue: any = 0;
-  private zonesSub: Subscription = null;
+
   public zones = [];
+
+  // Zones support
+  private meta: ISignalKMetadata = null;
+  private metaSub: Subscription;
 
   constructor(private settings: AppSettingsService) {
     super();
@@ -56,23 +61,18 @@ export class WidgetGaugeComponent extends BaseWidgetComponent implements OnInit,
       }
     );
 
-
-    // TODO: fix for new meta zones
-    // this.zonesSub = this.settings.getZonesAsO().subscribe(
-    //   zones => {
-    //     let myZones: IZone[] = [];
-    //     zones.forEach(zone => {
-    //       // get zones for our path
-    //       if (zone.path == this.widgetProperties.config.paths["gaugePath"].path) {
-    //         myZones.push(zone);
-    //       }
-    //     })
-    //     this.zones = myZones;
-    //   });
+    this.metaSub = this.signalKDataService.getPathMeta(this.widgetProperties.config.paths['gaugePath'].path).subscribe((meta: ISignalKMetadata) => {
+      if (meta) {
+        this.meta = meta;
+        meta.zones && meta.zones?.forEach(zone => {
+          this.zones.push(zone);
+        });
+      }
+    });
   }
 
   ngOnDestroy() {
     this.unsubscribeDataStream();
-    this.zonesSub?.unsubscribe();
+    this.metaSub?.unsubscribe();
   }
 }

--- a/src/app/widgets/widget-gauge/widget-gauge.component.ts
+++ b/src/app/widgets/widget-gauge/widget-gauge.component.ts
@@ -3,7 +3,7 @@ import { Component, OnInit, OnDestroy } from '@angular/core';
 import { BaseWidgetComponent } from '../../base-widget/base-widget.component';
 import { GaugeSteelComponent } from '../gauge-steel/gauge-steel.component';
 import { Subscription } from 'rxjs';
-import { ISignalKMetadata } from '../../core/interfaces/signalk-interfaces';
+import { ISkMetadata } from '../../core/interfaces/signalk-interfaces';
 
 @Component({
     selector: 'app-widget-gauge',
@@ -18,7 +18,7 @@ export class WidgetGaugeComponent extends BaseWidgetComponent implements OnInit,
   public zones = [];
 
   // Zones support
-  private meta: ISignalKMetadata = null;
+  private meta: ISkMetadata = null;
   private metaSub: Subscription;
 
   constructor(private settings: AppSettingsService) {
@@ -61,7 +61,7 @@ export class WidgetGaugeComponent extends BaseWidgetComponent implements OnInit,
       }
     );
 
-    this.metaSub = this.signalKDataService.getPathMeta(this.widgetProperties.config.paths['gaugePath'].path).subscribe((meta: ISignalKMetadata) => {
+    this.metaSub = this.DataService.getPathMeta(this.widgetProperties.config.paths['gaugePath'].path).subscribe((meta: ISkMetadata) => {
       if (meta) {
         this.meta = meta;
         meta.zones && meta.zones?.forEach(zone => {

--- a/src/app/widgets/widget-numeric/widget-numeric.component.ts
+++ b/src/app/widgets/widget-numeric/widget-numeric.component.ts
@@ -68,7 +68,7 @@ export class WidgetNumericComponent extends BaseWidgetComponent implements OnIni
     this.canvasBGCtx = this.canvasBG.nativeElement.getContext('2d');
     this.getColors(this.widgetProperties.config.textColor);
     this.observeDataStream('numericPath', newValue => {
-        this.dataValue = newValue.value;
+        this.dataValue = newValue.data.value;
         // init min/max
         if (this.minValue === null) { this.minValue = this.dataValue; }
         if (this.maxValue === null) { this.maxValue = this.dataValue; }

--- a/src/app/widgets/widget-numeric/widget-numeric.component.ts
+++ b/src/app/widgets/widget-numeric/widget-numeric.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, OnDestroy, ViewChild, ElementRef, AfterViewChecked } from '@angular/core';
 
-import { IZoneState } from "../../core/interfaces/app-settings.interfaces";
 import { BaseWidgetComponent } from '../../base-widget/base-widget.component';
+import { States } from '../../core/interfaces/signalk-interfaces';
 
 @Component({
     selector: 'app-widget-numeric',
@@ -17,7 +17,6 @@ export class WidgetNumericComponent extends BaseWidgetComponent implements OnIni
 
 
   dataValue: number = null;
-  IZoneState: IZoneState = null;
   maxValue: number = null;
   minValue: number = null;
   labelColor: string = undefined;
@@ -29,6 +28,7 @@ export class WidgetNumericComponent extends BaseWidgetComponent implements OnIni
   minMaxFontSize: number = 1;
   flashOn: boolean = false;
   flashInterval = null;
+  dataState: string = States.Normal;
 
   canvasValCtx: CanvasRenderingContext2D;
   canvasMMCtx: CanvasRenderingContext2D;
@@ -75,19 +75,17 @@ export class WidgetNumericComponent extends BaseWidgetComponent implements OnIni
         if (this.dataValue > this.maxValue) { this.maxValue = this.dataValue; }
         if (this.dataValue < this.minValue) { this.minValue = this.dataValue; }
 
-        this.IZoneState = newValue.state;
-
         //start flashing if alarm
-        if ((this.IZoneState == IZoneState.alarm || this.IZoneState == IZoneState.warning) && !this.flashInterval) {
+        if ((newValue.state == States.Alarm || newValue.state == States.Warn) && !this.flashInterval) {
           this.flashInterval = setInterval(() => {
             this.flashOn = !this.flashOn;
             this.updateCanvas();
           }, 350); // used to flash stuff in alarm
-        } else if (this.IZoneState == IZoneState.normal) {
+        } else if (newValue.state == States.Normal) {
           // stop alarming if not in alarm state
           clearInterval(this.flashInterval);
         }
-
+        this.dataState = newValue.state;
         this.updateCanvas();
       }
     );
@@ -221,8 +219,8 @@ export class WidgetNumericComponent extends BaseWidgetComponent implements OnIni
     }
 
     // get color based on zone
-    switch (this.IZoneState) {
-      case IZoneState.alarm:
+    switch (this.dataState) {
+      case States.Alarm:
         if (this.flashOn) {
           this.canvasValCtx.fillStyle = this.valueColor;
         } else {
@@ -233,7 +231,7 @@ export class WidgetNumericComponent extends BaseWidgetComponent implements OnIni
         }
         break;
 
-      case IZoneState.warning:
+      case States.Warn:
         if (this.flashOn) {
           this.canvasValCtx.fillStyle = this.valueColor;
         } else {

--- a/src/app/widgets/widget-race-timer/widget-race-timer.component.ts
+++ b/src/app/widgets/widget-race-timer/widget-race-timer.component.ts
@@ -2,9 +2,9 @@ import { Component, OnInit, OnDestroy,ViewChild, ElementRef } from '@angular/cor
 import { Subscription } from 'rxjs';
 import { ResizedEvent, AngularResizeEventModule } from 'angular-resize-event';
 
-import { TimersService } from '../../core/services/timers.service';
-import { IZoneState } from "../../core/interfaces/app-settings.interfaces";
 import { BaseWidgetComponent } from '../../base-widget/base-widget.component';
+import { TimersService } from '../../core/services/timers.service';
+import { States } from '../../core/interfaces/signalk-interfaces';
 import { NgIf } from '@angular/common';
 import { MatButton } from '@angular/material/button';
 
@@ -20,7 +20,7 @@ export class WidgetRaceTimerComponent extends BaseWidgetComponent implements OnI
   @ViewChild('canvasBG', {static: true, read: ElementRef}) canvasBG: ElementRef;
 
   dataValue: number = null;
-  IZoneState: IZoneState = null;
+  zoneState: string = null;
   currentValueLength: number = 0; // length (in characters) of value text to be displayed. if changed from last time, need to recalculate font size...
   valueFontSize: number = 1;
   flashOn: boolean = false;
@@ -84,22 +84,22 @@ export class WidgetRaceTimerComponent extends BaseWidgetComponent implements OnI
         this.dataValue = newValue;
 
         if (newValue > 0) {
-          this.IZoneState = IZoneState.normal;
+          this.zoneState = States.Normal;
         } else if (newValue > -100) {
-          this.IZoneState = IZoneState.alarm;
+          this.zoneState = States.Alarm;
         } else if (newValue > -300) {
-          this.IZoneState = IZoneState.warning;
+          this.zoneState =States.Warn;
         } else {
-          this.IZoneState = IZoneState.normal;
+          this.zoneState = States.Normal;
         }
 
        //start flashing if alarm
-       if (this.IZoneState == IZoneState.alarm && !this.flashInterval) {
+       if (this.zoneState == States.Alarm && !this.flashInterval) {
         this.flashInterval = setInterval(() => {
           this.flashOn = !this.flashOn;
           this.updateCanvas();
         }, 500); // used to flash stuff in alarm
-      } else if (this.IZoneState != IZoneState.alarm) {
+      } else if (this.zoneState != States.Alarm) {
         // stop alarming if not in alarm state
         clearInterval(this.flashInterval);
       }
@@ -268,8 +268,8 @@ export class WidgetRaceTimerComponent extends BaseWidgetComponent implements OnI
     }
 
     // get color based on zone
-    switch (this.IZoneState) {
-      case IZoneState.alarm:
+    switch (this.zoneState) {
+      case States.Alarm:
 
         if (this.flashOn) {
           this.canvasCtx.fillStyle = this.textColor;
@@ -282,7 +282,7 @@ export class WidgetRaceTimerComponent extends BaseWidgetComponent implements OnI
         }
         break;
 
-      case IZoneState.warning:
+      case States.Warn:
         this.canvasCtx.fillStyle = this.warnColor;
         break;
 

--- a/src/app/widgets/widget-simple-linear/widget-simple-linear.component.ts
+++ b/src/app/widgets/widget-simple-linear/widget-simple-linear.component.ts
@@ -50,24 +50,25 @@ export class WidgetSimpleLinearComponent extends BaseWidgetComponent implements 
     this.validateConfig();
     // set Units label sting based on gauge config
     if (this.widgetProperties.config.gaugeUnitLabelFormat == "abr") {
-      //  TODO: Improve Units service to have Full Measure label, abbreviation and descriptions so that we can use Full or abr display labels...!
+      //TODO: Improve Units service to have Full Measure label, abbreviation and descriptions so that we can use Full or abr display labels...!
+      //TODO: Add zones support to widget
       this.unitsLabel = this.widgetProperties.config.paths['gaugePath'].convertUnitTo.substr(0,1);
     } else {
       this.unitsLabel = this.widgetProperties.config.paths['gaugePath'].convertUnitTo;
     }
 
     this.observeDataStream('gaugePath', newValue => {
-        if (newValue.value == null) {
-          newValue.value = 0;
+        if (newValue.data.value == null) {
+          newValue.data.value = 0;
         }
 
-        newValue.value = this.formatWidgetNumberValue(newValue.value);
-        this.dataValue = (newValue.value as number);
+        newValue.data.value = this.formatWidgetNumberValue(newValue.data.value);
+        this.dataValue = (newValue.data.value as number);
         // Format Widget display label value using settings
         if (this.widgetProperties.config.numDecimal != 0){
-          this.dataLabelValue = newValue.value.padStart((this.widgetProperties.config.numInt + 1 + this.widgetProperties.config.numDecimal), "0");
+          this.dataLabelValue = newValue.data.value.padStart((this.widgetProperties.config.numInt + 1 + this.widgetProperties.config.numDecimal), "0");
         } else {
-          this.dataLabelValue = newValue.value.padStart(this.widgetProperties.config.numInt, "0");
+          this.dataLabelValue = newValue.data.value.padStart(this.widgetProperties.config.numInt, "0");
         }
       }
     );

--- a/src/app/widgets/widget-text-generic/widget-text-generic.component.ts
+++ b/src/app/widgets/widget-text-generic/widget-text-generic.component.ts
@@ -52,7 +52,7 @@ export class WidgetTextGenericComponent extends BaseWidgetComponent implements O
     this.resizeWidget();
 
     this.observeDataStream('stringPath', newValue => {
-      this.dataValue = newValue.value;
+      this.dataValue = newValue.data.value;
       this.updateCanvas();
     });
   }

--- a/src/app/widgets/widget-wind/widget-wind.component.ts
+++ b/src/app/widgets/widget-wind/widget-wind.component.ts
@@ -113,57 +113,57 @@ export class WidgetWindComponent extends BaseWidgetComponent implements OnInit, 
   ngOnInit(): void {
     this.validateConfig();
     this.observeDataStream('headingPath', newValue => {
-      if (newValue.value == null) { // act upon data timeout of null
-        newValue.value = 0
+      if (newValue.data.value == null) { // act upon data timeout of null
+        newValue.data.value = 0
       }
-      this.currentHeading = newValue.value;
+      this.currentHeading = newValue.data.value;
     });
 
     this.observeDataStream('courseOverGround', newValue => {
-      if (newValue.value == null) { // act upon data timeout of null
-        newValue.value = 0
+      if (newValue.data.value == null) { // act upon data timeout of null
+        newValue.data.value = 0
       }
-      this.courseOverGroundAngle = newValue.value;
+      this.courseOverGroundAngle = newValue.data.value;
     });
 
     this.observeDataStream('nextWaypointBearing', newValue => {
-      if (newValue.value < 0) {// stb
-        this.waypointAngle = 360 + newValue.value; // adding a negative number subtracts it...
+      if (newValue.data.value < 0) {// stb
+        this.waypointAngle = 360 + newValue.data.value; // adding a negative number subtracts it...
       } else {
-        this.waypointAngle = newValue.value;
+        this.waypointAngle = newValue.data.value;
       }
     }
   );
 
     this.observeDataStream('appWindAngle', newValue => {
-        if (newValue.value == null) { // act upon data timeout of null
-          newValue.value = 0
+        if (newValue.data.value == null) { // act upon data timeout of null
+          newValue.data.value = 0
         }
-        if (newValue.value < 0) {// stb
-          this.appWindAngle = 360 + newValue.value; // adding a negative number subtracts it...
+        if (newValue.data.value < 0) {// stb
+          this.appWindAngle = 360 + newValue.data.value; // adding a negative number subtracts it...
         } else {
-          this.appWindAngle = newValue.value;
+          this.appWindAngle = newValue.data.value;
         }
       }
     );
 
     this.observeDataStream('appWindSpeed', newValue => {
-      if (newValue.value == null) { // act upon data timeout of null
-        newValue.value = 0
+      if (newValue.data.value == null) { // act upon data timeout of null
+        newValue.data.value = 0
       }
-      this.appWindSpeed = newValue.value;
+      this.appWindSpeed = newValue.data.value;
     });
 
     this.observeDataStream('trueWindSpeed', newValue => {
-      if (newValue.value == null) { // act upon data timeout of null
-        newValue.value = 0
+      if (newValue.data.value == null) { // act upon data timeout of null
+        newValue.data.value = 0
       }
-      this.trueWindSpeed = newValue.value;
+      this.trueWindSpeed = newValue.data.value;
     });
 
     this.observeDataStream('trueWindAngle', newValue => {
-      if (newValue.value == null) { // act upon data timeout of null
-        newValue.value = 0
+      if (newValue.data.value == null) { // act upon data timeout of null
+        newValue.data.value = 0
       }
         // Depending on path, this number can either be the magnetic compass heading, true compass heading, or heading relative to boat heading (-180 to 180deg)... Ugh...
           // 0-180+ for stb
@@ -172,13 +172,13 @@ export class WidgetWindComponent extends BaseWidgetComponent implements OnInit, 
         if (this.widgetProperties.config.paths['trueWindAngle'].path.match('angleTrueWater')||
         this.widgetProperties.config.paths['trueWindAngle'].path.match('angleTrueGround')) {
           //-180 to 180
-          this.trueWindAngle = this.addHeading(this.currentHeading, newValue.value);
+          this.trueWindAngle = this.addHeading(this.currentHeading, newValue.data.value);
         } else if (this.widgetProperties.config.paths['trueWindAngle'].path.match('direction')) {
           //0-360
-          this.trueWindAngle = newValue.value;
+          this.trueWindAngle = newValue.data.value;
         } else {
           // some other path... assume it's the angle
-          this.trueWindAngle = newValue.value;
+          this.trueWindAngle = newValue.data.value;
         }
 
         //add to historical for wind sectors

--- a/src/default-config/config.blank.const.ts
+++ b/src/default-config/config.blank.const.ts
@@ -1,4 +1,4 @@
-import { IConfig ,IAppConfig, IConnectionConfig, ILayoutConfig, IThemeConfig, IWidgetConfig, IZonesConfig } from "../app/core/interfaces/app-settings.interfaces"
+import { IConfig ,IAppConfig, IConnectionConfig, ILayoutConfig, IThemeConfig, IWidgetConfig } from "../app/core/interfaces/app-settings.interfaces"
 import { DefaultNotificationConfig } from './config.blank.notification.const';
 import { DefaultUnitsConfig } from "./config.blank.units.const";
 import { UUID } from "../app/utils/uuid";
@@ -44,16 +44,11 @@ export const DefaultThemeConfig: IThemeConfig = {
   "themeName": "modern-dark"
 }
 
-export const DefaultZonesConfig: IZonesConfig = {
-  "zones": [],
-}
-
 export const defaultConfig: IConfig = {
   "app": DefaultAppConfig,
   "widget": DefaultWidgetConfig,
   "layout": DefaultLayoutConfig,
-  "theme": DefaultThemeConfig,
-  "zones": DefaultZonesConfig,
+  "theme": DefaultThemeConfig
 }
 
 export const DefaultConnectionConfig: IConnectionConfig = {

--- a/src/default-config/config.blank.notification.const.ts
+++ b/src/default-config/config.blank.notification.const.ts
@@ -13,7 +13,7 @@ export const DefaultNotificationConfig = {
     "disableSound": false,
     "muteNormal": true,
     "muteNominal": true,
-    "muteWarning": false,
+    "muteWarn": true,
     "muteAlert": false,
     "muteAlarm": false,
     "muteEmergency": false,

--- a/src/default-config/config.blank.notification.const.ts
+++ b/src/default-config/config.blank.notification.const.ts
@@ -7,10 +7,12 @@ export const DefaultNotificationConfig = {
   "devices": {
     "disableDevices": false,
     "showNormalState": false,
+    "showNominalState": false,
   },
   "sound": {
     "disableSound": false,
-    "muteNormal": false,
+    "muteNormal": true,
+    "muteNominal": true,
     "muteWarning": false,
     "muteAlert": false,
     "muteAlarm": false,

--- a/src/default-config/config.demo.const.ts
+++ b/src/default-config/config.demo.const.ts
@@ -1,4 +1,4 @@
-import { IConfig, IAppConfig, IConnectionConfig, IThemeConfig, ILayoutConfig, IWidgetConfig, IZonesConfig } from "../app/core/interfaces/app-settings.interfaces"
+import { IConfig, IAppConfig, IConnectionConfig, IThemeConfig, ILayoutConfig, IWidgetConfig } from "../app/core/interfaces/app-settings.interfaces"
 import { UUID } from "../app/utils/uuid"
 
 // Demo Mode config settings file
@@ -618,16 +618,11 @@ export const DemoThemeConfig: IThemeConfig = {
   "themeName": "modern-dark"
 }
 
-export const DemoZonesConfig: IZonesConfig = {
-  "zones": [],
-}
-
 export const DemoConfig: IConfig = {
   "app": DemoAppConfig,
   "widget": DemoWidgetConfig,
   "layout": DemoLayoutConfig,
   "theme": DemoThemeConfig,
-  "zones": DemoZonesConfig,
 }
 
 export const DemoConnectionConfig: IConnectionConfig = {

--- a/src/default-config/config.demo.const.ts
+++ b/src/default-config/config.demo.const.ts
@@ -51,7 +51,7 @@ export const DemoAppConfig: IAppConfig = {
       "disableSound": false,
       "muteNormal": true,
       "muteNominal": true,
-      "muteWarning": false,
+      "muteWarn": true,
       "muteAlert": false,
       "muteAlarm": false,
       "muteEmergency": false,

--- a/src/default-config/config.demo.const.ts
+++ b/src/default-config/config.demo.const.ts
@@ -45,10 +45,12 @@ export const DemoAppConfig: IAppConfig = {
     "devices": {
       "disableDevices": false,
       "showNormalState": false,
+      "showNominalState": false,
     },
     "sound": {
       "disableSound": false,
-      "muteNormal": false,
+      "muteNormal": true,
+      "muteNominal": true,
       "muteWarning": false,
       "muteAlert": false,
       "muteAlarm": false,

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,7 +44,7 @@ import { LayoutSplitsService } from './app/core/services/layout-splits.service';
 import { DatasetService } from './app/core/services/data-set.service';
 import { SignalKDeltaService } from './app/core/services/signalk-delta.service';
 import { SignalKConnectionService } from './app/core/services/signalk-connection.service';
-import { SignalKDataService } from './app/core/services/signalk-data.service';
+import { SignalKDataService } from './app/core/services/data.service';
 import { AuthenticationService } from './app/core/services/authentication.service';
 import { MAT_FORM_FIELD_DEFAULT_OPTIONS } from '@angular/material/form-field';
 import { MAT_DIALOG_DEFAULT_OPTIONS, MatDialogModule } from '@angular/material/dialog';

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,7 +44,7 @@ import { LayoutSplitsService } from './app/core/services/layout-splits.service';
 import { DatasetService } from './app/core/services/data-set.service';
 import { SignalKDeltaService } from './app/core/services/signalk-delta.service';
 import { SignalKConnectionService } from './app/core/services/signalk-connection.service';
-import { SignalKDataService } from './app/core/services/data.service';
+import { DataService } from './app/core/services/data.service';
 import { AuthenticationService } from './app/core/services/authentication.service';
 import { MAT_FORM_FIELD_DEFAULT_OPTIONS } from '@angular/material/form-field';
 import { MAT_DIALOG_DEFAULT_OPTIONS, MatDialogModule } from '@angular/material/dialog';
@@ -179,7 +179,7 @@ bootstrapApplication(AppComponent, {
       },
     },
     AuthenticationService,
-    SignalKDataService,
+    DataService,
     SignalKConnectionService,
     SignalKDeltaService,
     DatasetService,


### PR DESCRIPTION
Major refactoring. Retires local KIP zones in favor of SK defined Zones. Using Zones now requires using the Edit zones SK plugin for zones definition (for the time being - until we can delete SK meta keys).

New Notification service and Menu now supports silencing and clearing SK server notifications for improved integration.

Simplified Zones Settings panel (for the time being).

Gauges now support 4 zone colors.

Path value subjects now emits path: value, timestamp and data state for simpler Gauge integration.

Many delta and data service processing improvements and general performance optimyzations.