### PR TITLE
Fix stripped Vessel Base Delta path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# V 3.4.2
+## Fixes
+* Stripped Vessel Base Delta path first character
 # V 3.4.1
 ## Fixes
 * Improve dashboard loading speed and keydown handling

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mxtommy/kip",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "An advanced and versatile marine instrumentation package to display Signal K data.",
   "license": "MIT",
   "author": {

--- a/src/app/core/services/signalk-delta.service.ts
+++ b/src/app/core/services/signalk-delta.service.ts
@@ -363,15 +363,6 @@ export class SignalKDeltaService implements OnDestroy {
                     timestamp: update.timestamp,
                     value: flatItem.value,
                   };
-
-                  if (update.$source == "defaults" && item.path == "") {
-                    dataPath.path = dataPath.path.slice(1);
-                  }
-
-                  if (context != this._selfUrn && item.path == "") {
-                    dataPath.path = dataPath.path.slice(1);
-                  }
-
                   this._skValue$.next(dataPath);
                 });
               } else {
@@ -384,15 +375,6 @@ export class SignalKDeltaService implements OnDestroy {
                     timestamp: update.timestamp,
                     value: item.value[key],
                   };
-
-                  if (update.$source == "defaults" && item.path == "") {
-                    dataPath.path = dataPath.path.slice(1);
-                  }
-
-                  if (context != this._selfUrn && item.path == "") {
-                    dataPath.path = dataPath.path.slice(1);
-                  }
-
                   this._skValue$.next(dataPath);
                 });
               }


### PR DESCRIPTION
Update the Vessel Base Delta path handling to stop removing the first character of Vessel Delta.