### PR TITLE
Refactor color handling in widget components

### DIFF
--- a/src/app/widgets/widget-boolean-switch/widget-boolean-switch.component.html
+++ b/src/app/widgets/widget-boolean-switch/widget-boolean-switch.component.html
@@ -1,5 +1,5 @@
 <widget-host [(config)]="widgetProperties.config" [id]="widgetProperties.uuid" (configChange)="updateConfig($event)">
-  <widget-title [text]="widgetProperties.config.displayName" [color]="labelColor"></widget-title>
+  <widget-title [text]="widgetProperties.config.displayName" [color]="labelColor()"></widget-title>
   <div class="widgets-container" #widgetContainer (onResize)="onResized($event)">
     @for (ctrl of switchControls(); track $index) {
       <ng-container>

--- a/src/app/widgets/widget-boolean-switch/widget-boolean-switch.component.ts
+++ b/src/app/widgets/widget-boolean-switch/widget-boolean-switch.component.ts
@@ -12,6 +12,7 @@ import { SvgBooleanButtonComponent } from '../svg-boolean-button/svg-boolean-but
 import { IDimensions, SvgBooleanSwitchComponent } from '../svg-boolean-switch/svg-boolean-switch.component';
 import { DashboardService } from '../../core/services/dashboard.service';
 import { WidgetTitleComponent } from "../../core/components/widget-title/widget-title.component";
+import { getColors } from '../../core/utils/themeColors.utils';
 
 @Component({
     selector: 'widget-boolean-switch',
@@ -26,7 +27,7 @@ export class WidgetBooleanSwitchComponent extends BaseWidgetComponent implements
   public switchControls = signal<IDynamicControl[]>([]);
   private skRequestSub = new Subscription; // Request result observer
 
-  protected labelColor: string = undefined;
+  protected labelColor = signal<string>(undefined);
 
   private nbCtrl: number = null;
   public ctrlDimensions: IDimensions = { width: 0, height: 0};
@@ -48,7 +49,7 @@ export class WidgetBooleanSwitchComponent extends BaseWidgetComponent implements
 
     effect(() => {
       if (this.theme()) {
-        this.getColors(this.widgetProperties.config.color);
+        this.labelColor.set(getColors(this.widgetProperties.config.color, this.theme()).dim);
       }
     });
   }
@@ -62,6 +63,7 @@ export class WidgetBooleanSwitchComponent extends BaseWidgetComponent implements
   }
 
   protected startWidget(): void {
+    this.labelColor.set(getColors(this.widgetProperties.config.color, this.theme()).dim);
     this.nbCtrl = this.widgetProperties.config.multiChildCtrls.length;
 
     // Build control array
@@ -98,7 +100,6 @@ export class WidgetBooleanSwitchComponent extends BaseWidgetComponent implements
 
   protected updateConfig(config: IWidgetSvcConfig): void {
     this.widgetProperties.config = config;
-    this.getColors(this.widgetProperties.config.color);
     this.startWidget();
   }
 
@@ -140,38 +141,6 @@ export class WidgetBooleanSwitchComponent extends BaseWidgetComponent implements
         $event.value,
         this.widgetProperties.uuid
       );
-    }
-  }
-
-  private getColors(color: string): void {
-    switch (color) {
-      case "contrast":
-        this.labelColor = this.theme().contrastDim;
-        break;
-      case "blue":
-        this.labelColor = this.theme().blueDim;
-        break;
-      case "green":
-        this.labelColor = this.theme().greenDim;
-        break;
-      case "pink":
-        this.labelColor = this.theme().pinkDim;
-        break;
-      case "orange":
-        this.labelColor = this.theme().orangeDim;
-        break;
-      case "purple":
-        this.labelColor = this.theme().purpleDim;
-        break;
-      case "grey":
-        this.labelColor = this.theme().greyDim;
-        break;
-      case "yellow":
-        this.labelColor = this.theme().yellowDim;
-        break;
-      default:
-        this.labelColor = this.theme().contrastDim;
-        break;
     }
   }
 

--- a/src/app/widgets/widget-datetime/widget-datetime.component.html
+++ b/src/app/widgets/widget-datetime/widget-datetime.component.html
@@ -1,6 +1,6 @@
 <widget-host [(config)]="widgetProperties.config" [id]="widgetProperties.uuid" (configChange)="updateConfig($event)">
   <div class="dateGenericWrapper" (onResize)="onResized($event)">
     <canvas #canvasValue style="z-index: inherit;" ></canvas>
-    <widget-title [text]="widgetProperties.config.displayName" [color]="labelColor"></widget-title>
+    <widget-title [text]="widgetProperties.config.displayName" [color]="labelColor()"></widget-title>
   </div>
 </widget-host>

--- a/src/app/widgets/widget-datetime/widget-datetime.component.ts
+++ b/src/app/widgets/widget-datetime/widget-datetime.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, ElementRef, AfterViewInit, effect, inject, viewChild } from '@angular/core';
+import { Component, OnInit, OnDestroy, ElementRef, AfterViewInit, effect, inject, viewChild, signal } from '@angular/core';
 import { formatDate } from '@angular/common';
 import { BaseWidgetComponent } from '../../core/utils/base-widget.component';
 import { WidgetHostComponent } from '../../core/components/widget-host/widget-host.component';
@@ -6,6 +6,7 @@ import { IWidgetSvcConfig } from '../../core/interfaces/widgets-interface';
 import { NgxResizeObserverModule } from 'ngx-resize-observer';
 import { CanvasService } from '../../core/services/canvas.service';
 import { WidgetTitleComponent } from '../../core/components/widget-title/widget-title.component';
+import { getColors } from '../../core/utils/themeColors.utils';
 
 @Component({
     selector: 'widget-datetime',
@@ -21,7 +22,7 @@ export class WidgetDatetimeComponent extends BaseWidgetComponent implements Afte
   private _timeZoneGTM = "";
   private isDestroyed = false; // guard against callbacks after destroyed
   private canvasCtx: CanvasRenderingContext2D;
-  protected labelColor: string = undefined;
+  protected labelColor = signal<string>(undefined);
   private valueColor: string = undefined;
   private maxTextWidth = 0;
   private maxTextHeight = 0;
@@ -51,7 +52,7 @@ export class WidgetDatetimeComponent extends BaseWidgetComponent implements Afte
 
     effect(() => {
       if (this.theme()) {
-        this.getColors(this.widgetProperties.config.color);
+        this.setColors();
         this.drawValue();
       }
     });
@@ -67,13 +68,13 @@ export class WidgetDatetimeComponent extends BaseWidgetComponent implements Afte
     this.maxTextWidth = Math.floor(this.canvasValue().nativeElement.width * 0.85);
     this.maxTextHeight = Math.floor(this.canvasValue().nativeElement.height * 0.70);
     if (this.isDestroyed) return;
-    this.getColors(this.widgetProperties.config.color);
     this.startWidget();
   }
 
   protected startWidget(): void {
     this._timeZoneGTM = this.getGMTOffset(this.widgetProperties.config.dateTimezone);
     this.unsubscribeDataStream();
+    this.setColors();
     this.observeDataStream('gaugePath', newValue => {
       this.dataValue = newValue.data.value;
       this.drawValue();
@@ -82,7 +83,6 @@ export class WidgetDatetimeComponent extends BaseWidgetComponent implements Afte
 
   protected updateConfig(config: IWidgetSvcConfig): void {
     this.widgetProperties.config = config;
-    this.getColors(this.widgetProperties.config.color);
     this.startWidget();
     this.drawValue();
   }
@@ -110,45 +110,9 @@ export class WidgetDatetimeComponent extends BaseWidgetComponent implements Afte
     }
 }
 
-  private getColors(color: string): void {
-    switch (color) {
-      case "contrast":
-        this.labelColor = this.theme().contrastDim;
-        this.valueColor = this.theme().contrast;
-        break;
-      case "blue":
-        this.labelColor = this.theme().blueDim;
-        this.valueColor = this.theme().blue;
-        break;
-      case "green":
-        this.labelColor = this.theme().greenDim;
-        this.valueColor = this.theme().green;
-        break;
-      case "pink":
-        this.labelColor = this.theme().pinkDim;
-        this.valueColor = this.theme().pink;
-        break;
-      case "orange":
-        this.labelColor = this.theme().orangeDim;
-        this.valueColor = this.theme().orange;
-        break;
-      case "purple":
-        this.labelColor = this.theme().purpleDim;
-        this.valueColor = this.theme().purple;
-        break;
-      case "grey":
-        this.labelColor = this.theme().greyDim;
-        this.valueColor = this.theme().grey;
-        break;
-      case "yellow":
-        this.labelColor = this.theme().yellowDim;
-        this.valueColor = this.theme().yellow;
-        break;
-      default:
-        this.labelColor = this.theme().contrastDim;
-        this.valueColor = this.theme().contrast;
-        break;
-    }
+  private setColors(): void {
+    this.labelColor.set(getColors(this.widgetProperties.config.color, this.theme()).dim);
+    this.valueColor = getColors(this.widgetProperties.config.color, this.theme()).color;
   }
 
   protected onResized(e: ResizeObserverEntry): void {

--- a/src/app/widgets/widget-numeric/widget-numeric.component.html
+++ b/src/app/widgets/widget-numeric/widget-numeric.component.html
@@ -1,6 +1,6 @@
 <widget-host [(config)]="widgetProperties.config" [id]="widgetProperties.uuid" (configChange)="updateConfig($event)">
   <div class="textGenericWrapper" (onResize)="onResized($event)">
-    <widget-title [text]="widgetProperties.config.displayName" [color]="labelColor"/>
+    <widget-title [text]="widgetProperties.config.displayName" [color]="labelColor()"/>
     <canvas #canvasUnit class="canvas"></canvas>
     <canvas #canvasValue class="canvas"></canvas>
     <canvas #canvasMinMax class="canvas"></canvas>

--- a/src/app/widgets/widget-numeric/widget-numeric.component.ts
+++ b/src/app/widgets/widget-numeric/widget-numeric.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, ElementRef, OnInit, AfterViewInit, effect, inject, viewChild } from '@angular/core';
+import { Component, OnDestroy, ElementRef, OnInit, AfterViewInit, effect, inject, viewChild, signal } from '@angular/core';
 import { BaseWidgetComponent } from '../../core/utils/base-widget.component';
 import { States } from '../../core/interfaces/signalk-interfaces';
 import { WidgetHostComponent } from '../../core/components/widget-host/widget-host.component';
@@ -6,6 +6,7 @@ import { IWidgetSvcConfig } from '../../core/interfaces/widgets-interface';
 import { NgxResizeObserverModule } from 'ngx-resize-observer';
 import { CanvasService } from '../../core/services/canvas.service';
 import { WidgetTitleComponent } from "../../core/components/widget-title/widget-title.component";
+import { getColors } from '../../core/utils/themeColors.utils';
 
 @Component({
     selector: 'widget-numeric',
@@ -18,10 +19,10 @@ export class WidgetNumericComponent extends BaseWidgetComponent implements After
   private canvasMinMax = viewChild.required<ElementRef<HTMLCanvasElement>>('canvasMinMax');
   private canvasValue = viewChild.required<ElementRef<HTMLCanvasElement>>('canvasValue');
   private canvas = inject(CanvasService);
-  private dataValue: number = null;
+  private dataValue: number = null;ù
   private maxValue: number = null;
   private minValue: number = null;
-  protected labelColor: string = undefined;
+  protected labelColor = signal<string>(undefined);
   private valueColor: string = undefined;
   private valueStateColor: string = undefined;
   private maxValueTextWidth = 0;
@@ -67,7 +68,7 @@ export class WidgetNumericComponent extends BaseWidgetComponent implements After
 
     effect(() => {
       if (this.theme()) {
-        this.getColors(this.widgetProperties.config.color);
+        this.setColors();
         this.updateCanvas();
         this.updateCanvasUnit();
       }
@@ -101,7 +102,7 @@ export class WidgetNumericComponent extends BaseWidgetComponent implements After
     this.minValue = null;
     this.maxValue = null;
     this.dataValue = null;
-    this.getColors(this.widgetProperties.config.color);
+    this.setColors();
     this.observeDataStream('numericPath', newValue => {
       this.dataValue = newValue.data.value;
       // Initialize min/max
@@ -155,46 +156,9 @@ export class WidgetNumericComponent extends BaseWidgetComponent implements After
     this.updateCanvasUnit();
   }
 
-  private getColors(color: string): void {
-    switch (color) {
-      case "contrast":
-        this.labelColor = this.theme().contrastDim;
-        this.valueColor = this.theme().contrast;
-        break;
-      case "blue":
-        this.labelColor = this.theme().blueDim;
-        this.valueColor = this.theme().blue;
-        break;
-      case "green":
-        this.labelColor = this.theme().greenDim;
-        this.valueColor = this.theme().green;
-        break;
-      case "pink":
-        this.labelColor = this.theme().pinkDim;
-        this.valueColor = this.theme().pink;
-        break;
-      case "orange":
-        this.labelColor = this.theme().orangeDim;
-        this.valueColor = this.theme().orange;
-        break;
-      case "purple":
-        this.labelColor = this.theme().purpleDim;
-        this.valueColor = this.theme().purple;
-        break;
-      case "grey":
-        this.labelColor = this.theme().greyDim;
-        this.valueColor = this.theme().grey;
-        break;
-      case "yellow":
-        this.labelColor = this.theme().yellowDim;
-        this.valueColor = this.theme().yellow;
-        break;
-      default:
-        this.labelColor = this.theme().contrastDim;
-        this.valueColor = this.theme().contrast;
-        break;
-    }
-    this.valueStateColor = this.valueColor;
+  private setColors(): void {
+    this.labelColor.set(getColors(this.widgetProperties.config.color, this.theme()).dim);
+    this.valueStateColor = this.valueColor = getColors(this.widgetProperties.config.color, this.theme()).color;
   }
 
   ngOnDestroy() {

--- a/src/app/widgets/widget-numeric/widget-numeric.component.ts
+++ b/src/app/widgets/widget-numeric/widget-numeric.component.ts
@@ -19,7 +19,7 @@ export class WidgetNumericComponent extends BaseWidgetComponent implements After
   private canvasMinMax = viewChild.required<ElementRef<HTMLCanvasElement>>('canvasMinMax');
   private canvasValue = viewChild.required<ElementRef<HTMLCanvasElement>>('canvasValue');
   private canvas = inject(CanvasService);
-  private dataValue: number = null;ù
+  private dataValue: number = null;
   private maxValue: number = null;
   private minValue: number = null;
   protected labelColor = signal<string>(undefined);

--- a/src/app/widgets/widget-position/widget-position.component.html
+++ b/src/app/widgets/widget-position/widget-position.component.html
@@ -1,5 +1,5 @@
 <widget-host [(config)]="widgetProperties.config" [id]="widgetProperties.uuid" (configChange)="updateConfig($event)">
-  <widget-title [text]="widgetProperties.config.displayName" [color]="labelColor"></widget-title>
+  <widget-title [text]="widgetProperties.config.displayName" [color]="labelColor()"></widget-title>
   <div class="textGenericWrapper" (onResize)="onResized($event)">
     <canvas #canvasValue class="canvas"></canvas>
   </div>

--- a/src/app/widgets/widget-position/widget-position.component.ts
+++ b/src/app/widgets/widget-position/widget-position.component.ts
@@ -1,10 +1,11 @@
-import { Component, OnInit, OnDestroy, ElementRef, AfterViewInit, effect, inject, viewChild } from '@angular/core';
+import { Component, OnInit, OnDestroy, ElementRef, AfterViewInit, effect, inject, viewChild, signal } from '@angular/core';
 import { BaseWidgetComponent } from '../../core/utils/base-widget.component';
 import { WidgetHostComponent } from '../../core/components/widget-host/widget-host.component';
 import { IWidgetSvcConfig } from '../../core/interfaces/widgets-interface';
 import { NgxResizeObserverModule } from 'ngx-resize-observer';
 import { CanvasService } from '../../core/services/canvas.service';
 import { WidgetTitleComponent } from '../../core/components/widget-title/widget-title.component';
+import { getColors } from '../../core/utils/themeColors.utils';
 
 @Component({
     selector: 'widget-position',
@@ -17,7 +18,7 @@ export class WidgetPositionComponent extends BaseWidgetComponent implements Afte
   private canvas = inject(CanvasService);
   private latPos = '';
   private longPos = '';
-  protected labelColor: string = undefined;
+  protected labelColor = signal<string>(undefined);
   private valueColor: string = undefined;
   private maxTextWidth = 0;
   private maxTextHeight = 0;
@@ -63,7 +64,7 @@ export class WidgetPositionComponent extends BaseWidgetComponent implements Afte
 
     effect(() => {
       if (this.theme()) {
-        this.getColors(this.widgetProperties.config.color);
+        this.setColors();
         this.drawValue();
       }
     });
@@ -85,6 +86,7 @@ export class WidgetPositionComponent extends BaseWidgetComponent implements Afte
 
   protected startWidget(): void {
     this.unsubscribeDataStream();
+    this.setColors();
     this.observeDataStream('longPath', newValue => {
       if (newValue.data.value ===  null) {
         this.longPos = '';
@@ -116,7 +118,6 @@ export class WidgetPositionComponent extends BaseWidgetComponent implements Afte
 
   protected updateConfig(config: IWidgetSvcConfig): void {
     this.widgetProperties.config = config;
-    this.getColors(this.widgetProperties.config.color);
     this.startWidget();
   }
 
@@ -129,45 +130,9 @@ export class WidgetPositionComponent extends BaseWidgetComponent implements Afte
     this.drawValue();
   }
 
-  private getColors(color: string): void {
-    switch (color) {
-      case 'white':
-        this.labelColor = this.theme().contrastDim;
-        this.valueColor = this.theme().contrast;
-        break;
-      case 'blue':
-        this.labelColor = this.theme().blueDim;
-        this.valueColor = this.theme().blue;
-        break;
-      case 'green':
-        this.labelColor = this.theme().greenDim;
-        this.valueColor = this.theme().green;
-        break;
-      case 'pink':
-        this.labelColor = this.theme().pinkDim;
-        this.valueColor = this.theme().pink;
-        break;
-      case 'orange':
-        this.labelColor = this.theme().orangeDim;
-        this.valueColor = this.theme().orange;
-        break;
-      case 'purple':
-        this.labelColor = this.theme().purpleDim;
-        this.valueColor = this.theme().purple;
-        break;
-      case 'grey':
-        this.labelColor = this.theme().greyDim;
-        this.valueColor = this.theme().grey;
-        break;
-      case 'yellow':
-        this.labelColor = this.theme().yellowDim;
-        this.valueColor = this.theme().yellow;
-        break;
-      default:
-        this.labelColor = this.theme().contrastDim;
-        this.valueColor = this.theme().contrast;
-        break;
-    }
+  private setColors(): void {
+    this.labelColor.set(getColors(this.widgetProperties.config.color, this.theme()).dim);
+    this.valueColor = getColors(this.widgetProperties.config.color, this.theme()).color;
   }
 
   private calculateFontSizeAndPositions(): void {

--- a/src/app/widgets/widget-slider/widget-slider.component.html
+++ b/src/app/widgets/widget-slider/widget-slider.component.html
@@ -1,5 +1,5 @@
 <widget-host [(config)]="widgetProperties.config" [id]="widgetProperties.uuid" (configChange)="updateConfig($event)">
-  <widget-title [text]="widgetProperties.config.displayName" [color]="labelColor"/>
+  <widget-title [text]="widgetProperties.config.displayName" [color]="labelColor()"/>
   <div class="widgets-container" (onResize)="onResized()">
     <svg width="100%" height="100%" viewBox="0 40 200 40">
       <rect
@@ -13,7 +13,7 @@
         style="display:inline;stroke-width:1.57144" />
       <rect
         [attr.width]="lineWidth"
-        [attr.fill]="barColor"
+        [attr.fill]="barColor()"
         height="8"
         rx="4.5"
         id="rect3"

--- a/src/app/widgets/widget-slider/widget-slider.component.ts
+++ b/src/app/widgets/widget-slider/widget-slider.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, effect, ElementRef, inject, OnDestroy, OnInit, viewChild } from '@angular/core';
+import { AfterViewInit, Component, effect, ElementRef, inject, OnDestroy, OnInit, signal, viewChild } from '@angular/core';
 import { BaseWidgetComponent } from '../../core/utils/base-widget.component';
 import { WidgetHostComponent } from '../../core/components/widget-host/widget-host.component';
 import { DashboardService } from '../../core/services/dashboard.service';
@@ -23,8 +23,8 @@ export class WidgetSliderComponent extends BaseWidgetComponent implements OnInit
   protected dashboard = inject(DashboardService);
   private signalkRequestsService = inject(SignalkRequestsService);
   private appService = inject(AppService);
-  protected labelColor: string = undefined;
-  protected barColor: string = undefined;
+  protected labelColor = signal<string>(undefined)
+  protected barColor = signal<string>(undefined);
   private skRequestSub = new Subscription; // Request result observer
 
   private lineStartPx: number;
@@ -259,8 +259,8 @@ export class WidgetSliderComponent extends BaseWidgetComponent implements OnInit
 
   private getColors(color: string): void {
     const colors = this.colorMap.get(color) || this.colorMap.get("contrast");
-    this.labelColor = colors.label;
-    this.barColor = colors.bar;
+    this.labelColor.set(colors.label);
+    this.barColor.set(colors.bar);
   }
 
   ngOnDestroy(): void {

--- a/src/app/widgets/widget-text/widget-text.component.html
+++ b/src/app/widgets/widget-text/widget-text.component.html
@@ -1,6 +1,6 @@
 <widget-host [(config)]="widgetProperties.config" [id]="widgetProperties.uuid" (configChange)="updateConfig($event)">
   <div class="textGenericWrapper" (onResize)="onResized($event)">
     <canvas #canvasValue style="z-index: inherit;"></canvas>
-    <widget-title [text]="widgetProperties.config.displayName" [color]="labelColor"/>
+    <widget-title [text]="widgetProperties.config.displayName" [color]="labelColor()"/>
   </div>
 </widget-host>


### PR DESCRIPTION
Refactor the color management in widget components by replacing the `labelColor` and `barColor` properties with signals for better reactivity and updating the color retrieval logic accordingly.