### PR TITLE
Makes ng-gauge highlights width configurable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mxtommy/kip",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mxtommy/kip",
-      "version": "2.12.0",
+      "version": "2.12.1",
       "license": "MIT",
       "devDependencies": {
         "@angular-devkit/build-angular": "^17.3.4",

--- a/src/app/core/interfaces/widgets-interface.ts
+++ b/src/app/core/interfaces/widgets-interface.ts
@@ -143,6 +143,8 @@ export interface IWidgetSvcConfig {
     rotateFace?: boolean;
     /** Optional. GaugeSteel digital or bar */
     digitalMeter?: boolean;
+    /** Optional. Width of gauge highlights */
+    highlightsWidth?: number;
   }
   /** Used by numeric data Widget: Display minimum registered value since started */
   showMin?: boolean;

--- a/src/app/widget-config/modal-widget-config/modal-widget-config.component.html
+++ b/src/app/widget-config/modal-widget-config/modal-widget-config.component.html
@@ -168,6 +168,10 @@
                       <mat-option value="capacity">Capacity</mat-option>
                     </mat-select>
                   </mat-form-field>
+                  <mat-form-field formGroupName="gauge" class="options-grid-span2">
+                    <mat-label>Highlights Width</mat-label>
+                    <input type="number" min="0" max="25" matInput placeholder="Enter or select number..." name="highlightsWidth" formControlName="highlightsWidth" required>
+                  </mat-form-field>
 
               }
             }

--- a/src/app/widget-config/modal-widget-config/modal-widget-config.component.html
+++ b/src/app/widget-config/modal-widget-config/modal-widget-config.component.html
@@ -157,7 +157,6 @@
                   </mat-checkbox>
                 </div>
               } @else if ( ['measuring','capacity'].indexOf(formMaster.value.gauge.subType) > -1 ) {
-
                   <mat-form-field formGroupName="gauge" class="options-grid-span2">
                     <mat-label>Gauge Type</mat-label>
                     <mat-select
@@ -172,7 +171,6 @@
                     <mat-label>Highlights Width</mat-label>
                     <input type="number" min="0" max="25" matInput placeholder="Enter or select number..." name="highlightsWidth" formControlName="highlightsWidth" required>
                   </mat-form-field>
-
               }
             }
 
@@ -186,6 +184,10 @@
                     <mat-option value="vertical">Vertical</mat-option>
                     <mat-option value="horizontal">Horizontal</mat-option>
                 </mat-select>
+              </mat-form-field>
+              <mat-form-field formGroupName="gauge" class="options-grid-span2">
+                <mat-label>Highlights Width</mat-label>
+                <input type="number" min="0" max="25" matInput placeholder="Enter or select number..." name="highlightsWidth" formControlName="highlightsWidth" required>
               </mat-form-field>
             }
 

--- a/src/app/widget-config/modal-widget-config/modal-widget-config.component.html
+++ b/src/app/widget-config/modal-widget-config/modal-widget-config.component.html
@@ -167,10 +167,6 @@
                       <mat-option value="capacity">Capacity</mat-option>
                     </mat-select>
                   </mat-form-field>
-                  <mat-form-field formGroupName="gauge" class="options-grid-span2">
-                    <mat-label>Highlights Width</mat-label>
-                    <input type="number" min="0" max="25" matInput placeholder="Enter or select number..." name="highlightsWidth" formControlName="highlightsWidth" required>
-                  </mat-form-field>
               }
             }
 
@@ -185,6 +181,9 @@
                     <mat-option value="horizontal">Horizontal</mat-option>
                 </mat-select>
               </mat-form-field>
+            }
+
+            @if ( (widgetConfig.gauge?.type == 'ngRadial' && ['measuring','capacity'].includes(formMaster.value.gauge.subType)) || widgetConfig.gauge?.type == 'ngLinear') {
               <mat-form-field formGroupName="gauge" class="options-grid-span2">
                 <mat-label>Highlights Width</mat-label>
                 <input type="number" min="0" max="25" matInput placeholder="Enter or select number..." name="highlightsWidth" formControlName="highlightsWidth" required>

--- a/src/app/widgets/widget-gauge-ng-linear/widget-gauge-ng-linear.component.ts
+++ b/src/app/widgets/widget-gauge-ng-linear/widget-gauge-ng-linear.component.ts
@@ -253,7 +253,7 @@ export class WidgetGaugeNgLinearComponent extends BaseWidgetComponent implements
       needleSide: "both",
 
       highlights: [],
-      highlightsWidth: this.widgetProperties.config.gauge.highlightsWidth !== undefined && this.widgetProperties.config.gauge.highlightsWidth !== null ? this.widgetProperties.config.gauge.highlightsWidth : 5,
+      highlightsWidth: this.widgetProperties.config.gauge.highlightsWidth,
 
       animation: true,
       animationRule: "linear",

--- a/src/app/widgets/widget-gauge-ng-linear/widget-gauge-ng-linear.component.ts
+++ b/src/app/widgets/widget-gauge-ng-linear/widget-gauge-ng-linear.component.ts
@@ -82,6 +82,7 @@ export class WidgetGaugeNgLinearComponent extends BaseWidgetComponent implements
   }
 
   ngOnInit() {
+    this.initWidget();
     this.setGaugeConfig();
 
     const gaugeSize = this.wrapper.nativeElement.getBoundingClientRect();
@@ -129,8 +130,6 @@ export class WidgetGaugeNgLinearComponent extends BaseWidgetComponent implements
         this.linearGauge.update(option);
       }
     });
-
-    this.initWidget();
 
     this.metaSub = this.zones$.subscribe(zones => {
       if (zones && zones.length > 0) {

--- a/src/app/widgets/widget-gauge-ng-linear/widget-gauge-ng-linear.component.ts
+++ b/src/app/widgets/widget-gauge-ng-linear/widget-gauge-ng-linear.component.ts
@@ -70,6 +70,7 @@ export class WidgetGaugeNgLinearComponent extends BaseWidgetComponent implements
         type: 'ngLinear',
         subType: 'vertical',    // vertical or horizontal
         enableTicks: true,
+        highlightsWidth: 5,
       },
       numInt: 1,
       numDecimal: 0,
@@ -81,7 +82,6 @@ export class WidgetGaugeNgLinearComponent extends BaseWidgetComponent implements
   }
 
   ngOnInit() {
-    this.initWidget();
     this.setGaugeConfig();
 
     const gaugeSize = this.wrapper.nativeElement.getBoundingClientRect();
@@ -129,6 +129,8 @@ export class WidgetGaugeNgLinearComponent extends BaseWidgetComponent implements
         this.linearGauge.update(option);
       }
     });
+
+    this.initWidget();
 
     this.metaSub = this.zones$.subscribe(zones => {
       if (zones && zones.length > 0) {
@@ -252,7 +254,7 @@ export class WidgetGaugeNgLinearComponent extends BaseWidgetComponent implements
       needleSide: "both",
 
       highlights: [],
-      highlightsWidth: 0,
+      highlightsWidth: this.widgetProperties.config.gauge.highlightsWidth !== undefined && this.widgetProperties.config.gauge.highlightsWidth !== null ? this.widgetProperties.config.gauge.highlightsWidth : 5,
 
       animation: true,
       animationRule: "linear",
@@ -358,7 +360,7 @@ export class WidgetGaugeNgLinearComponent extends BaseWidgetComponent implements
     };
     //@ts-ignore
     let highlights: LinearGaugeOptions = {};
-    highlights.highlightsWidth = 5;
+    highlights.highlightsWidth = this.widgetProperties.config.gauge.highlightsWidth;
     //@ts-ignore - bug in highlights property definition
     highlights.highlights = JSON.stringify(gaugeZonesHighlight, null, 1);
     this.linearGauge.update(highlights);

--- a/src/app/widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component.ts
+++ b/src/app/widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component.ts
@@ -130,7 +130,7 @@ export class WidgetGaugeNgRadialComponent extends BaseWidgetComponent implements
     });
 
     this.metaSub = this.zones$.subscribe(zones => {
-      if (zones && zones.length > 0 && this.widgetProperties.config.gauge.subType == "measuring") {
+      if (zones && zones.length > 0 && ["capacity", "measuring"].includes(this.widgetProperties.config.gauge.subType)) {
         this.setHighlights(zones);
       }
     });

--- a/src/app/widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component.ts
+++ b/src/app/widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component.ts
@@ -90,7 +90,6 @@ export class WidgetGaugeNgRadialComponent extends BaseWidgetComponent implements
 
   ngOnInit() {
     //TODO: simplify initialization
-    this.initWidget();
     const gaugeSize = this.wrapper.nativeElement.getBoundingClientRect();
     this.gaugeOptions.height = Math.floor(gaugeSize.height * this.WIDGET_SIZE_FACTOR);
     this.gaugeOptions.width = Math.floor(gaugeSize.width * this.WIDGET_SIZE_FACTOR);
@@ -128,6 +127,8 @@ export class WidgetGaugeNgRadialComponent extends BaseWidgetComponent implements
         this.radialGauge.update(option);
       }
     });
+
+    this.initWidget();
 
     this.metaSub = this.zones$.subscribe(zones => {
       if (zones && zones.length > 0 && this.widgetProperties.config.gauge.subType == "measuring") {

--- a/src/app/widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component.ts
+++ b/src/app/widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component.ts
@@ -77,7 +77,8 @@ export class WidgetGaugeNgRadialComponent extends BaseWidgetComponent implements
         type: 'ngRadial', // capacity, measuring, marineCompass, baseplateCompass
         subType: 'measuring', // capacity, measuring, marineCompass, baseplateCompass
         enableTicks: true,
-        compassUseNumbers: false
+        compassUseNumbers: false,
+        highlightsWidth: 5,
       },
       numInt: 1,
       numDecimal: 0,
@@ -171,7 +172,7 @@ export class WidgetGaugeNgRadialComponent extends BaseWidgetComponent implements
     this.gaugeOptions.valueDec = this.widgetProperties.config.numDecimal !== undefined && this.widgetProperties.config.numDecimal !== null ? this.widgetProperties.config.numDecimal : 2;
     this.gaugeOptions.majorTicksInt = this.widgetProperties.config.numInt !== undefined && this.widgetProperties.config.numInt !== null ? this.widgetProperties.config.numInt : 1;
     this.gaugeOptions.majorTicksDec = this.widgetProperties.config.numDecimal !== undefined && this.widgetProperties.config.numDecimal !== null ? this.widgetProperties.config.numDecimal : 2;
-    this.gaugeOptions.highlightsWidth = 0;
+    this.gaugeOptions.highlightsWidth = this.widgetProperties.config.gauge.highlightsWidth !== undefined && this.widgetProperties.config.gauge.highlightsWidth !== null ? this.widgetProperties.config.gauge.highlightsWidth : 5;
 
     this.gaugeOptions.animation = true;
     this.gaugeOptions.animateOnInit = false;
@@ -379,7 +380,7 @@ export class WidgetGaugeNgRadialComponent extends BaseWidgetComponent implements
     };
     //@ts-ignore
     let highlights: LinearGaugeOptions = {};
-    highlights.highlightsWidth = 5;
+    highlights.highlightsWidth = this.widgetProperties.config.gauge.highlightsWidth;
     //@ts-ignore - bug in highlights property definition
     highlights.highlights = JSON.stringify(gaugeZonesHighlight, null, 1);
     this.radialGauge.update(highlights);

--- a/src/app/widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component.ts
+++ b/src/app/widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component.ts
@@ -90,6 +90,7 @@ export class WidgetGaugeNgRadialComponent extends BaseWidgetComponent implements
 
   ngOnInit() {
     //TODO: simplify initialization
+    this.initWidget();
     const gaugeSize = this.wrapper.nativeElement.getBoundingClientRect();
     this.gaugeOptions.height = Math.floor(gaugeSize.height * this.WIDGET_SIZE_FACTOR);
     this.gaugeOptions.width = Math.floor(gaugeSize.width * this.WIDGET_SIZE_FACTOR);
@@ -127,8 +128,6 @@ export class WidgetGaugeNgRadialComponent extends BaseWidgetComponent implements
         this.radialGauge.update(option);
       }
     });
-
-    this.initWidget();
 
     this.metaSub = this.zones$.subscribe(zones => {
       if (zones && zones.length > 0 && this.widgetProperties.config.gauge.subType == "measuring") {

--- a/src/app/widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component.ts
+++ b/src/app/widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component.ts
@@ -172,7 +172,7 @@ export class WidgetGaugeNgRadialComponent extends BaseWidgetComponent implements
     this.gaugeOptions.valueDec = this.widgetProperties.config.numDecimal !== undefined && this.widgetProperties.config.numDecimal !== null ? this.widgetProperties.config.numDecimal : 2;
     this.gaugeOptions.majorTicksInt = this.widgetProperties.config.numInt !== undefined && this.widgetProperties.config.numInt !== null ? this.widgetProperties.config.numInt : 1;
     this.gaugeOptions.majorTicksDec = this.widgetProperties.config.numDecimal !== undefined && this.widgetProperties.config.numDecimal !== null ? this.widgetProperties.config.numDecimal : 2;
-    this.gaugeOptions.highlightsWidth = this.widgetProperties.config.gauge.highlightsWidth !== undefined && this.widgetProperties.config.gauge.highlightsWidth !== null ? this.widgetProperties.config.gauge.highlightsWidth : 5;
+    this.gaugeOptions.highlightsWidth = this.widgetProperties.config.gauge.highlightsWidth;
 
     this.gaugeOptions.animation = true;
     this.gaugeOptions.animateOnInit = false;

--- a/src/app/widgets/widget-gauge-steel/widget-gauge-steel.component.ts
+++ b/src/app/widgets/widget-gauge-steel/widget-gauge-steel.component.ts
@@ -62,7 +62,6 @@ export class WidgetGaugeComponent extends BaseWidgetComponent implements OnInit,
   }
 
   ngOnInit() {
-    this.initWidget();
     this.observeDataStream('gaugePath', newValue => {
         if (newValue.data.value == null) {
           newValue.data.value = 0;
@@ -71,6 +70,8 @@ export class WidgetGaugeComponent extends BaseWidgetComponent implements OnInit,
         this.dataValue = Math.min(Math.max(newValue.data.value, this.widgetProperties.config.displayScale.lower), this.widgetProperties.config.displayScale.upper);
       }
     );
+
+    this.initWidget();
 
     this.metaSub = this.zones$.subscribe(zones => {
       if (zones && zones.length > 0) {

--- a/src/app/widgets/widget-gauge-steel/widget-gauge-steel.component.ts
+++ b/src/app/widgets/widget-gauge-steel/widget-gauge-steel.component.ts
@@ -62,6 +62,7 @@ export class WidgetGaugeComponent extends BaseWidgetComponent implements OnInit,
   }
 
   ngOnInit() {
+    this.initWidget();
     this.observeDataStream('gaugePath', newValue => {
         if (newValue.data.value == null) {
           newValue.data.value = 0;
@@ -70,8 +71,6 @@ export class WidgetGaugeComponent extends BaseWidgetComponent implements OnInit,
         this.dataValue = Math.min(Math.max(newValue.data.value, this.widgetProperties.config.displayScale.lower), this.widgetProperties.config.displayScale.upper);
       }
     );
-
-    this.initWidget();
 
     this.metaSub = this.zones$.subscribe(zones => {
       if (zones && zones.length > 0) {


### PR DESCRIPTION
This adds a "highlights width" property to the radial gauge config with a range of `0-25`.  It still defaults to `5`, but that value is too skinny for my old eyes.

<img width="338" alt="image" src="https://github.com/user-attachments/assets/904c4f91-f9a4-4b7a-8c0d-06d4512923b8">
<img width="972" alt="image" src="https://github.com/user-attachments/assets/26d83f1e-45a5-4fd2-b7f9-f09be81ee5d0">

It also looks like there's a bug that prevents zones (and therefore highlights) from being available on initial load.  I clumsily fixed this in the 2nd commit by moving `initWidget()` after `observeDataStream()`, otherwise it seems the data service `_pathRegister` isn't loaded when the gauge tries to subscribe to metadata.  There's probably a better way to solve this, but it felt that would require a more fundamental change that would affect all widgets (although other widgets likely have this problem, too).