### PR TITLE
Update paths tab label visibility condition

### DIFF
--- a/src/app/widget-config/modal-widget-config/modal-widget-config.component.html
+++ b/src/app/widget-config/modal-widget-config/modal-widget-config.component.html
@@ -418,7 +418,7 @@
         <div class="tab-content">
           <div>
             <ng-template mat-tab-label>
-              <span [style]="formMaster.controls.paths.valid ? 'display: none' : 'display: block'" class="warning material-icons">
+              <span [style]="formMaster.controls.paths.valid || this.formMaster.controls.paths.disabled ? 'display: none' : 'display: block'" class="warning material-icons">
                 error
               </span>
               &nbsp;Paths


### PR DESCRIPTION
Adjust the visibility condition for the paths tab label to account for the disabled state, ensuring proper display when the form is not valid or disabled.