### PR TITLE
increase wind speed font size, keep 2 significant digits

### DIFF
--- a/src/app/widgets/svg-wind/svg-wind.component.svg
+++ b/src/app/widgets/svg-wind/svg-wind.component.svg
@@ -468,23 +468,23 @@
       <text
         xml:space="preserve"
         class="true-wind-label"
-        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.6667px;font-family:Roboto;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke:none;stroke-width:14.5521;stroke-miterlimit:0"
+        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:24.6667px;font-family:Roboto;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke:none;stroke-width:14.5521;stroke-miterlimit:0"
         x="904.27722"
-        y="150.88913"
+        y="155.88913"
         id="text43">kts</text>
       <text
         xml:space="preserve"
         class="true-wind"
-        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:66.6667px;font-family:Roboto;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke:none;stroke-width:14.5521;stroke-miterlimit:0"
+        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:116.6667px;font-family:Roboto;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke:none;stroke-width:14.5521;stroke-miterlimit:0"
         x="903.84814"
-        y="114.73512"
+        y="124.73512"
         id="text42">{{ trueWindSpeedDisplay() }}</text>
       <text
         xml:space="preserve"
         class="true-wind-label"
-        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.6667px;font-family:Roboto;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke:none;stroke-width:14.5521;stroke-miterlimit:0"
+        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:24.6667px;font-family:Roboto;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke:none;stroke-width:14.5521;stroke-miterlimit:0"
         x="905.25897"
-        y="52.894646"
+        y="27.894646"
         id="text41">TWS</text>
     </g>
     <g id="awsCounter"
@@ -492,23 +492,23 @@
       <text
         xml:space="preserve"
         class="app-wind-label"
-        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.6667px;font-family:Roboto;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke:none;stroke-width:14.5521;stroke-miterlimit:0"
+        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:24.6667px;font-family:Roboto;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke:none;stroke-width:14.5521;stroke-miterlimit:0"
         x="94.554222"
-        y="150.88913"
+        y="155.88913"
         id="text39">kts</text>
       <text
         xml:space="preserve"
         class="app-wind"
-        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:66.6667px;font-family:Roboto;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke:none;stroke-width:14.5521;stroke-miterlimit:0"
+        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:116.6667px;font-family:Roboto;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke:none;stroke-width:14.5521;stroke-miterlimit:0"
         x="94.580925"
-        y="114.63747"
+        y="124.63747"
         id="text40">{{ appWindSpeedDisplay() }}</text>
       <text
        xml:space="preserve"
        class="app-wind-label"
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:34.6667px;font-family:Roboto;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke:none;stroke-width:14.5521;stroke-miterlimit:0"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:24.6667px;font-family:Roboto;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;stroke:none;stroke-width:14.5521;stroke-miterlimit:0"
        x="95.967644"
-       y="52.894646"
+       y="27.894646"
        id="text39-7">AWS</text>
     </g>
   </g>

--- a/src/app/widgets/svg-wind/svg-wind.component.ts
+++ b/src/app/widgets/svg-wind/svg-wind.component.ts
@@ -60,6 +60,7 @@ export class SvgWindComponent implements AfterViewInit {
   protected appWindSpeedDisplay = computed(() => {
     const appWindSpeed = this.appWindSpeed();
     if (appWindSpeed == null) return "--";
+    else if (appWindSpeed >= 9.95) return appWindSpeed.toFixed(0);
     return appWindSpeed.toFixed(1);
   });
   protected trueWind: ISVGRotationObject = {
@@ -70,6 +71,7 @@ export class SvgWindComponent implements AfterViewInit {
   protected trueWindSpeedDisplay = computed(() => {
     const trueWindSpeed = this.trueWindSpeed();
     if (trueWindSpeed == null) return "--";
+    else if (trueWindSpeed >= 9.95) return trueWindSpeed.toFixed(0);
     return trueWindSpeed.toFixed(1);
   });
   private trueWindHeading: number = 0;


### PR DESCRIPTION
Simple mods to increase wind speed font size for svg-wind widget.
Just my example / idea of larger size / feel free to adjust to your preference.

Wind data display shows 10th of unit below 10, then switches to integer.
 eg. Displays 0.0 - 9.9  and then displays 10,11,12...