### PR TITLE
Match directionTrue instead of direction

### DIFF
--- a/src/app/widgets/widget-wind/widget-wind.component.ts
+++ b/src/app/widgets/widget-wind/widget-wind.component.ts
@@ -237,7 +237,7 @@ export class WidgetWindComponent extends BaseWidgetComponent implements OnInit, 
         this.widgetProperties.config.paths['trueWindAngle'].path.match('angleTrueGround')) {
           //-180 to 180
           this.trueWindAngle = this.addHeading(this.currentHeading, newValue.data.value);
-        } else if (this.widgetProperties.config.paths['trueWindAngle'].path.match('direction')) {
+        } else if (this.widgetProperties.config.paths['trueWindAngle'].path.match('directionTrue')) {
           //0-360
           this.trueWindAngle = newValue.data.value;
         } else {


### PR DESCRIPTION
It seems that when in SignalK simulator mode the send out value is "directionTrue" instead of "direction" (also in the specs).

This resulted in the true wind angle not changing in at least simulation mode. Probably on boats the other properties are used (TrueWindAngle) so this issue does not appear there.

Please do some proper testing for this