### PR TITLE
Position Paths Should Not Be Converted To Radian

### DIFF
--- a/src/app/core/services/canvas.service.ts
+++ b/src/app/core/services/canvas.service.ts
@@ -104,19 +104,32 @@ export class CanvasService {
    * @return {*}  {void}
    * @memberof CanvasService
    */
-  public drawText(ctx: CanvasRenderingContext2D, text: string, x: number = this.EDGE_BUFFER, y: number = this.EDGE_BUFFER, maxWidth: number, maxHeight: number, fontWeight: string = 'normal', color: string = '#000', textAlign: CanvasTextAlign = 'center', textBaseline: CanvasTextBaseline = 'middle'): void {
+  public drawText(
+    ctx: CanvasRenderingContext2D,
+    text: string,
+    x: number = this.EDGE_BUFFER,
+    y: number = this.EDGE_BUFFER,
+    maxWidth: number,
+    maxHeight: number,
+    fontWeight: string = 'normal',
+    color: string = '#000',
+    textAlign: CanvasTextAlign = 'center',
+    textBaseline: CanvasTextBaseline = 'middle'
+  ): void {
     if (!ctx) return;
 
-    this.fontsReadyPromise
-      .then(() => {
-        requestAnimationFrame(() => {
+    if (document.fonts.status === 'loaded') {
+      this.drawTextInternal(ctx, text, x, y, maxWidth, maxHeight, fontWeight, color, textAlign, textBaseline);
+    } else {
+      this.fontsReadyPromise
+        .then(() => {
+          this.drawTextInternal(ctx, text, x, y, maxWidth, maxHeight, fontWeight, color, textAlign, textBaseline);
+        })
+        .catch((err) => {
+          console.warn('[Canvas Service] Font readiness failed:');
           this.drawTextInternal(ctx, text, x, y, maxWidth, maxHeight, fontWeight, color, textAlign, textBaseline);
         });
-      })
-      .catch((err) => {
-        console.warn('[Canvas Service] Font readiness failed:');
-        this.drawTextInternal(ctx, text, x, y, maxWidth, maxHeight, fontWeight, color, textAlign, textBaseline);
-      });
+    }
   }
 
   /**

--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -274,12 +274,6 @@ export class DataService implements OnDestroy {
     this._deltaUpdatesCounter++;
     const updatePath = this.setPathContext(dataPath.context, dataPath.path);
 
-    // Convert position values from degrees to radians
-    if (updatePath.includes('position.latitude') || updatePath.includes('position.longitude')) {
-      const degToRad = Qty.swiftConverter('deg', 'rad');
-      dataPath.value = degToRad(dataPath.value);
-    }
-
     // Find the path item in _skData or create a new one if it doesn't exist
     let pathItem = this._skData.find(pathObject => pathObject.path == updatePath);
     if (!pathItem) {

--- a/src/app/core/services/units.service.ts
+++ b/src/app/core/services/units.service.ts
@@ -189,6 +189,7 @@ export class UnitsService implements OnDestroy {
       { measure: 'ratio', description: "Ratio 0-1 (base)" }
     ] },
     { group: 'Position', units: [
+      { measure: 'pdeg', description: "Position Degrees" },
       { measure: 'latitudeMin', description: "Latitude in minutes" },
       { measure: 'latitudeSec', description: "Latitude in seconds" },
       { measure: 'longitudeMin', description: "Longitude in minutes" },
@@ -241,14 +242,14 @@ export class UnitsService implements OnDestroy {
         }
       },
       { unit: "deg", properties: {
-          display: "\u00b0",
+          display: "Position",
           quantity: "Angle",
           quantityDisplay: "\u2220",
           description: "Latitude or longitude in decimal degrees"
         }
       },
       { unit: "rad", properties: {
-          display: "\u33ad",
+          display: "\u00b0",
           quantity: "Angle",
           quantityDisplay: "\u2220",
           description: "Angular arc in radians"
@@ -530,9 +531,9 @@ export class UnitsService implements OnDestroy {
     'percent': function(v) { return v * 100 },
     'percentraw': function(v) { return v },
     'ratio': function(v) { return v },
-// lat/lon
+// Position Degrees lat/lon
+    'pdeg': function(v) { return v; }, // Signal K uses degrees for lat/lon
     'latitudeMin': function(v) {
-        v = Qty(v, 'rad').to('deg').scalar ;
         let degree = Math.trunc(v);
         let s = 'N';
         if (v < 0) { s = 'S'; degree = degree * -1 }
@@ -541,7 +542,6 @@ export class UnitsService implements OnDestroy {
         return degree + '° ' + r.toFixed(2).padStart(5, '0') + '\' ' + s;
       },
     'latitudeSec': function(v) {
-      v = Qty(v, 'rad').to('deg').scalar ;
       let degree = Math.trunc(v);
       let s = 'N';
       if (v < 0) { s = 'S'; degree = degree * -1 }
@@ -553,7 +553,6 @@ export class UnitsService implements OnDestroy {
       return degree + '° ' + minutes + '\' ' + seconds.toFixed(2).padStart(5, '0') + '" ' + s;
     },
     'longitudeMin': function(v) {
-      v = Qty(v, 'rad').to('deg').scalar ;
       let degree = Math.trunc(v);
       let s = 'E';
       if (v < 0) { s = 'W'; degree = degree * -1 }
@@ -562,7 +561,6 @@ export class UnitsService implements OnDestroy {
       return degree + '° ' + r.toFixed(2).padStart(5, '0') + '\' ' + s;
     },
     'longitudeSec': function(v) {
-      v = Qty(v, 'rad').to('deg').scalar ;
       let degree = Math.trunc(v);
       let s = 'E';
       if (v < 0) { s = 'W'; degree = degree * -1 }

--- a/src/app/widgets/widget-position/widget-position.component.ts
+++ b/src/app/widgets/widget-position/widget-position.component.ts
@@ -87,11 +87,23 @@ export class WidgetPositionComponent extends BaseWidgetComponent implements Afte
   protected startWidget(): void {
     this.unsubscribeDataStream();
     this.observeDataStream('longPath', newValue => {
-      this.longPos = newValue.data.value ? newValue.data.value.toString() : '';
+      if (newValue.data.value ===  null) {
+        this.longPos = '';
+      } else if (this.widgetProperties.config.paths['longPath'].convertUnitTo === 'pdeg') {
+        this.longPos = newValue.data.value.toFixed(6) + '°';
+      } else {
+        this.longPos = newValue.data.value.toString();
+      }
       this.drawValue();
     });
     this.observeDataStream('latPath', newValue => {
-      this.latPos = newValue.data.value ? newValue.data.value.toString() : '';
+      if (newValue.data.value ===  null) {
+        this.latPos = '';
+      } else if (this.widgetProperties.config.paths['latPath'].convertUnitTo === 'pdeg') {
+        this.latPos = newValue.data.value.toFixed(7) + '°';
+      } else {
+        this.latPos = newValue.data.value.toString();
+      }
       this.drawValue();
     });
   }


### PR DESCRIPTION
Fixes #654
1- Remove the default deg to rad conversion for paths containing *.position.*
2- Remove Position format group reconversion from rad to deg before formatting to string representation
3- adjust Position widget to correct standard.
4- Cleanup units group listing
5- Fix canvas drawing overlap