### PR TITLE
Godind/issue408

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mxtommy/kip",
-  "version": "2.10.1",
+  "version": "2.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mxtommy/kip",
-      "version": "2.10.1",
+      "version": "2.11.0",
       "license": "MIT",
       "devDependencies": {
         "@angular-devkit/build-angular": "^17.3.4",

--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -337,7 +337,7 @@ export class DataService implements OnDestroy {
           path: metaPath,
           pathValue: undefined,
           pathTimestamp: undefined,
-          type: undefined,
+          type: meta.meta.units ? "number" : undefined,
           state: States.Normal,
           defaultSource: undefined,
           sources: {},

--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -345,6 +345,9 @@ export class DataService implements OnDestroy {
         };
         this._skData.push(pathObject);
       } else {
+        if (pathObject.type === 'object' && meta.meta.units) {
+          pathObject.type = "number";
+        }
         pathObject.meta = merge(pathObject.meta, meta.meta);
       }
 


### PR DESCRIPTION
Fixes issue #408
If meta delta is received before path values and meta unit is defined, set path type to numeric. If meta unit is received after path values and path type is object and meta unit is defined, this means the value received was null, update the path type to numeric.

This fix will not work if numeric path have defined meta units.