### PR TITLE
Add days:hours:minutes option for uptime tracking

### DIFF
--- a/src/app/core/services/units.service.ts
+++ b/src/app/core/services/units.service.ts
@@ -199,7 +199,7 @@ export class UnitsService implements OnDestroy {
       { measure: 'Minutes', description: "Minutes" },
       { measure: 'Hours', description: "Hours" },
       { measure: 'Days', description: "Days" },
-      { measure: 'HH:MM:SS', description: "Hours:Minute:seconds"}
+      { measure: 'D HH:MM:SS', description: "Day Hour:Minute:sec"}
     ] },
     { group: 'Angular Velocity', units: [
       { measure: 'rad/s', description: "Radians per second (base)" },
@@ -533,20 +533,25 @@ export class UnitsService implements OnDestroy {
     "Minutes": Qty.swiftConverter('s', 'minutes'),
     "Hours": Qty.swiftConverter('s', 'hours'),
     "Days": Qty.swiftConverter('s', 'days'),
-    "HH:MM:SS": function(v) {
+    "D HH:MM:SS": function(v) {
       v = parseInt(v, 10);
       const isNegative = v < 0; // Check if the value is negative
       v = Math.abs(v); // Use the absolute value for calculations
 
-      const h = Math.floor(v / 3600);
-      const m = Math.floor(v % 3600 / 60);
-      const s = Math.floor(v % 3600 % 60);
+      const days = Math.floor(v / 86400);
+      const h = Math.floor((v % 86400) / 3600);
+      const m = Math.floor((v % 3600) / 60);
+      const s = Math.floor(v % 60);
 
-      // Add a negative sign if the original value was negative
-      return (isNegative ? '-' : '') +
-             ('0' + h).slice(-2) + ":" +
-             ('0' + m).slice(-2) + ":" +
-             ('0' + s).slice(-2);
+      let result = (isNegative ? '-' : '');
+      if (days > 0) {
+        result += days + 'd ' + h.toString() + ':' + m.toString().padStart(2, '0') + ':' + s.toString().padStart(2, '0');
+      } else {
+        result += h.toString() + ':' +
+                  m.toString().padStart(2, '0') + ':' +
+                  s.toString().padStart(2, '0');
+      }
+      return result;
     },
 //  angularVelocity
     "rad/s": function(v) { return v; },

--- a/src/app/widgets/widget-autopilot/widget-autopilot.component.ts
+++ b/src/app/widgets/widget-autopilot/widget-autopilot.component.ts
@@ -147,7 +147,7 @@ export class WidgetAutopilotComponent extends BaseWidgetComponent implements OnI
           source: "default",
           pathType: "number",
           isPathConfigurable: true,
-          convertUnitTo: "HH:MM:SS",
+          convertUnitTo: "D HH:MM:SS",
           showPathSkUnitsFilter: true,
           pathSkUnitsFilter: null,
           sampleTime: 500

--- a/src/app/widgets/widget-numeric/widget-numeric.component.ts
+++ b/src/app/widgets/widget-numeric/widget-numeric.component.ts
@@ -252,7 +252,7 @@ private updateCanvas(): void {
     }
 
     const cUnit = this.widgetProperties.config.paths['numericPath'].convertUnitTo;
-    if (['latitudeSec', 'latitudeMin', 'longitudeSec', 'longitudeMin', 'HH:MM:SS'].includes(cUnit)) {
+    if (['latitudeSec', 'latitudeMin', 'longitudeSec', 'longitudeMin', 'D HH:MM:SS'].includes(cUnit)) {
         return this.dataValue.toString();
     }
 


### PR DESCRIPTION
Introduce a new format for displaying time that includes days, hours, minutes, and seconds. This change addresses the issue of uptime exceeding 99:59:59 by allowing for a more comprehensive time representation.

Fixes #664