### PR TITLE
Fixes issue with metadata not being available on initial load

### DIFF
--- a/src/app/base-widget/base-widget.component.ts
+++ b/src/app/base-widget/base-widget.component.ts
@@ -41,7 +41,6 @@ export abstract class BaseWidgetComponent {
 
   protected initWidget(): void {
     this.validateConfig();
-    this.observeMeta();
   }
 
   private observeMeta(): void {
@@ -132,6 +131,8 @@ export abstract class BaseWidgetComponent {
     if (this.dataStream === undefined) {
       this.createDataObservable();
     }
+
+    this.observeMeta();
 
     const pathType = this.widgetProperties.config.paths[pathName].pathType;
     const path = this.widgetProperties.config.paths[pathName].path;


### PR DESCRIPTION
This moves `observeMeta()` to after `createDataObservable()` so that the subscription path is ensured to be loaded when the gauge is initially rendered.  Without this, zone data may not be available, causing highlights to not render.