### PR TITLE
Fix plugin service resource loader property

### DIFF
--- a/src/app/core/services/signalk-plugins.service.ts
+++ b/src/app/core/services/signalk-plugins.service.ts
@@ -35,7 +35,7 @@ export class SignalkPluginsService {
   private _connection = toSignal(this._connectionSvc.getServiceEndpointStatusAsO());
 
   private _pluginInformation = resource<skFeatures, unknown>({
-    stream: async ({ abortSignal }) => {
+    loader: async ({ abortSignal }) => {
       const url = this._API_URL();
       if (!url) {
         console.error('API URL not set yet.');


### PR DESCRIPTION
Change back the property name from `stream` to `loader` in the plugin information resource signal  that was updated improperly in Angular 20 upgrade.