### PR TITLE
Remove standalone components and improve code readability

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -25,7 +25,6 @@ import { BreakpointObserver, Breakpoints, BreakpointState } from '@angular/cdk/l
     selector: 'app-root',
     templateUrl: './app.component.html',
     styleUrls: ['./app.component.scss'],
-    standalone: true,
     imports: [ MenuNotificationsComponent, MenuActionsComponent, MatButtonModule, MatMenuModule, MatIconModule, RouterModule, MatSidenavModule ]
 })
 export class AppComponent implements OnInit, AfterViewInit, OnDestroy {

--- a/src/app/core/components/configuration/config.component.html
+++ b/src/app/core/components/configuration/config.component.html
@@ -11,44 +11,47 @@
         name="saveConfigForm"
         (ngSubmit)="saveConfig(this.getActiveConfig(), saveConfigScope, saveConfigName)"
         #saveConfigForm="ngForm"
-      >
+        >
         <h2>Backup</h2>
         <p style="margin-bottom: 16px">
           Create a backup of the current active configuration on the server.
         </p>
-        <div *ngIf="hasToken; else elseBlockBackup">
-          <mat-form-field style="width: 25%">
-            <mat-label>Scope</mat-label>
-            <mat-select
-              name="serverConfiScope"
-              [(ngModel)]="saveConfigScope"
-              required
-            >
-              <mat-option value="global"> Global </mat-option>
-              <mat-option value="user"> User </mat-option>
-            </mat-select>
-          </mat-form-field>
-          <mat-form-field style="width: 70%; padding-left: 3%">
-            <mat-label>Configuration Name</mat-label>
-            <input
-              matInput
-              name="serverConfigName"
-              placeholder="Enter a name for the configuration"
-              [(ngModel)]="saveConfigName"
-              [ngModelOptions]="{ standalone: false }"
-              required
-            />
-          </mat-form-field>
-          <div *ngIf="!hasToken">
-            Writing to the server requires "Login to Server" authentication or a
-            Device token
+        @if (hasToken) {
+          <div>
+            <mat-form-field style="width: 25%">
+              <mat-label>Scope</mat-label>
+              <mat-select
+                name="serverConfiScope"
+                [(ngModel)]="saveConfigScope"
+                required
+                >
+                <mat-option value="global"> Global </mat-option>
+                <mat-option value="user"> User </mat-option>
+              </mat-select>
+            </mat-form-field>
+            <mat-form-field style="width: 70%; padding-left: 3%">
+              <mat-label>Configuration Name</mat-label>
+              <input
+                matInput
+                name="serverConfigName"
+                placeholder="Enter a name for the configuration"
+                [(ngModel)]="saveConfigName"
+                [ngModelOptions]="{ standalone: false }"
+                required
+                />
+            </mat-form-field>
+            @if (!hasToken) {
+              <div>
+                Writing to the server requires "Login to Server" authentication or a
+                Device token
+              </div>
+            }
           </div>
-        </div>
-        <ng-template #elseBlockBackup>
+        } @else {
           <div class="no-token-notice">
             <p>Server authentication or Device Token required</p>
           </div>
-        </ng-template>
+        }
         <div class="formActionFooter">
           <mat-divider class="formActionDivider"></mat-divider>
           <button
@@ -56,7 +59,7 @@
             type="submit"
             [disabled]="!hasToken || !saveConfigForm.valid"
             color="accent"
-          >
+            >
             Create
           </button>
         </div>
@@ -67,33 +70,35 @@
         name="deleteConfigForm"
         (ngSubmit)="deleteConfig(deleteConfigItem.scope, deleteConfigItem.name)"
         #deleteConfigForm="ngForm"
-      >
+        >
         <h2>Delete</h2>
         <p style="margin-bottom: 16px">
           Select a backup configuration to permanently delete from the server.
         </p>
-        <div *ngIf="hasToken; else elseBlockDelete">
-          <mat-form-field style="width: 100%">
-            <mat-label>Configuration</mat-label>
-            <mat-select
-              name="selectedDeleteItem"
-              [(ngModel)]="deleteConfigItem"
-              required
-            >
-              <mat-option
-                *ngFor="let config of serverConfigList"
-                [value]="config"
-              >
-                {{ config.scope }} / {{ config.name }}
-              </mat-option>
-            </mat-select>
-          </mat-form-field>
-        </div>
-        <ng-template #elseBlockDelete>
+        @if (hasToken) {
+          <div>
+            <mat-form-field style="width: 100%">
+              <mat-label>Configuration</mat-label>
+              <mat-select
+                name="selectedDeleteItem"
+                [(ngModel)]="deleteConfigItem"
+                required
+                >
+                @for (config of serverConfigList; track config) {
+                  <mat-option
+                    [value]="config"
+                    >
+                    {{ config.scope }} / {{ config.name }}
+                  </mat-option>
+                }
+              </mat-select>
+            </mat-form-field>
+          </div>
+        } @else {
           <div class="no-token-notice">
             <p>Authentication or Device Token required</p>
           </div>
-        </ng-template>
+        }
         <div class="formActionFooter">
           <mat-divider class="formActionDivider"></mat-divider>
           <button
@@ -101,7 +106,7 @@
             type="submit"
             [disabled]="!hasToken || !deleteConfigForm.valid"
             color="accent"
-          >
+            >
             Delete
           </button>
         </div>
@@ -113,24 +118,26 @@
         <p style="margin-bottom: 16px">
           Replace the current configuration with a backup from the server.
         </p>
-        <div *ngIf="hasToken; else elseBlockRestore">
-          <mat-form-field style="width: 100%">
-            <mat-label>Configuration</mat-label>
-            <mat-select formControlName="sourceTarget">
-              <mat-option
-                *ngFor="let config of serverConfigList"
-                [value]="config"
-              >
-                {{ config.scope }} / {{ config.name }}
-              </mat-option>
-            </mat-select>
-          </mat-form-field>
-        </div>
-        <ng-template #elseBlockRestore>
+        @if (hasToken) {
+          <div>
+            <mat-form-field style="width: 100%">
+              <mat-label>Configuration</mat-label>
+              <mat-select formControlName="sourceTarget">
+                @for (config of serverConfigList; track $index) {
+                  <mat-option
+                    [value]="config"
+                    >
+                    {{ config.scope }} / {{ config.name }}
+                  </mat-option>
+                }
+              </mat-select>
+            </mat-form-field>
+          </div>
+        } @else {
           <div class="no-token-notice">
             <p>Authentication or Device Token required</p>
           </div>
-        </ng-template>
+        }
         <div class="formActionFooter">
           <mat-divider class="formActionDivider"></mat-divider>
           <button
@@ -138,7 +145,7 @@
             type="submit"
             color="accent"
             [disabled]="!this.copyConfigForm.valid"
-          >
+            >
             Restore
           </button>
         </div>
@@ -156,7 +163,7 @@
             type="button"
             class="adv-btn"
             (click)="downloadJsonConfig()"
-          >
+            >
             Download
           </button>
         </div>
@@ -174,7 +181,7 @@
             (change)="uploadJsonConfig($event)"
             accept=".json"
             hidden
-          />
+            />
           <!-- Material button to trigger file input -->
           <button mat-flat-button class="adv-btn" (click)="fileInput.click()">
             Upload
@@ -192,7 +199,7 @@
             type="button"
             class="adv-btn"
             (click)="loadDemoConfig()"
-          >
+            >
             Demo
           </button>
         </div>
@@ -209,7 +216,7 @@
             type="button"
             class="adv-btn"
             (click)="resetConfigToDefault()"
-          >
+            >
             Default
           </button>
         </div>
@@ -225,7 +232,7 @@
             type="button"
             class="adv-btn"
             (click)="resetConnectionToDefault()"
-          >
+            >
             Connection
           </button>
         </div>

--- a/src/app/core/components/configuration/config.component.html
+++ b/src/app/core/components/configuration/config.component.html
@@ -9,16 +9,14 @@
     <div class="flex-item-rounded-card rounded-card-color">
       <form
         name="saveConfigForm"
-        (ngSubmit)="
-          saveConfig(this.getActiveConfig(), saveConfigScope, saveConfigName)
-        "
+        (ngSubmit)="saveConfig(this.getActiveConfig(), saveConfigScope, saveConfigName)"
         #saveConfigForm="ngForm"
       >
         <h2>Backup</h2>
         <p style="margin-bottom: 16px">
           Create a backup of the current active configuration on the server.
         </p>
-        <div *ngIf="hasToken; else elseBlock">
+        <div *ngIf="hasToken; else elseBlockBackup">
           <mat-form-field style="width: 25%">
             <mat-label>Scope</mat-label>
             <mat-select
@@ -46,7 +44,7 @@
             Device token
           </div>
         </div>
-        <ng-template #elseBlock>
+        <ng-template #elseBlockBackup>
           <div class="no-token-notice">
             <p>Server authentication or Device Token required</p>
           </div>
@@ -74,7 +72,7 @@
         <p style="margin-bottom: 16px">
           Select a backup configuration to permanently delete from the server.
         </p>
-        <div *ngIf="hasToken; else elseBlock">
+        <div *ngIf="hasToken; else elseBlockDelete">
           <mat-form-field style="width: 100%">
             <mat-label>Configuration</mat-label>
             <mat-select
@@ -91,7 +89,7 @@
             </mat-select>
           </mat-form-field>
         </div>
-        <ng-template #elseBlock>
+        <ng-template #elseBlockDelete>
           <div class="no-token-notice">
             <p>Authentication or Device Token required</p>
           </div>
@@ -115,7 +113,7 @@
         <p style="margin-bottom: 16px">
           Replace the current configuration with a backup from the server.
         </p>
-        <div *ngIf="hasToken; else elseBlock">
+        <div *ngIf="hasToken; else elseBlockRestore">
           <mat-form-field style="width: 100%">
             <mat-label>Configuration</mat-label>
             <mat-select formControlName="sourceTarget">
@@ -128,7 +126,7 @@
             </mat-select>
           </mat-form-field>
         </div>
-        <ng-template #elseBlock>
+        <ng-template #elseBlockRestore>
           <div class="no-token-notice">
             <p>Authentication or Device Token required</p>
           </div>

--- a/src/app/core/components/configuration/config.component.ts
+++ b/src/app/core/components/configuration/config.component.ts
@@ -14,7 +14,7 @@ import { MatSelect } from '@angular/material/select';
 import { MatFormField, MatLabel } from '@angular/material/form-field';
 import { MatButton } from '@angular/material/button';
 import { MatDivider } from '@angular/material/divider';
-import { NgIf, NgFor } from '@angular/common';
+
 import { RouterLink } from '@angular/router';
 import { PageHeaderComponent } from '../page-header/page-header.component';
 
@@ -28,7 +28,7 @@ interface IRemoteConfig {
     selector: 'settings-config',
     templateUrl: './config.component.html',
     styleUrls: ['./config.component.scss'],
-    imports: [RouterLink, NgIf, FormsModule, MatDivider, MatButton, MatFormField, MatLabel, MatSelect, MatOption, MatInput, NgFor, ReactiveFormsModule, PageHeaderComponent, MatInputModule]
+    imports: [RouterLink, FormsModule, MatDivider, MatButton, MatFormField, MatLabel, MatSelect, MatOption, MatInput, ReactiveFormsModule, PageHeaderComponent, MatInputModule]
 })
 export class SettingsConfigComponent implements OnInit, OnDestroy {
   private appSettingsService = inject(AppSettingsService);

--- a/src/app/core/components/configuration/config.component.ts
+++ b/src/app/core/components/configuration/config.component.ts
@@ -28,7 +28,6 @@ interface IRemoteConfig {
     selector: 'settings-config',
     templateUrl: './config.component.html',
     styleUrls: ['./config.component.scss'],
-    standalone: true,
     imports: [RouterLink, NgIf, FormsModule, MatDivider, MatButton, MatFormField, MatLabel, MatSelect, MatOption, MatInput, NgFor, ReactiveFormsModule, PageHeaderComponent, MatInputModule]
 })
 export class SettingsConfigComponent implements OnInit, OnDestroy {

--- a/src/app/core/components/dashboard/dashboard.component.ts
+++ b/src/app/core/components/dashboard/dashboard.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, DestroyRef, inject, OnDestroy, signal, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, DestroyRef, inject, OnDestroy, signal, viewChild } from '@angular/core';
 import { GridstackComponent, GridstackModule, NgGridStackOptions, NgGridStackWidget } from 'gridstack/dist/angular';
 import { GridItemHTMLElement } from 'gridstack';
 import { DashboardService, widgetOperation } from '../../services/dashboard.service';
@@ -53,7 +53,7 @@ export class DashboardComponent implements AfterViewInit, OnDestroy{
   protected readonly notificationsInfo = toSignal(this._notifications.observerNotificationsInfo());
   protected readonly isDashboardStatic = toSignal(this.dashboard.isDashboardStatic$);
   protected isLoading = signal(true);
-  @ViewChild('grid', { static: true }) private _gridstack!: GridstackComponent;
+  private readonly _gridstack = viewChild.required<GridstackComponent>('grid');
   private _previousIsStaticState = true;
   protected readonly gridOptions: NgGridStackOptions = {
     margin: 4,
@@ -92,20 +92,20 @@ export class DashboardComponent implements AfterViewInit, OnDestroy{
   ngAfterViewInit(): void {
     this.dashboard.isDashboardStatic$.pipe(takeUntilDestroyed(this._destroyRef)).subscribe((isStatic) => {
       if (isStatic) {
-        this._gridstack.grid.setStatic(isStatic);
+        this._gridstack().grid.setStatic(isStatic);
         if (isStatic !== this._previousIsStaticState) {
           this.saveDashboard();
           this._previousIsStaticState = isStatic;
         }
       } else {
-        this._gridstack.grid.setStatic(isStatic);
+        this._gridstack().grid.setStatic(isStatic);
         this._previousIsStaticState = isStatic;
       }
     });
 
     this.dashboard.widgetAction$.pipe(takeUntilDestroyed(this._destroyRef)).subscribe((action: widgetOperation) => {
       if (action) {
-        this._gridstack.grid.getGridItems().forEach((item: GridItemHTMLElement) => {
+        this._gridstack().grid.getGridItems().forEach((item: GridItemHTMLElement) => {
           if (item.gridstackNode.id === action.id) {
             switch (action.operation) {
               case 'delete':
@@ -137,12 +137,10 @@ export class DashboardComponent implements AfterViewInit, OnDestroy{
 
   ngOnDestroy(): void {
     // Destroy the Gridstack instance to clean up internal resources
-    if (this._gridstack?.grid) {
-      this._gridstack.grid.destroy(true); // Ensure this cleans up event listeners and DOM elements
+    const _gridstack = this._gridstack();
+    if (_gridstack?.grid) {
+      _gridstack.grid.destroy(true); // Ensure this cleans up event listeners and DOM elements
     }
-    // Remove the reference to the GridstackComponent
-    this._gridstack = null;
-
     this._uiEvent.removeHotkeyListener(this._boundHandleKeyDown);
   }
 
@@ -155,7 +153,7 @@ export class DashboardComponent implements AfterViewInit, OnDestroy{
   }
 
   protected resizeGridColumns(): void {
-    this._gridstack.grid.cellHeight(window.innerHeight / this._gridstack.grid.getRow());
+    this._gridstack().grid.cellHeight(window.innerHeight / this._gridstack().grid.getRow());
   }
 
   /**
@@ -167,16 +165,17 @@ export class DashboardComponent implements AfterViewInit, OnDestroy{
    */
   protected loadDashboard(dashboardId: number): void {
     const dashboard = this.dashboard.dashboards()[dashboardId];
-    if (this._gridstack?.grid) {
-      this._gridstack.grid.batchUpdate();
-      this._gridstack.grid.load(dashboard.configuration as NgGridStackWidget[]);
-      this._gridstack.grid.commit();
+    const _gridstack = this._gridstack();
+    if (_gridstack?.grid) {
+      _gridstack.grid.batchUpdate();
+      _gridstack.grid.load(dashboard.configuration as NgGridStackWidget[]);
+      _gridstack.grid.commit();
       this.isLoading.set(false);
     }
   }
 
   protected saveDashboard(): void {
-    const serializedData = this._gridstack.grid.save(false, false) as NgGridStackWidget[] || null;
+    const serializedData = this._gridstack().grid.save(false, false) as NgGridStackWidget[] || null;
     this.dashboard.updateConfiguration(this.dashboard.activeDashboard(), serializedData);
   }
 
@@ -193,11 +192,11 @@ export class DashboardComponent implements AfterViewInit, OnDestroy{
     if (!this.dashboard.isDashboardStatic()) {
       const inputX = (e as HammerInput).center.x;
       const inputY = (e as HammerInput).center.y;
-      const gridCell = this._gridstack.grid.getCellFromPixel({left: inputX, top: inputY});
-      const isCellEmpty = this._gridstack.grid.isAreaEmpty(gridCell.x, gridCell.y, 1, 1)
+      const gridCell = this._gridstack().grid.getCellFromPixel({left: inputX, top: inputY});
+      const isCellEmpty = this._gridstack().grid.isAreaEmpty(gridCell.x, gridCell.y, 1, 1)
 
       if (isCellEmpty) {
-        if (this._gridstack.grid.willItFit({x: gridCell.x, y: gridCell.y, w: 2, h: 3})) {
+        if (this._gridstack().grid.willItFit({x: gridCell.x, y: gridCell.y, w: 2, h: 3})) {
           this._dialog.openFrameDialog({
             title: 'Add Widget',
             component: 'select-widget',
@@ -222,7 +221,7 @@ export class DashboardComponent implements AfterViewInit, OnDestroy{
                 }
               }
             };
-            this._gridstack.grid.addWidget(newWidget);
+            this._gridstack().grid.addWidget(newWidget);
           });
         } else {
           this._app.sendSnackbarNotification('Error Adding Widget: Not enough space at the selected location. Please reorganize the dashboard to free up space or choose a larger empty area.', 0);
@@ -247,13 +246,14 @@ export class DashboardComponent implements AfterViewInit, OnDestroy{
       }
     } as NgGridStackWidget;
 
-    if(this._gridstack.grid.willItFit(newItem)) {
-      this._gridstack.grid.addWidget(newItem);
+    const _gridstack = this._gridstack();
+    if(_gridstack.grid.willItFit(newItem)) {
+      _gridstack.grid.addWidget(newItem);
     } else {
       newItem.h = 2;
       newItem.w = 2;
-      if(this._gridstack.grid.willItFit(newItem)) {
-        this._gridstack.grid.addWidget(newItem);
+      if(_gridstack.grid.willItFit(newItem)) {
+        _gridstack.grid.addWidget(newItem);
       } else {
        this._app.sendSnackbarNotification('Duplication failed: Insufficient space on the dashboard. Please reorganize to free up space.', 0);
       }
@@ -261,14 +261,14 @@ export class DashboardComponent implements AfterViewInit, OnDestroy{
   }
 
   private deleteWidget(item: GridItemHTMLElement): void {
-    this._gridstack.grid.removeWidget(item);
+    this._gridstack().grid.removeWidget(item);
   }
 
   protected nextDashboard(e: Event): void {
     e.preventDefault();
     if (this.dashboard.isDashboardStatic()) {
       this.dashboard.nextDashboard();
-      if (this._gridstack?.grid) {
+      if (this._gridstack()?.grid) {
         setTimeout(() => {
           this.loadDashboard(this.dashboard.activeDashboard());
         }, 0);
@@ -280,7 +280,7 @@ export class DashboardComponent implements AfterViewInit, OnDestroy{
     e.preventDefault();
     if (this.dashboard.isDashboardStatic()) {
       this.dashboard.previousDashboard();
-      if (this._gridstack?.grid) {
+      if (this._gridstack()?.grid) {
         setTimeout(() => {
           this.loadDashboard(this.dashboard.activeDashboard());
         }, 0);

--- a/src/app/core/components/data-inspector-row/data-inspector-row.component.ts
+++ b/src/app/core/components/data-inspector-row/data-inspector-row.component.ts
@@ -15,7 +15,6 @@ import { MatFormField, MatLabel } from '@angular/material/form-field';
     templateUrl: './data-inspector-row.component.html',
     styleUrls: ['./data-inspector-row.component.css'],
     encapsulation: ViewEncapsulation.None,
-    standalone: true,
     imports: [MatCell, MatButtonModule]
 })
 export class DataInspectorRowComponent implements OnInit {
@@ -62,7 +61,6 @@ export class DataInspectorRowComponent implements OnInit {
 @Component({
     selector: 'dialog-unit-selector',
     templateUrl: 'data-inspector-row-unit-modal.html',
-    standalone: true,
     imports: [
     MatDialogTitle,
     MatDialogContent,

--- a/src/app/core/components/data-inspector/data-inspector.component.ts
+++ b/src/app/core/components/data-inspector/data-inspector.component.ts
@@ -1,5 +1,5 @@
 import { MatIconModule } from '@angular/material/icon';
-import { Component, AfterViewInit, OnDestroy, inject, DestroyRef, ViewChild, Signal, effect } from '@angular/core';
+import { Component, AfterViewInit, OnDestroy, inject, DestroyRef, Signal, effect, viewChild } from '@angular/core';
 import { MatTableDataSource, MatTableModule } from '@angular/material/table';
 import { DataService } from '../../services/data.service';
 import { ISkPathData } from "../../interfaces/app-interfaces";
@@ -30,8 +30,8 @@ export class DataInspectorComponent implements AfterViewInit, OnDestroy {
   private isPhonePortrait: Signal<BreakpointState>;
   private filterSubject = new Subject<string>();
 
-  @ViewChild(MatPaginator) paginator!: MatPaginator;
-  @ViewChild(MatSort) sort!: MatSort;
+  readonly paginator = viewChild.required(MatPaginator);
+  readonly sort = viewChild.required(MatSort);
   protected readonly pageTitle = 'Data Inspector';
 
   public pageSize = 25;
@@ -97,8 +97,8 @@ export class DataInspectorComponent implements AfterViewInit, OnDestroy {
       });
 
     // Assign paginator and sort to the tableData
-    this.tableData.paginator = this.paginator;
-    this.tableData.sort = this.sort;
+    this.tableData.paginator = this.paginator();
+    this.tableData.sort = this.sort();
 
     // Add a custom sorting accessor for the "supportsPut" column
     this.tableData.sortingDataAccessor = (item, property) => {

--- a/src/app/core/components/data-inspector/data-inspector.component.ts
+++ b/src/app/core/components/data-inspector/data-inspector.component.ts
@@ -21,7 +21,6 @@ import { BreakpointObserver, Breakpoints, BreakpointState } from '@angular/cdk/l
     selector: 'data-inspector',
     templateUrl: './data-inspector.component.html',
     styleUrls: ['./data-inspector.component.scss'],
-    standalone: true,
     imports: [ MatFormFieldModule, MatTableModule, MatInputModule, MatPaginatorModule, MatSortModule, DataInspectorRowComponent, KeyValuePipe, PageHeaderComponent, MatIconModule]
 })
 export class DataInspectorComponent implements AfterViewInit, OnDestroy {

--- a/src/app/core/components/datasets/datasets.component.ts
+++ b/src/app/core/components/datasets/datasets.component.ts
@@ -27,7 +27,6 @@ import { PageHeaderComponent } from '../page-header/page-header.component';
     selector: 'settings-datasets',
     templateUrl: './datasets.component.html',
     styleUrls: ['./datasets.component.scss'],
-    standalone: true,
     imports: [FormsModule, MatFormField, MatLabel, MatInput, MatTable, MatSort, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatSortHeader, MatCellDef, MatCell, MatButton, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow, MatNoDataRow, MatPaginator, MatDivider, PageHeaderComponent]
 })
 export class SettingsDatasetsComponent implements OnInit, AfterViewInit {
@@ -135,7 +134,6 @@ export class SettingsDatasetsComponent implements OnInit, AfterViewInit {
     selector: 'settings-datasets-modal',
     templateUrl: './datasets.modal.html',
     styleUrls: ['./datasets.component.scss'],
-    standalone: true,
     imports: [MatRadioModule, MatDialogTitle, MatDialogContent, FormsModule, MatStepper, MatStep, MatStepLabel, MatFormField, MatLabel, MatSelect, MatOption, MatCheckbox, MatDivider, MatButton, MatStepperNext, MatInput, MatStepperPrevious, FilterSelfPipe]
 })
 export class SettingsDatasetsModalComponent implements OnInit {

--- a/src/app/core/components/menu-notifications/menu-notifications.component.ts
+++ b/src/app/core/components/menu-notifications/menu-notifications.component.ts
@@ -15,7 +15,6 @@ import isEqual from 'lodash-es/isEqual';
     selector: 'menu-notifications',
     templateUrl: './menu-notifications.component.html',
     styleUrls: ['./menu-notifications.component.scss'],
-    standalone: true,
     imports: [MatListModule, MatButtonModule, MatBadgeModule, MatTooltipModule, MatIconModule, SlicePipe]
 })
 export class MenuNotificationsComponent {

--- a/src/app/core/components/modal-user-credential/modal-user-credential.component.ts
+++ b/src/app/core/components/modal-user-credential/modal-user-credential.component.ts
@@ -11,7 +11,6 @@ import { FormsModule } from '@angular/forms';
     selector: 'app-modal-user-credential',
     templateUrl: './modal-user-credential.component.html',
     styleUrls: ['./modal-user-credential.component.scss'],
-    standalone: true,
     imports: [FormsModule, MatDialogTitle, MatDialogContent, MatFormField, MatLabel, MatInput, MatError, MatDivider, MatDialogActions, MatButton, MatDialogClose]
 })
 export class ModalUserCredentialComponent {

--- a/src/app/settings/display/display.component.ts
+++ b/src/app/settings/display/display.component.ts
@@ -17,7 +17,6 @@ import { DataService } from '../../core/services/data.service';
     selector: 'settings-display',
     templateUrl: './display.component.html',
     styleUrls: ['./display.component.scss'],
-    standalone: true,
     imports: [
         FormsModule,
         MatCheckbox,

--- a/src/app/settings/notifications/notifications.component.ts
+++ b/src/app/settings/notifications/notifications.component.ts
@@ -17,7 +17,6 @@ import { toSignal } from '@angular/core/rxjs-interop';
     selector: 'settings-notifications',
     templateUrl: './notifications.component.html',
     styleUrls: ['./notifications.component.scss'],
-    standalone: true,
 
     imports: [
         FormsModule,

--- a/src/app/settings/settings/settings.component.ts
+++ b/src/app/settings/settings/settings.component.ts
@@ -11,7 +11,6 @@ import { PageHeaderComponent } from '../../core/components/page-header/page-head
     selector: 'settings',
     templateUrl: './settings.component.html',
     styleUrls: ['./settings.component.scss'],
-    standalone: true,
     imports: [
       MatTabGroup,
       MatTab,

--- a/src/app/settings/signalk/signalk.component.ts
+++ b/src/app/settings/signalk/signalk.component.ts
@@ -33,7 +33,6 @@ import 'chartjs-adapter-date-fns';
     selector: 'settings-signalk',
     templateUrl: './signalk.component.html',
     styleUrls: ['./signalk.component.scss'],
-    standalone: true,
     imports: [
         FormsModule,
         MatFormField,

--- a/src/app/settings/units/units.component.ts
+++ b/src/app/settings/units/units.component.ts
@@ -14,7 +14,6 @@ import { KeyValuePipe } from '@angular/common';
     selector: 'settings-units',
     templateUrl: './units.component.html',
     styleUrls: ['./units.component.scss'],
-    standalone: true,
     imports: [FormsModule, ReactiveFormsModule, MatFormField, MatLabel, MatSelect, MatOption, MatDivider, MatButton, KeyValuePipe]
 })
 export class SettingsUnitsComponent implements OnInit {

--- a/src/app/widget-config/boolean-control-config/boolean-control-config.component.ts
+++ b/src/app/widget-config/boolean-control-config/boolean-control-config.component.ts
@@ -18,7 +18,6 @@ export interface IDeleteEventObj {
     selector: 'boolean-control-config',
     templateUrl: './boolean-control-config.component.html',
     styleUrls: ['./boolean-control-config.component.scss'],
-    standalone: true,
     imports: [FormsModule, ReactiveFormsModule, MatFormField, MatLabel, MatInput, MatSelect, MatOption, MatIconButton, MatCheckboxModule, MatIconModule]
 })
 export class BooleanControlConfigComponent implements OnInit {

--- a/src/app/widget-config/boolean-multicontrol-options/boolean-multicontrol-options.component.ts
+++ b/src/app/widget-config/boolean-multicontrol-options/boolean-multicontrol-options.component.ts
@@ -18,7 +18,6 @@ export interface IAddNewPathObject {
     selector: 'boolean-multicontrol-options',
     templateUrl: './boolean-multicontrol-options.component.html',
     styleUrls: ['./boolean-multicontrol-options.component.css'],
-    standalone: true,
     imports: [
         FormsModule,
         ReactiveFormsModule,

--- a/src/app/widget-config/display-datetime/display-datetime.component.html
+++ b/src/app/widget-config/display-datetime/display-datetime.component.html
@@ -12,11 +12,11 @@
     <input type="text" matInput
       placeholder="Type to use autocomplete"
       name="dateTimezone"
-      [formControl]="dateTimezone"
+      [formControl]="dateTimezone()"
       required
       [matAutocomplete]="timeZoneAutoComplete">
-    @if (dateTimezone.value) {
-      <button mat-icon-button matSuffix aria-label="Clear" (click)="dateTimezone.setValue('')">
+    @if (dateTimezone().value) {
+      <button mat-icon-button matSuffix aria-label="Clear" (click)="dateTimezone().setValue('')">
         <span class="fa-solid fa-close"></span>
       </button>
     }

--- a/src/app/widget-config/display-datetime/display-datetime.component.ts
+++ b/src/app/widget-config/display-datetime/display-datetime.component.ts
@@ -40,7 +40,6 @@ export const getDynamicTimeZones = (): ITzDefinition[] => {
     selector: 'display-datetime-options',
     templateUrl: './display-datetime.component.html',
     styleUrls: ['./display-datetime.component.css'],
-    standalone: true,
     imports: [MatFormField, MatLabel, MatInput, FormsModule, ReactiveFormsModule, MatAutocompleteTrigger, MatIconButton, MatSuffix, MatAutocomplete, MatOption, AsyncPipe]
 })
 export class DisplayDatetimeComponent implements OnInit, OnDestroy {

--- a/src/app/widget-config/modal-widget-config/modal-widget-config.component.html
+++ b/src/app/widget-config/modal-widget-config/modal-widget-config.component.html
@@ -105,11 +105,6 @@
                 </display-datetime-options>
               }
               <!-- Autopilot gauge stuff -->
-              <!-- <mat-checkbox *ngIf="(widgetConfig.courseDirectionTrue !== undefined)"
-              name="courseDirectionTrue"
-              formControlName="courseDirectionTrue">
-              Display True Bearing
-            </mat-checkbox> -->
             @if ((widgetConfig.headingDirectionTrue !== undefined)) {
               <mat-checkbox
                 name="headingDirectionTrue"

--- a/src/app/widget-config/modal-widget-config/modal-widget-config.component.ts
+++ b/src/app/widget-config/modal-widget-config/modal-widget-config.component.ts
@@ -27,7 +27,6 @@ import { DisplayDatetimeComponent } from '../display-datetime/display-datetime.c
     selector: 'modal-widget-config',
     templateUrl: './modal-widget-config.component.html',
     styleUrls: ['./modal-widget-config.component.scss'],
-    standalone: true,
     imports: [FormsModule, ReactiveFormsModule, MatDialogTitle, MatDialogContent, MatTabGroup, MatTab, MatFormField, MatLabel, MatInput, MatCheckbox, MatSelect, MatOption, MatTabLabel, MatDivider, MatDialogActions, MatButton, MatDialogClose, DisplayDatetimeComponent, DisplayChartOptionsComponent, DatasetChartOptionsComponent, BooleanMultiControlOptionsComponent, PathsOptionsComponent]
 })
 export class ModalWidgetConfigComponent implements OnInit {

--- a/src/app/widget-config/path-control-config/path-control-config.component.html
+++ b/src/app/widget-config/path-control-config/path-control-config.component.html
@@ -1,9 +1,9 @@
-@if (pathFormGroup.value.isPathConfigurable) {
-  <div [formGroup]="pathFormGroup" class="flex-container rounded-card rounded-card-color">
+@if (pathFormGroup().value.isPathConfigurable) {
+  <div [formGroup]="pathFormGroup()" class="flex-container rounded-card rounded-card-color">
     <div class="flex-field-100">
-      <span [style.color]="pathFormGroup.enabled ? '' : 'rgba(255,255,255,0.5)'">{{pathFormGroup.value.description}}</span>
+      <span [style.color]="pathFormGroup().enabled ? '' : 'rgba(255,255,255,0.5)'">{{pathFormGroup().value.description}}</span>
     </div>
-      @if (pathFormGroup.value.pathType === 'number' && showPathSkUnitsFilter) {
+      @if (pathFormGroup().value.pathType === 'number' && showPathSkUnitsFilter) {
         <div class="flex-field-fixed">
           <mat-form-field floatLabel="auto" appearance="fill" class="filter-path">
             <mat-label>
@@ -16,7 +16,7 @@
             <mat-select #pathUnitsFilter
               [formControl]="pathSkUnitsFilterControl"
               panelWidth=""
-              (selectionChange)="pathFormGroup.controls['path'].setValue(pathInput.value)">
+              (selectionChange)="pathFormGroup().controls['path'].setValue(pathInput.value)">
               <mat-option>All</mat-option>
               @for (item of pathSkUnitsFiltersList; track $index) {
                 <mat-option [value]="item">{{item.properties.quantity}}: {{item.properties.display}}</mat-option>
@@ -29,7 +29,7 @@
         <mat-form-field floatLabel="auto" appearance="fill" class="pathField">
           <mat-label>
             Signal K Path
-            @if (pathFormGroup.value.pathRequired === false) {
+            @if (pathFormGroup().value.pathRequired === false) {
               <span class="optional-label">(optional)</span>
             }
           </mat-label>
@@ -38,19 +38,19 @@
             formControlName="path"
             [matAutocomplete]="pathAutoComplete"
           >
-          @if (pathFormGroup.value.pathRequired === false) {
+          @if (pathFormGroup().value.pathRequired === false) {
             <mat-hint>Leave blank to disable this path.</mat-hint>
           }
-          @if (pathFormGroup.value.path) {
-            <button mat-icon-button matIconSuffix aria-label="Clear" (click)="pathFormGroup.controls['path'].setValue('')">
+          @if (pathFormGroup().value.path) {
+            <button mat-icon-button matIconSuffix aria-label="Clear" (click)="pathFormGroup().controls['path'].setValue('')">
               <mat-icon>close</mat-icon>
             </button>
           }
-          @if (pathFormGroup.controls['path'].errors?.['required']) {
+          @if (pathFormGroup().controls['path'].errors?.['required']) {
             <mat-error>
               Path is required. Please enter a valid Signal K path.
             </mat-error>
-          } @else if (pathFormGroup.controls['path'].errors?.['requireMatch']) {
+          } @else if (pathFormGroup().controls['path'].errors?.['requireMatch']) {
             <mat-error>
               Path not recognized. Please enter a path from the server's published list.
             </mat-error>
@@ -97,7 +97,7 @@
         </mat-form-field>
       </div>
       <div class="unitField">
-        @if ((pathFormGroup.value.pathType === 'number' && pathFormGroup.value.showConvertUnitTo === undefined) || (pathFormGroup.value.pathType === 'number' && pathFormGroup.value.showConvertUnitTo === true)) {
+        @if ((pathFormGroup().value.pathType === 'number' && pathFormGroup().value.showConvertUnitTo === undefined) || (pathFormGroup().value.pathType === 'number' && pathFormGroup().value.showConvertUnitTo === true)) {
           <mat-form-field class="fields">
             <mat-label>Display Format</mat-label>
             <mat-select

--- a/src/app/widget-config/path-control-config/path-control-config.component.ts
+++ b/src/app/widget-config/path-control-config/path-control-config.component.ts
@@ -46,7 +46,6 @@ function pathRequiredOrValidMatch(getPaths: () => IPathMetaData[]): ValidatorFn 
     selector: 'path-control-config',
     templateUrl: './path-control-config.component.html',
     styleUrls: ['./path-control-config.component.scss'],
-    standalone: true,
     imports: [FormsModule, ReactiveFormsModule, MatFormField, MatLabel, MatInput, MatAutocompleteModule, MatIconButton, MatSuffix, MatOption, MatError, MatSelect, MatOptgroup, AsyncPipe, MatIconModule, MatHint]
 })
 export class ModalPathControlConfigComponent implements OnInit, OnChanges, OnDestroy {

--- a/src/app/widget-config/path-control-config/path-control-config.component.ts
+++ b/src/app/widget-config/path-control-config/path-control-config.component.ts
@@ -1,10 +1,10 @@
-import { Component, Input, OnInit, OnChanges, SimpleChange, OnDestroy, input, inject } from '@angular/core';
+import { Component, OnInit, OnChanges, SimpleChange, input, inject, DestroyRef } from '@angular/core';
 import { DataService } from '../../core/services/data.service';
 import { IPathMetaData } from "../../core/interfaces/app-interfaces";
 import { IConversionPathList, ISkBaseUnit, UnitsService } from '../../core/services/units.service';
 import { UntypedFormGroup, UntypedFormControl, Validators, ValidatorFn, AbstractControl, ValidationErrors, FormsModule, ReactiveFormsModule, FormControl, FormGroup } from '@angular/forms';
 import { debounce, map, startWith } from 'rxjs/operators';
-import { BehaviorSubject, Subscription, timer } from 'rxjs'
+import { BehaviorSubject, timer } from 'rxjs'
 import { MatSelect } from '@angular/material/select';
 import { MatOption, MatOptgroup } from '@angular/material/core';
 import { MatIconButton } from '@angular/material/button';
@@ -16,6 +16,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { compare } from 'compare-versions';
 import { SignalKConnectionService } from '../../core/services/signalk-connection.service';
 import { IDynamicControl } from '../../core/interfaces/widgets-interface';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 function pathRequiredOrValidMatch(getPaths: () => IPathMetaData[]): ValidatorFn {
   return (control: AbstractControl): ValidationErrors | null => {
@@ -48,19 +49,18 @@ function pathRequiredOrValidMatch(getPaths: () => IPathMetaData[]): ValidatorFn 
     styleUrls: ['./path-control-config.component.scss'],
     imports: [FormsModule, ReactiveFormsModule, MatFormField, MatLabel, MatInput, MatAutocompleteModule, MatIconButton, MatSuffix, MatOption, MatError, MatSelect, MatOptgroup, AsyncPipe, MatIconModule, MatHint]
 })
-export class ModalPathControlConfigComponent implements OnInit, OnChanges, OnDestroy {
-  private _data = inject(DataService);
-  private _units = inject(UnitsService);
-  private _connection = inject(SignalKConnectionService);
+export class ModalPathControlConfigComponent implements OnInit, OnChanges {
+  private readonly _data = inject(DataService);
+  private readonly _units = inject(UnitsService);
+  private readonly _connection = inject(SignalKConnectionService);
+  private readonly _destroyRef = inject(DestroyRef);
 
-  @Input() pathFormGroup!: UntypedFormGroup;
+  readonly pathFormGroup = input.required<UntypedFormGroup>();
   readonly multiCTRLArray = input.required<IDynamicControl[]>();
   readonly filterSelfPaths = input.required<boolean>();
 
   public availablePaths: IPathMetaData[];
   public filteredPaths = new BehaviorSubject<IPathMetaData[] | null>(null);
-  private _pathValueChange$: Subscription = null;
-  private _pathFormGroup$: Subscription = null;
 
   // Sources control
   public availableSources: string[];
@@ -75,57 +75,59 @@ export class ModalPathControlConfigComponent implements OnInit, OnChanges, OnDes
   ngOnInit() {
     // Do not process if path is disabled. Disabled path control (isPathConfigurable: false
     // widget property) means the path is hardcoded and cannot be changed by the user.
-    if (this.pathFormGroup.controls['path'].disabled) return;
+    const pathFormGroup = this.pathFormGroup();
+    if (pathFormGroup.controls['path'].disabled) return;
     // Path Unit filter setup
     this.pathSkUnitsFiltersList = this._units.skBaseUnits.sort((a, b) => {
       return a.properties.quantity > b.properties.quantity ? 1 : -1;
     });
     this.pathSkUnitsFiltersList.unshift(this.unitlessUnit);
 
-    if (this.pathFormGroup.value.pathSkUnitsFilter) {
-      this.pathSkUnitsFilterControl.setValue(this.pathSkUnitsFiltersList.find(item => item.unit === this.pathFormGroup.value.pathSkUnitsFilter), {onlySelf: true});
+    if (pathFormGroup.value.pathSkUnitsFilter) {
+      this.pathSkUnitsFilterControl.setValue(this.pathSkUnitsFiltersList.find(item => item.unit === this.pathFormGroup().value.pathSkUnitsFilter), {onlySelf: true});
     }
 
-    if (this.pathFormGroup.value.showPathSkUnitsFilter) {
-      this.showPathSkUnitsFilter = this.pathFormGroup.value.showPathSkUnitsFilter;
+    if (pathFormGroup.value.showPathSkUnitsFilter) {
+      this.showPathSkUnitsFilter = pathFormGroup.value.showPathSkUnitsFilter;
     }
 
     // add path validator fn and validate
-    this.pathFormGroup.controls['path'].setValidators([
+    pathFormGroup.controls['path'].setValidators([
       pathRequiredOrValidMatch(() => this.getPaths())
     ]);
-    this.pathFormGroup.controls['path'].updateValueAndValidity({onlySelf: true, emitEvent: false});
+    pathFormGroup.controls['path'].updateValueAndValidity({onlySelf: true, emitEvent: false});
     // Subscribe to pathRequired changes to re-validate path
-    if (this.pathFormGroup.controls['pathRequired']) {
-      this.pathFormGroup.controls['pathRequired'].valueChanges.subscribe(() => {
-        this.pathFormGroup.controls['path'].updateValueAndValidity();
+    if (pathFormGroup.controls['pathRequired']) {
+      pathFormGroup.controls['pathRequired'].valueChanges.pipe(takeUntilDestroyed(this._destroyRef)).subscribe(() => {
+        this.pathFormGroup().controls['path'].updateValueAndValidity();
       });
     }
-    if (this.pathFormGroup.controls['path'].valid) {
+    if (pathFormGroup.controls['path'].valid) {
       this.enableFormFields(false);
     } else {
       this.disablePathFields();
     }
 
     // If SampleTime control is not present because the path property is missing, add it.
-    if (!this.pathFormGroup.controls['sampleTime']) {
-      this.pathFormGroup.addControl('sampleTime', new UntypedFormControl('500', Validators.required));
-      this.pathFormGroup.controls['sampleTime'].updateValueAndValidity({onlySelf: true, emitEvent: false});
+    if (!pathFormGroup.controls['sampleTime']) {
+      pathFormGroup.addControl('sampleTime', new UntypedFormControl('500', Validators.required));
+      pathFormGroup.controls['sampleTime'].updateValueAndValidity({onlySelf: true, emitEvent: false});
     }
 
     // subscribe to path formControl changes
-    this._pathValueChange$ = this.pathFormGroup.controls['path'].valueChanges.pipe(
+    pathFormGroup.controls['path'].valueChanges.pipe(
       debounce(value => value === '' ? timer(0) : timer(350)),
       startWith(''),
       map(value => this.filterPaths(value || '')))
-      .subscribe(() => {
-        if (this.pathFormGroup.controls['path'].pristine) {
+      .pipe(takeUntilDestroyed(this._destroyRef)).subscribe(() => {
+        const pathFormGroupValue = this.pathFormGroup();
+        if (pathFormGroupValue.controls['path'].pristine) {
           return;
         } else {
-          if (this.pathFormGroup.controls['path'].valid){
+          if (pathFormGroupValue.controls['path'].valid){
             this.enableFormFields(true);
-            this.updatePathMetaBoundDisplayName(this.pathFormGroup.controls['path'].value);
-            this.updatePathMetaBoundDisplayScale(this.pathFormGroup.controls['path'].value);
+            this.updatePathMetaBoundDisplayName(pathFormGroupValue.controls['path'].value);
+            this.updatePathMetaBoundDisplayScale(pathFormGroupValue.controls['path'].value);
           } else {
             this.disablePathFields();
           }
@@ -133,39 +135,41 @@ export class ModalPathControlConfigComponent implements OnInit, OnChanges, OnDes
       }
     );
 
-    this._pathFormGroup$ = this.pathFormGroup.controls['pathType'].valueChanges.subscribe(() => {
-      if (this.pathFormGroup.value.showPathSkUnitsFilter) {
+    pathFormGroup.controls['pathType'].valueChanges.pipe(takeUntilDestroyed(this._destroyRef)).subscribe(() => {
+      const pathFormGroupValue = this.pathFormGroup();
+      if (pathFormGroupValue.value.showPathSkUnitsFilter) {
         this.pathSkUnitsFilterControl.setValue(this.unitlessUnit);
       } else {
         this.pathSkUnitsFilterControl.setValue(null);
       }
-      this.pathFormGroup.controls['path'].updateValueAndValidity();
+      pathFormGroupValue.controls['path'].updateValueAndValidity();
     });
   }
 
   ngOnChanges(changes: Record<string, SimpleChange>) {
     //subscribe to filterSelfPaths parent formControl changes
     if (changes['filterSelfPaths'] && !changes['filterSelfPaths'].firstChange) {
-      this.pathFormGroup.controls['path'].updateValueAndValidity();
+      this.pathFormGroup().controls['path'].updateValueAndValidity();
     }
   }
 
   private getPaths(): IPathMetaData[] {
-    const pathType = this.pathFormGroup.controls['pathType'].value;
+    const pathType = this.pathFormGroup().controls['pathType'].value;
     const filterSelfPaths = this.filterSelfPaths();
     let supportsPUT = false;
-    if (this.pathFormGroup.value.supportsPut) {
+    const pathFormGroup = this.pathFormGroup();
+    if (pathFormGroup.value.supportsPut) {
       let isMultiCTRLTypeLight = false;
       if (this.multiCTRLArray().length > 0) {
         isMultiCTRLTypeLight = this.multiCTRLArray().some((ctrlItem: IDynamicControl) =>
-            ctrlItem.pathID === this.pathFormGroup.value.pathID && ctrlItem.type === '3' // type 3 = light
+            ctrlItem.pathID === this.pathFormGroup().value.pathID && ctrlItem.type === '3' // type 3 = light
           );
       }
 
       if (isMultiCTRLTypeLight) {
         supportsPUT = false;
       } else {
-        supportsPUT = compare(this._connection.skServerVersion, '2.12.0', ">=") ? this.pathFormGroup.value.supportsPut : false;
+        supportsPUT = compare(this._connection.skServerVersion, '2.12.0', ">=") ? pathFormGroup.value.supportsPut : false;
       }
     }
     return this._data.getPathsAndMetaByType(pathType, supportsPUT, filterSelfPaths).sort();
@@ -193,34 +197,35 @@ export class ModalPathControlConfigComponent implements OnInit, OnChanges, OnDes
   }
 
   private enableFormFields(setValues?: boolean): void {
-    const pathObject = this._data.getPathObject(this.pathFormGroup.controls['path'].value);
+    const pathObject = this._data.getPathObject(this.pathFormGroup().controls['path'].value);
     if (pathObject != null) {
-      this.pathFormGroup.controls['sampleTime'].enable({onlySelf: false});
-      if (this.pathFormGroup.controls['pathType'].value == 'number') { // convertUnitTo control not present unless pathType is number
-        this.unitList = this._units.getConversionsForPath(this.pathFormGroup.controls['path'].value); // array of Group or Groups: "angle", "speed", etc...
+      this.pathFormGroup().controls['sampleTime'].enable({onlySelf: false});
+      const pathFormGroup = this.pathFormGroup();
+      if (pathFormGroup.controls['pathType'].value == 'number') { // convertUnitTo control not present unless pathType is number
+        this.unitList = this._units.getConversionsForPath(pathFormGroup.controls['path'].value); // array of Group or Groups: "angle", "speed", etc...
         if (setValues) {
-          this.pathFormGroup.controls['convertUnitTo'].setValue(this.unitList.base, {onlySelf: true});
+          pathFormGroup.controls['convertUnitTo'].setValue(this.unitList.base, {onlySelf: true});
         }
-        this.pathFormGroup.controls['convertUnitTo'].enable({onlySelf: false});
+        pathFormGroup.controls['convertUnitTo'].enable({onlySelf: false});
       }
 
       if (Object.keys(pathObject.sources).length == 1) {
         this.availableSources = ['default'];
         if (setValues) {
-          if (this.pathFormGroup.controls['source'].value != 'default') {
-            this.pathFormGroup.controls['source'].setValue('default', {onlySelf: true});
+          if (pathFormGroup.controls['source'].value != 'default') {
+            pathFormGroup.controls['source'].setValue('default', {onlySelf: true});
           }
         }
-        else if (this.pathFormGroup.controls['source'].value != 'default') {
-          this.pathFormGroup.controls['source'].setValue('', {onlySelf: true});
+        else if (pathFormGroup.controls['source'].value != 'default') {
+          pathFormGroup.controls['source'].setValue('', {onlySelf: true});
         }
       } else if (Object.keys(pathObject.sources).length > 1) {
         this.availableSources = Object.keys(pathObject.sources);
-        if (this.pathFormGroup.controls['source'].value == 'default') {
-          this.pathFormGroup.controls['source'].reset();
+        if (pathFormGroup.controls['source'].value == 'default') {
+          pathFormGroup.controls['source'].reset();
         }
       }
-      this.pathFormGroup.controls['source'].enable({onlySelf: false});
+      pathFormGroup.controls['source'].enable({onlySelf: false});
     } else {
       // we don't know this path. Maybe and old saved path...
       this.disablePathFields();
@@ -228,30 +233,33 @@ export class ModalPathControlConfigComponent implements OnInit, OnChanges, OnDes
   }
 
   private disablePathFields(): void {
-    this.pathFormGroup.controls['source'].reset('', {onlySelf: true});
-    this.pathFormGroup.controls['source'].disable({onlySelf: false});
-    this.pathFormGroup.controls['sampleTime'].disable({onlySelf: false});
-    if (this.pathFormGroup.controls['pathType'].value == 'number') { // convertUnitTo control not present unless pathType is number
-      this.pathFormGroup.controls['convertUnitTo'].reset('', {onlySelf: true});
-      this.pathFormGroup.controls['convertUnitTo'].disable({onlySelf: false});
+    this.pathFormGroup().controls['source'].reset('', {onlySelf: true});
+    this.pathFormGroup().controls['source'].disable({onlySelf: false});
+    this.pathFormGroup().controls['sampleTime'].disable({onlySelf: false});
+    const pathFormGroup = this.pathFormGroup();
+    if (pathFormGroup.controls['pathType'].value == 'number') { // convertUnitTo control not present unless pathType is number
+      pathFormGroup.controls['convertUnitTo'].reset('', {onlySelf: true});
+      pathFormGroup.controls['convertUnitTo'].disable({onlySelf: false});
     }
   }
 
   private updatePathMetaBoundDisplayName(path: string) {
-    if (!Object.prototype.hasOwnProperty.call(this.pathFormGroup.parent.parent.value, 'displayName')) {return;}
+    const pathFormGroup = this.pathFormGroup();
+    if (!Object.prototype.hasOwnProperty.call(pathFormGroup.parent.parent.value, 'displayName')) {return;}
     const meta = this._data.getPathMeta(path);
     if (meta?.displayName) {
-      this.pathFormGroup.parent.parent.controls['displayName'].setValue(meta.displayName);
+      pathFormGroup.parent.parent.controls['displayName'].setValue(meta.displayName);
     }
   }
 
   private updatePathMetaBoundDisplayScale(path: string) {
-    if (!Object.prototype.hasOwnProperty.call(this.pathFormGroup.parent.parent.value, 'displayScale')) {return;}
+    const pathFormGroup = this.pathFormGroup();
+    if (!Object.prototype.hasOwnProperty.call(pathFormGroup.parent.parent.value, 'displayScale')) {return;}
 
     const meta = this._data.getPathMeta(path);
     if (meta?.displayScale) {
-      const displayScale = this.pathFormGroup.parent.parent.get('displayScale') as FormGroup;
-      const unit = this.pathFormGroup.controls['convertUnitTo'].value;
+      const displayScale = pathFormGroup.parent.parent.get('displayScale') as FormGroup;
+      const unit = pathFormGroup.controls['convertUnitTo'].value;
 
       if (meta.displayScale.lower !== null && meta.displayScale.lower !== undefined) {
         displayScale.controls['lower'].setValue(this._units.convertToUnit(unit, meta.displayScale.lower));
@@ -266,10 +274,5 @@ export class ModalPathControlConfigComponent implements OnInit, OnChanges, OnDes
         displayScale.controls['power'].setValue(meta.displayScale.power);
       }
     }
-  }
-
-  ngOnDestroy(): void {
-    this._pathValueChange$?.unsubscribe();
-    this._pathFormGroup$?.unsubscribe();
   }
 }

--- a/src/app/widget-config/paths-options/paths-options.component.ts
+++ b/src/app/widget-config/paths-options/paths-options.component.ts
@@ -18,7 +18,6 @@ export interface IAddNewPath {
     selector: 'paths-options',
     templateUrl: './paths-options.component.html',
     styleUrls: ['./paths-options.component.scss'],
-    standalone: true,
     imports: [MatCheckbox, FormsModule, ReactiveFormsModule, MatFormField, MatLabel, MatInput, MatSuffix, ModalPathControlConfigComponent, ObjectKeysPipe]
 })
 export class PathsOptionsComponent implements OnInit, OnChanges {

--- a/src/app/widgets/gauge-steel/gauge-steel.component.ts
+++ b/src/app/widgets/gauge-steel/gauge-steel.component.ts
@@ -46,7 +46,6 @@ export const SteelFrameColors = {
     selector: 'gauge-steel',
     templateUrl: './gauge-steel.component.html',
     styleUrls: ['./gauge-steel.component.scss'],
-    standalone: true,
     imports: [NgxResizeObserverModule]
 })
 export class GaugeSteelComponent implements OnInit, OnChanges {

--- a/src/app/widgets/svg-simple-linear-gauge/svg-simple-linear-gauge.component.ts
+++ b/src/app/widgets/svg-simple-linear-gauge/svg-simple-linear-gauge.component.ts
@@ -1,4 +1,4 @@
-import { ViewChild, ElementRef, Component, SimpleChanges, OnChanges, OnDestroy, input } from '@angular/core';
+import { ElementRef, Component, SimpleChanges, OnChanges, input, viewChild } from '@angular/core';
 
 @Component({
     selector: 'svg-simple-linear-gauge',
@@ -6,8 +6,8 @@ import { ViewChild, ElementRef, Component, SimpleChanges, OnChanges, OnDestroy, 
     styleUrl: './svg-simple-linear-gauge.component.scss',
     standalone: true
 })
-export class SvgSimpleLinearGaugeComponent implements OnChanges, OnDestroy {
-  @ViewChild('gaugeBarAnimate', {static: false}) gaugeBarAnimate: ElementRef;
+export class SvgSimpleLinearGaugeComponent implements OnChanges {
+  readonly gaugeBarAnimate = viewChild<ElementRef>('gaugeBarAnimate');
   readonly displayName = input.required<string>();
   readonly displayNameColor = input.required<string>();
   readonly dataValue = input.required<string>();
@@ -35,18 +35,15 @@ export class SvgSimpleLinearGaugeComponent implements OnChanges, OnDestroy {
         this.oldGaugeValue = this.newGaugeValue;
         this.newGaugeValue = (changes.gaugeValue.currentValue - this.gaugeMinValue()) * scaleSliceValue;
 
-        if (this.gaugeBarAnimate?.nativeElement) {
+        if (this.gaugeBarAnimate()?.nativeElement) {
           requestAnimationFrame(() => {
-            if (this.gaugeBarAnimate?.nativeElement) {
-              this.gaugeBarAnimate.nativeElement.beginElement();
+            const gaugeBarAnimate = this.gaugeBarAnimate();
+            if (gaugeBarAnimate?.nativeElement) {
+              gaugeBarAnimate.nativeElement.beginElement();
             }
           });
         }
       }
     }
-  }
-
-  ngOnDestroy() {
-    this.gaugeBarAnimate = null;
   }
 }

--- a/src/app/widgets/svg-wind/svg-wind.component.ts
+++ b/src/app/widgets/svg-wind/svg-wind.component.ts
@@ -12,7 +12,6 @@ interface ISVGRotationObject {
     selector: 'app-svg-wind',
     templateUrl: './svg-wind.component.svg',
     styleUrl: './svg-wind.component.scss',
-    standalone: true,
     imports: []
 })
 export class SvgWindComponent {

--- a/src/app/widgets/widget-autopilot/widget-autopilot.component.ts
+++ b/src/app/widgets/widget-autopilot/widget-autopilot.component.ts
@@ -51,7 +51,6 @@ interface MenuItem {
     selector: 'widget-autopilot',
     templateUrl: './widget-autopilot.component.html',
     styleUrls: ['./widget-autopilot.component.scss'],
-    standalone: true,
     imports: [WidgetHostComponent, SvgAutopilotComponent, MatButtonModule, TitleCasePipe, MatIconModule, MatBadgeModule, WidgetPositionComponent, WidgetNumericComponent, WidgetDatetimeComponent],
 })
 export class WidgetAutopilotComponent extends BaseWidgetComponent implements OnInit, OnDestroy {

--- a/src/app/widgets/widget-boolean-switch/widget-boolean-switch.component.ts
+++ b/src/app/widgets/widget-boolean-switch/widget-boolean-switch.component.ts
@@ -17,7 +17,6 @@ import { WidgetTitleComponent } from "../../core/components/widget-title/widget-
     selector: 'widget-boolean-switch',
     templateUrl: './widget-boolean-switch.component.html',
     styleUrls: ['./widget-boolean-switch.component.scss'],
-    standalone: true,
     imports: [WidgetHostComponent, NgxResizeObserverModule, SvgBooleanSwitchComponent, SvgBooleanButtonComponent, SvgBooleanLightComponent, WidgetTitleComponent]
 })
 export class WidgetBooleanSwitchComponent extends BaseWidgetComponent implements OnInit, AfterViewInit, OnDestroy {

--- a/src/app/widgets/widget-freeboardsk/widget-freeboardsk.component.ts
+++ b/src/app/widgets/widget-freeboardsk/widget-freeboardsk.component.ts
@@ -9,7 +9,6 @@ import { Subscription } from 'rxjs';
 
 @Component({
     selector: 'widget-freeboardsk',
-    standalone: true,
     templateUrl: './widget-freeboardsk.component.html',
     styleUrl: './widget-freeboardsk.component.scss',
     imports: [WidgetHostComponent, SafePipe]

--- a/src/app/widgets/widget-gauge-ng-compass/widget-gauge-ng-compass.component.ts
+++ b/src/app/widgets/widget-gauge-ng-compass/widget-gauge-ng-compass.component.ts
@@ -5,7 +5,7 @@
  * Gauge .update() function should ONLY be called after ngAfterViewInit. Used to update
  * instantiated gauge config.
  */
-import { ViewChild, Component, OnInit, OnDestroy, AfterViewInit, ElementRef, effect } from '@angular/core';
+import { Component, OnInit, OnDestroy, AfterViewInit, ElementRef, effect, viewChild } from '@angular/core';
 import { NgxResizeObserverModule } from 'ngx-resize-observer';
 
 import { GaugesModule, RadialGaugeOptions, RadialGauge } from '@godind/ng-canvas-gauges';
@@ -60,8 +60,8 @@ export class WidgetGaugeNgCompassComponent extends BaseWidgetComponent implement
   // Gauge value
   protected value = 0;
 
-  @ViewChild('compassGauge', { static: true }) ngGauge: RadialGauge;
-  @ViewChild('compassGauge', { static: true, read: ElementRef }) gauge: ElementRef;
+  readonly ngGauge = viewChild<RadialGauge>('compassGauge');
+  readonly gauge = viewChild('compassGauge', { read: ElementRef });
 
   protected gaugeOptions = {} as RadialGaugeOptions;
   // fix for RadialGauge GaugeOptions object ** missing color-stroke-ticks property
@@ -121,7 +121,7 @@ export class WidgetGaugeNgCompassComponent extends BaseWidgetComponent implement
 
   protected startWidget(): void {
     this.setGaugeConfig();
-    this.ngGauge.update(this.gaugeOptions);
+    this.ngGauge().update(this.gaugeOptions);
 
     this.unsubscribeDataStream();
 
@@ -173,7 +173,7 @@ export class WidgetGaugeNgCompassComponent extends BaseWidgetComponent implement
           default:
             option.colorValueText = this.theme().contrast; // Fallback for unknown or null state
         }
-        this.ngGauge.update(option);
+        this.ngGauge().update(option);
       }
     });
   }
@@ -185,12 +185,12 @@ export class WidgetGaugeNgCompassComponent extends BaseWidgetComponent implement
   }
 
   private setCanvasHight(): void {
-    const gaugeSize = this.gauge.nativeElement.getBoundingClientRect();
+    const gaugeSize = this.gauge().nativeElement.getBoundingClientRect();
     const resize: RadialGaugeOptions = {};
     resize.height = gaugeSize.height;
     resize.width = gaugeSize.width;
 
-    this.ngGauge.update(resize);
+    this.ngGauge().update(resize);
   }
 
   ngAfterViewInit(): void {
@@ -203,7 +203,7 @@ export class WidgetGaugeNgCompassComponent extends BaseWidgetComponent implement
     resize.height = event.contentRect.height;
     resize.width = event.contentRect.width;
 
-    this.ngGauge.update(resize);
+    this.ngGauge().update(resize);
   }
 
   private setGaugeConfig(): void {
@@ -336,8 +336,5 @@ export class WidgetGaugeNgCompassComponent extends BaseWidgetComponent implement
 
   ngOnDestroy(): void {
     this.destroyDataStreams();
-    // Clear references to DOM elements
-    this.ngGauge = null;
-    this.gauge = null;
   }
 }

--- a/src/app/widgets/widget-gauge-ng-linear/widget-gauge-ng-linear.component.ts
+++ b/src/app/widgets/widget-gauge-ng-linear/widget-gauge-ng-linear.component.ts
@@ -21,7 +21,6 @@ import { adjustLinearScaleAndMajorTicks } from '../../core/utils/dataScales.util
     selector: 'widget-gauge-ng-linear',
     templateUrl: './widget-gauge-ng-linear.component.html',
     styleUrls: ['./widget-gauge-ng-linear.component.scss'],
-    standalone: true,
     imports: [WidgetHostComponent, NgxResizeObserverModule, GaugesModule]
 })
 

--- a/src/app/widgets/widget-gauge-ng-linear/widget-gauge-ng-linear.component.ts
+++ b/src/app/widgets/widget-gauge-ng-linear/widget-gauge-ng-linear.component.ts
@@ -5,7 +5,7 @@
  * Gauge .update() function should ONLY be called after ngAfterViewInit. Used to update
  * instantiated gauge config.
  */
-import { ViewChild, Component, OnInit, OnDestroy, AfterViewInit, ElementRef, effect } from '@angular/core';
+import { Component, OnInit, OnDestroy, AfterViewInit, ElementRef, effect, viewChild } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { NgxResizeObserverModule } from 'ngx-resize-observer';
 
@@ -25,8 +25,8 @@ import { adjustLinearScaleAndMajorTicks } from '../../core/utils/dataScales.util
 })
 
 export class WidgetGaugeNgLinearComponent extends BaseWidgetComponent implements OnInit, AfterViewInit, OnDestroy {
-  @ViewChild('linearGauge', {static: true, read: LinearGauge}) protected ngGauge: LinearGauge;
-  @ViewChild('linearGauge', {static: true, read: ElementRef}) protected gauge: ElementRef;
+  protected readonly ngGauge = viewChild('linearGauge', { read: LinearGauge });
+  protected readonly gauge = viewChild('linearGauge', { read: ElementRef });
 
   // Gauge text value for value box rendering
   protected textValue = "";
@@ -93,7 +93,7 @@ export class WidgetGaugeNgLinearComponent extends BaseWidgetComponent implements
 
   protected startWidget(): void {
     this.setGaugeConfig();
-    this.ngGauge.update(this.gaugeOptions);
+    this.ngGauge().update(this.gaugeOptions);
 
     this.unsubscribeDataStream();
     this.unsubscribeMetaStream();
@@ -173,7 +173,7 @@ export class WidgetGaugeNgLinearComponent extends BaseWidgetComponent implements
               }
           }
         }
-        this.ngGauge.update(option);
+        this.ngGauge().update(option);
       }
     });
     if (!this.widgetProperties.config.ignoreZones) {
@@ -224,16 +224,16 @@ export class WidgetGaugeNgLinearComponent extends BaseWidgetComponent implements
     resize.height -= 10; // Adjust height to account for margin-top
 
     // Apply the calculated dimensions to the canvas
-    this.ngGauge.update(resize);
+    this.ngGauge().update(resize);
   }
 
   private setCanvasHight(): void {
-    const gaugeSize = this.gauge.nativeElement.getBoundingClientRect();
+    const gaugeSize = this.gauge().nativeElement.getBoundingClientRect();
     const resize: RadialGaugeOptions = {};
     resize.height = gaugeSize.height;
     resize.width = gaugeSize.width;
 
-    this.ngGauge.update(resize);
+    this.ngGauge().update(resize);
   }
 
   private setGaugeConfig() {
@@ -246,7 +246,7 @@ export class WidgetGaugeNgLinearComponent extends BaseWidgetComponent implements
       majorTicks: []
     };
 
-    const rect = this.gauge.nativeElement.getBoundingClientRect();
+    const rect = this.gauge().nativeElement.getBoundingClientRect();
     let height: number = null;
     let width: number = null;
 
@@ -491,14 +491,11 @@ export class WidgetGaugeNgLinearComponent extends BaseWidgetComponent implements
     const highlights: LinearGaugeOptions = {};
     highlights.highlightsWidth = this.widgetProperties.config.gauge.highlightsWidth;
     highlights.highlights = JSON.stringify(gaugeZonesHighlight, null, 1);
-    this.ngGauge.update(highlights);
+    this.ngGauge().update(highlights);
   }
 
   ngOnDestroy() {
     this.destroyDataStreams();
     this.metaSub?.unsubscribe();
-    // Clear references to DOM elements
-    this.ngGauge = null;
-    this.gauge = null;
   }
 }

--- a/src/app/widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component.ts
+++ b/src/app/widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component.ts
@@ -5,7 +5,7 @@
  * Gauge .update() function should ONLY be called after ngAfterViewInit. Used to update
  * instantiated gauge config.
  */
-import { ViewChild, Component, OnInit, OnDestroy, AfterViewInit, ElementRef, effect } from '@angular/core';
+import { Component, OnInit, OnDestroy, AfterViewInit, ElementRef, effect, viewChild } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { NgxResizeObserverModule } from 'ngx-resize-observer';
 
@@ -28,8 +28,8 @@ export class WidgetGaugeNgRadialComponent extends BaseWidgetComponent implements
   private readonly LINE: string = "line";
   private readonly ANIMATION_TARGET_NEEDLE:string = "needle";
 
-  @ViewChild('radialGauge', { static: true }) ngGauge: RadialGauge;
-  @ViewChild('radialGauge', { static: true, read: ElementRef }) gauge: ElementRef;
+  readonly ngGauge = viewChild<RadialGauge>('radialGauge');
+  readonly gauge = viewChild('radialGauge', { read: ElementRef });
 
   // Gauge text value for value box rendering
   protected textValue = "";
@@ -100,7 +100,7 @@ export class WidgetGaugeNgRadialComponent extends BaseWidgetComponent implements
 
   protected startWidget(): void {
     this.setGaugeConfig();
-    this.ngGauge.update(this.gaugeOptions);
+    this.ngGauge().update(this.gaugeOptions);
 
     this.unsubscribeDataStream();
     this.unsubscribeMetaStream();
@@ -154,7 +154,7 @@ export class WidgetGaugeNgRadialComponent extends BaseWidgetComponent implements
               option.colorValueText = this.getColors(this.widgetProperties.config.color).color;
           }
         }
-        this.ngGauge.update(option);
+        this.ngGauge().update(option);
       }
     });
 
@@ -175,12 +175,12 @@ export class WidgetGaugeNgRadialComponent extends BaseWidgetComponent implements
   }
 
   private setCanvasHight(): void {
-    const gaugeSize = this.gauge.nativeElement.getBoundingClientRect();
+    const gaugeSize = this.gauge().nativeElement.getBoundingClientRect();
     const resize: RadialGaugeOptions = {};
     resize.height = gaugeSize.height;
     resize.width = gaugeSize.width;
 
-    this.ngGauge.update(resize);
+    this.ngGauge().update(resize);
   }
 
   ngAfterViewInit(): void {
@@ -193,7 +193,7 @@ export class WidgetGaugeNgRadialComponent extends BaseWidgetComponent implements
       resize.height = event.contentRect.height;
       resize.width = event.contentRect.width;
 
-      this.ngGauge.update(resize);
+      this.ngGauge().update(resize);
   }
 
   private setGaugeConfig(): void {
@@ -440,15 +440,11 @@ export class WidgetGaugeNgRadialComponent extends BaseWidgetComponent implements
     const highlights: LinearGaugeOptions = {};
     highlights.highlightsWidth = this.widgetProperties.config.gauge.highlightsWidth;
     highlights.highlights = JSON.stringify(gaugeZonesHighlight, null, 1);
-    this.ngGauge.update(highlights);
+    this.ngGauge().update(highlights);
   }
 
   ngOnDestroy() {
     this.destroyDataStreams();
     this.metaSub?.unsubscribe();
-    // Clear references to DOM elements
-    this.ngGauge = null;
-    this.gauge = null;
-
   }
 }

--- a/src/app/widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component.ts
+++ b/src/app/widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component.ts
@@ -21,7 +21,6 @@ import { ISkZone, States } from '../../core/interfaces/signalk-interfaces';
     selector: 'widget-gauge-ng-radial',
     templateUrl: './widget-gauge-ng-radial.component.html',
     styleUrls: ['./widget-gauge-ng-radial.component.scss'],
-    standalone: true,
     imports: [WidgetHostComponent, NgxResizeObserverModule, GaugesModule]
 })
 export class WidgetGaugeNgRadialComponent extends BaseWidgetComponent implements OnInit, AfterViewInit, OnDestroy {

--- a/src/app/widgets/widget-gauge-steel/widget-gauge-steel.component.ts
+++ b/src/app/widgets/widget-gauge-steel/widget-gauge-steel.component.ts
@@ -10,7 +10,6 @@ import { ISkZone } from '../../core/interfaces/signalk-interfaces';
     selector: 'widget-gauge-steel',
     templateUrl: './widget-gauge-steel.component.html',
     styleUrls: ['./widget-gauge-steel.component.scss'],
-    standalone: true,
     imports: [WidgetHostComponent, GaugeSteelComponent]
 })
 export class WidgetSteelGaugeComponent extends BaseWidgetComponent implements OnInit, OnDestroy {

--- a/src/app/widgets/widget-iframe/widget-iframe.component.ts
+++ b/src/app/widgets/widget-iframe/widget-iframe.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, effect, ElementRef, inject, OnDestroy, OnInit, signal, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, effect, ElementRef, inject, OnDestroy, OnInit, signal, viewChild } from '@angular/core';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import { BaseWidgetComponent } from '../../core/utils/base-widget.component';
 import { WidgetHostComponent } from '../../core/components/widget-host/widget-host.component';
@@ -14,7 +14,7 @@ import { DashboardService } from '../../core/services/dashboard.service';
 export class WidgetIframeComponent extends BaseWidgetComponent implements OnInit, AfterViewInit, OnDestroy {
   private _sanitizer = inject(DomSanitizer);
   protected _dashboard = inject(DashboardService);
-  @ViewChild('plainIframe', { static: false }) iframe!: ElementRef<HTMLIFrameElement>;
+  readonly iframe = viewChild.required<ElementRef<HTMLIFrameElement>>('plainIframe');
   protected widgetUrl: SafeResourceUrl | null = null;
   protected displayTransparentOverlay = signal<string>('block');
 
@@ -43,8 +43,9 @@ export class WidgetIframeComponent extends BaseWidgetComponent implements OnInit
   }
 
   ngAfterViewInit() {
-    if (this.iframe) {
-      this.iframe.nativeElement.onload = () => this.injectHammerJS();
+    const iframe = this.iframe();
+    if (iframe) {
+      iframe.nativeElement.onload = () => this.injectHammerJS();
     }
   }
 
@@ -100,8 +101,8 @@ export class WidgetIframeComponent extends BaseWidgetComponent implements OnInit
 
   private injectHammerJS() {
     const baseHref = document.getElementsByTagName('base')[0]?.href || '/';
-    const iframeWindow = this.iframe.nativeElement.contentWindow;
-    const iframeDocument = this.iframe.nativeElement.contentDocument;
+    const iframeWindow = this.iframe().nativeElement.contentWindow;
+    const iframeDocument = this.iframe().nativeElement.contentDocument;
 
     if (!iframeDocument || !iframeWindow) {
       console.error('[WidgetIframe] Iframe contentDocument or contentWindow is undefined. Possible cross-origin issue or iframe not fully loaded.');
@@ -122,7 +123,7 @@ export class WidgetIframeComponent extends BaseWidgetComponent implements OnInit
   }
 
   private injectSwipeHandler() {
-    const iframeDocument = this.iframe.nativeElement.contentDocument;
+    const iframeDocument = this.iframe().nativeElement.contentDocument;
     if (!iframeDocument) {
       console.error('[WidgetIframe] Iframe contentDocument is undefined. Possible cross-origin issue or iframe not fully loaded.');
       return;

--- a/src/app/widgets/widget-iframe/widget-iframe.component.ts
+++ b/src/app/widgets/widget-iframe/widget-iframe.component.ts
@@ -9,7 +9,6 @@ import { DashboardService } from '../../core/services/dashboard.service';
     selector: 'widget-iframe',
     templateUrl: './widget-iframe.component.html',
     styleUrls: ['./widget-iframe.component.scss'],
-    standalone: true,
     imports: [WidgetHostComponent]
 })
 export class WidgetIframeComponent extends BaseWidgetComponent implements OnInit, AfterViewInit, OnDestroy {

--- a/src/app/widgets/widget-numeric/widget-numeric.component.ts
+++ b/src/app/widgets/widget-numeric/widget-numeric.component.ts
@@ -11,7 +11,6 @@ import { WidgetTitleComponent } from "../../core/components/widget-title/widget-
     selector: 'widget-numeric',
     templateUrl: './widget-numeric.component.html',
     styleUrls: ['./widget-numeric.component.scss'],
-    standalone: true,
     imports: [WidgetHostComponent, NgxResizeObserverModule, WidgetTitleComponent]
 })
 export class WidgetNumericComponent extends BaseWidgetComponent implements AfterViewInit, OnInit, OnDestroy {

--- a/src/app/widgets/widget-position/widget-position.component.ts
+++ b/src/app/widgets/widget-position/widget-position.component.ts
@@ -10,7 +10,6 @@ import { WidgetTitleComponent } from '../../core/components/widget-title/widget-
     selector: 'widget-position',
     templateUrl: './widget-position.component.html',
     styleUrls: ['./widget-position.component.scss'],
-    standalone: true,
     imports: [WidgetHostComponent, NgxResizeObserverModule, WidgetTitleComponent]
 })
 export class WidgetPositionComponent extends BaseWidgetComponent implements AfterViewInit, OnInit, OnDestroy {

--- a/src/app/widgets/widget-race-timer/widget-race-timer.component.ts
+++ b/src/app/widgets/widget-race-timer/widget-race-timer.component.ts
@@ -14,7 +14,6 @@ import { CanvasService } from '../../core/services/canvas.service';
     selector: 'widget-racetimer',
     templateUrl: './widget-race-timer.component.html',
     styleUrls: ['./widget-race-timer.component.scss'],
-    standalone: true,
     imports: [WidgetHostComponent, NgxResizeObserverModule, MatButton]
 })
 export class WidgetRaceTimerComponent extends BaseWidgetComponent implements OnInit, OnDestroy {

--- a/src/app/widgets/widget-simple-linear/widget-simple-linear.component.ts
+++ b/src/app/widgets/widget-simple-linear/widget-simple-linear.component.ts
@@ -8,7 +8,6 @@ import { SvgSimpleLinearGaugeComponent } from '../svg-simple-linear-gauge/svg-si
     selector: 'widget-simple-linear',
     templateUrl: './widget-simple-linear.component.html',
     styleUrls: ['./widget-simple-linear.component.css'],
-    standalone: true,
     imports: [ WidgetHostComponent, SvgSimpleLinearGaugeComponent ]
 })
 export class WidgetSimpleLinearComponent extends BaseWidgetComponent implements OnInit, OnDestroy {

--- a/src/app/widgets/widget-tutorial/widget-tutorial.component.ts
+++ b/src/app/widgets/widget-tutorial/widget-tutorial.component.ts
@@ -9,7 +9,6 @@ import { DashboardService } from '../../core/services/dashboard.service';
     selector: 'widget-tutorial',
     templateUrl: './widget-tutorial.component.html',
     styleUrls: ['./widget-tutorial.component.scss'],
-    standalone: true,
     imports: [ WidgetHostComponent, MatButton]
 })
 export class WidgetTutorialComponent extends BaseWidgetComponent implements OnDestroy {

--- a/src/app/widgets/widget-wind/widget-wind.component.ts
+++ b/src/app/widgets/widget-wind/widget-wind.component.ts
@@ -9,7 +9,6 @@ import { SvgWindComponent } from '../svg-wind/svg-wind.component';
 @Component({
     selector: 'widget-wind-steer',
     templateUrl: './widget-wind.component.html',
-    standalone: true,
     imports: [ SvgWindComponent, WidgetHostComponent ]
 })
 export class WidgetWindComponent extends BaseWidgetComponent implements OnInit, OnDestroy  {


### PR DESCRIPTION
Eliminate the standalone property from multiple components to streamline the codebase. Update template variable names for backup, delete, and restore actions, and remove unused imports from the configuration component. Introduce destroyRef and signals for better state management, and refactor ViewChild usage to enhance readability across components.