### PR TITLE
Add start angle and handle null values in gauge components

### DIFF
--- a/src/app/core/interfaces/widgets-interface.ts
+++ b/src/app/core/interfaces/widgets-interface.ts
@@ -135,6 +135,8 @@ export interface IWidgetSvcConfig {
     backgroundColor?: string;
     /** Optional. Used by GaugeSteel to set face style */
     faceColor?: string;
+    /** Optional. Angle (0-360) the progress bar should start */
+    scaleStart?: number;
     /** Optional. Used by GaugeSteel to set radial faceplate size */
     radialSize?: string;
     /** Optional. Used by GaugeSteel to set faceplate rotation */

--- a/src/app/core/services/signalk-delta.service.ts
+++ b/src/app/core/services/signalk-delta.service.ts
@@ -55,8 +55,8 @@ export class SignalKDeltaService implements OnDestroy {
   // Websocket config
   private endpointWS: string = null;
   private SubscriptionType = "self";
-  private readonly WS_RECONNECT_INTERVAL = 3000;                 // connection error retry interval
-  private readonly WS_RETRY_COUNT = 3;                 // connection error retry interval
+  private readonly WS_RECONNECT_INTERVAL = 5000;       // connection error retry interval
+  private readonly WS_RETRY_COUNT = 5;                 // connection error retry interval
   private readonly WS_CONNECTION_SUBSCRIBE = "?subscribe=";
   private readonly WS_CONNECTION_META = "&sendMeta=all"; // default but we could use none + specific paths in the future
   private socketWS$: WebSocketSubject<object>;

--- a/src/app/widget-config/modal-widget-config/modal-widget-config.component.html
+++ b/src/app/widget-config/modal-widget-config/modal-widget-config.component.html
@@ -207,6 +207,12 @@
                     <mat-option value="capacity">Capacity</mat-option>
                   </mat-select>
                 </mat-form-field>
+                @if (formMaster.value.gauge.subType === 'capacity') {
+                  <mat-form-field formGroupName="gauge">
+                    <mat-label>Progress Bar Start Angle</mat-label>
+                    <input type="number" min="1" max="360" matInput placeholder="Enter or select number..." name="scaleStart" formControlName="scaleStart" required>
+                  </mat-form-field>
+                }
               }
             }
 

--- a/src/app/widgets/widget-gauge-ng-compass/widget-gauge-ng-compass.component.ts
+++ b/src/app/widgets/widget-gauge-ng-compass/widget-gauge-ng-compass.component.ts
@@ -126,7 +126,7 @@ export class WidgetGaugeNgCompassComponent extends BaseWidgetComponent implement
     this.unsubscribeDataStream();
 
     this.observeDataStream('gaugePath', newValue => {
-      if (!newValue || !newValue.data) {
+      if (!newValue || !newValue.data || newValue.data.value === null) {
         newValue = {
           data: {
             value: 0,
@@ -135,23 +135,23 @@ export class WidgetGaugeNgCompassComponent extends BaseWidgetComponent implement
           state: States.Normal // Default state
         };
 
-        this.textValue = "--";
         this.value = 0;
+        this.textValue = '--';
+      } else {
+        const convertedValue: number = this.negToPortPaths.includes(this.widgetProperties.config.paths['gaugePath'].path)
+          ? convertNegToPortDegree(newValue.data.value)
+          : newValue.data.value;
+
+        // Compound value to displayScale
+        this.value = Math.min(Math.max(convertedValue, 0), 360);
+        // Format for value box
+        this.textValue = this.value.toFixed(0);
       }
 
       // Validate and handle `newValue.state`
       if (newValue.state == null) {
         newValue.state = States.Normal; // Provide a default value for state
       }
-
-      const convertedValue: number = this.negToPortPaths.includes(this.widgetProperties.config.paths['gaugePath'].path)
-        ? convertNegToPortDegree(newValue.data.value)
-        : newValue.data.value;
-
-      // Compound value to displayScale
-      this.value = Math.min(Math.max(convertedValue, 0), 360);
-      // Format for value box
-      this.textValue = this.value.toFixed(0);
 
       if (this.state !== newValue.state) {
         this.state = newValue.state;

--- a/src/app/widgets/widget-gauge-ng-linear/widget-gauge-ng-linear.component.html
+++ b/src/app/widgets/widget-gauge-ng-linear/widget-gauge-ng-linear.component.html
@@ -2,5 +2,6 @@
   <linear-gauge class="linearGauge" id="{{widgetProperties.uuid}}" #linearGauge (onResize)="onResized($event)"
     [options]="gaugeOptions"
     [value]="value"
+    [attr.value-text]="textValue"
     ></linear-gauge>
 </widget-host>

--- a/src/app/widgets/widget-gauge-ng-linear/widget-gauge-ng-linear.component.ts
+++ b/src/app/widgets/widget-gauge-ng-linear/widget-gauge-ng-linear.component.ts
@@ -30,12 +30,12 @@ export class WidgetGaugeNgLinearComponent extends BaseWidgetComponent implements
   @ViewChild('linearGauge', {static: true, read: ElementRef}) protected gauge: ElementRef;
 
   // Gauge text value for value box rendering
-  public textValue = "--";
+  protected textValue = "";
   // Gauge value
-  public value = 0;
+  protected value = 0;
 
   // Gauge options
-  public gaugeOptions = {} as LinearGaugeOptions;
+  protected gaugeOptions = {} as LinearGaugeOptions;
   private isGaugeVertical = true;
 
   // Zones support
@@ -101,7 +101,7 @@ export class WidgetGaugeNgLinearComponent extends BaseWidgetComponent implements
     this.metaSub?.unsubscribe();
 
     this.observeDataStream('gaugePath', newValue => {
-      if (!newValue || !newValue.data) {
+      if (!newValue || !newValue.data || newValue.data.value === null) {
         newValue = {
           data: {
             value: 0,
@@ -109,15 +109,18 @@ export class WidgetGaugeNgLinearComponent extends BaseWidgetComponent implements
           },
           state: States.Normal // Default state
         };
+        this.textValue = '--';
+      } else if (this.textValue === '--') {
+          this.textValue = '';
       }
+
+      // Compound value to displayScale
+      this.value = Math.min(Math.max(newValue.data.value, this.widgetProperties.config.displayScale.lower), this.widgetProperties.config.displayScale.upper);
 
       // Validate and handle `newValue.state`
       if (newValue.state == null) {
         newValue.state = States.Normal; // Provide a default value for state
       }
-
-      // Compound value to displayScale
-      this.value = Math.min(Math.max(newValue.data.value, this.widgetProperties.config.displayScale.lower), this.widgetProperties.config.displayScale.upper);
 
       if (this.state !== newValue.state) {
         this.state = newValue.state;

--- a/src/app/widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component.html
+++ b/src/app/widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component.html
@@ -9,6 +9,7 @@
     #radialGauge
     [options]="gaugeOptions"
     [value]="value"
+    [attr.value-text]="textValue"
     (onResize)="onResized($event)"
   >
   </radial-gauge>

--- a/src/app/widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component.ts
+++ b/src/app/widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component.ts
@@ -33,15 +33,15 @@ export class WidgetGaugeNgRadialComponent extends BaseWidgetComponent implements
   @ViewChild('radialGauge', { static: true, read: ElementRef }) gauge: ElementRef;
 
   // Gauge text value for value box rendering
-  public textValue = "--";
+  protected textValue = "";
   // Gauge value
-  public value = 0;
+  protected value = 0;
 
   // Gauge options
-  public gaugeOptions = {} as RadialGaugeOptions;
+  protected gaugeOptions = {} as RadialGaugeOptions;
   // fix for RadialGauge GaugeOptions object ** missing color-stroke-ticks property
-  public colorStrokeTicks = "";
-  public unitName: string = null;
+  protected colorStrokeTicks = "";
+  protected unitName: string = null;
 
   // Zones support
   private metaSub: Subscription;
@@ -107,7 +107,7 @@ export class WidgetGaugeNgRadialComponent extends BaseWidgetComponent implements
     this.metaSub?.unsubscribe();
 
     this.observeDataStream('gaugePath', newValue => {
-      if (!newValue || !newValue.data) {
+      if (!newValue || !newValue.data || newValue.data.value === null) {
         newValue = {
           data: {
             value: 0,
@@ -115,14 +115,17 @@ export class WidgetGaugeNgRadialComponent extends BaseWidgetComponent implements
           },
           state: States.Normal // Default state
         };
-      }
-
-      if (newValue.state == null) {
-        newValue.state = States.Normal; // Provide a default value for state
+        this.textValue = '--';
+      } else if (this.textValue === '--') {
+          this.textValue = '';
       }
 
       // Compound value to displayScale
       this.value = Math.min(Math.max(newValue.data.value, this.widgetProperties.config.displayScale.lower), this.widgetProperties.config.displayScale.upper);
+
+      if (newValue.state == null) {
+        newValue.state = States.Normal; // Provide a default value for state
+      }
 
       if (this.state !== newValue.state) {
         this.state = newValue.state;

--- a/src/app/widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component.ts
+++ b/src/app/widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component.ts
@@ -35,7 +35,7 @@ export class WidgetGaugeNgRadialComponent extends BaseWidgetComponent implements
   // Gauge text value for value box rendering
   protected textValue = "";
   // Gauge value
-  protected value = 0;
+  protected value: number = null;
 
   // Gauge options
   protected gaugeOptions = {} as RadialGaugeOptions;
@@ -77,6 +77,7 @@ export class WidgetGaugeNgRadialComponent extends BaseWidgetComponent implements
         enableTicks: true,
         compassUseNumbers: false,
         highlightsWidth: 5,
+        scaleStart: 180
       },
       numInt: 1,
       numDecimal: 0,
@@ -304,7 +305,7 @@ export class WidgetGaugeNgRadialComponent extends BaseWidgetComponent implements
     this.gaugeOptions.colorValueBoxRectEnd = '';
 
     this.gaugeOptions.ticksAngle = 360;
-    this.gaugeOptions.startAngle = 180;
+    this.gaugeOptions.startAngle = this.widgetProperties.config.gauge.scaleStart || 180;
     this.gaugeOptions.majorTicks = 0;
     this.gaugeOptions.exactTicks = true;
     this.gaugeOptions.strokeTicks = false;


### PR DESCRIPTION
Introduce a start angle option for capacity gauges and improve handling of null values in gauge displays. This ensures that gauges correctly reflect their state and provide a more robust user experience.