### PR TITLE
Remove unused unit tests for themeColors and zonesHighlight utilities

### DIFF
--- a/src/app/core/utils/themeColors.utils.spec.ts
+++ b/src/app/core/utils/themeColors.utils.spec.ts
@@ -1,7 +1,0 @@
-import { ThemeColorsUtils } from './themeColors.utils';
-
-describe('ThemeColorsUtils', () => {
-  it('should create an instance', () => {
-    expect(new ThemeColorsUtils()).toBeTruthy();
-  });
-});

--- a/src/app/core/utils/zones-highlight.utils.spec.ts
+++ b/src/app/core/utils/zones-highlight.utils.spec.ts
@@ -1,7 +1,0 @@
-import { ZonesHighlightUtils } from './zones-highlight.utils';
-
-describe('ZonesHighlightUtils', () => {
-  it('should create an instance', () => {
-    expect(new ZonesHighlightUtils()).toBeTruthy();
-  });
-});


### PR DESCRIPTION
Delete obsolete unit tests for the themeColors and zonesHighlight utilities to streamline the codebase.