### PR TITLE
Add dashboard number to URL for bookmarking

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -2,13 +2,39 @@ import { Routes } from '@angular/router';
 import { DashboardComponent } from './core/components/dashboard/dashboard.component';
 
 export const routes: Routes = [
-  { path: 'dashboard', component: DashboardComponent },
-  { path: 'settings', loadComponent: () => import('./settings/settings/settings.component').then(m => m.AppSettingsComponent) },
-  { path: 'help', loadComponent: () => import('./core/components/app-help/app-help.component').then(m => m.AppHelpComponent) },
-  { path: 'data', loadComponent: () => import('./core/components/data-inspector/data-inspector.component').then(m => m.DataInspectorComponent) },
-  { path: 'dashboards', loadComponent: () => import('./core/components/dashboards-editor/dashboards-editor.component').then(m => m.DashboardsEditorComponent) },
-  { path: 'datasets', loadComponent: () => import('./core/components/datasets/datasets.component').then(m => m.SettingsDatasetsComponent) },
-  { path: 'configurations', loadComponent: () => import('./core/components/configuration/config.component').then(m => m.SettingsConfigComponent) },
-  { path: 'login', loadComponent: () => import('./widgets/widget-login/widget-login.component').then(m => m.WidgetLoginComponent) },
-  { path: '**', component: DashboardComponent }
+  { path: 'dashboard/:id',
+    component: DashboardComponent
+  },
+  { path: 'settings',
+    loadComponent: () => import('./settings/settings/settings.component').then(m => m.AppSettingsComponent),
+    title: 'KIP - Settings'
+  },
+  { path: 'help',
+    loadComponent: () => import('./core/components/app-help/app-help.component').then(m => m.AppHelpComponent),
+    title: 'KIP - Help'
+  },
+  { path: 'data',
+    loadComponent: () => import('./core/components/data-inspector/data-inspector.component').then(m => m.DataInspectorComponent),
+    title: 'KIP - Data Inspector'
+  },
+  { path: 'dashboards',
+    loadComponent: () => import('./core/components/dashboards-editor/dashboards-editor.component').then(m => m.DashboardsEditorComponent),
+    title: 'KIP - Dashboards'
+  },
+  { path: 'datasets',
+    loadComponent: () => import('./core/components/datasets/datasets.component').then(m => m.SettingsDatasetsComponent),
+    title: 'KIP - Datasets'
+  },
+  { path: 'configurations',
+    loadComponent: () => import('./core/components/configuration/config.component').then(m => m.SettingsConfigComponent),
+    title: 'KIP - Configurations'
+  },
+  { path: 'login',
+    loadComponent: () => import('./widgets/widget-login/widget-login.component').then(m => m.WidgetLoginComponent),
+    title: 'Login'
+  },
+  { path: '**',
+    component: DashboardComponent,
+    title: 'KIP',
+  }
 ];

--- a/src/app/core/components/dashboard/dashboard.component.html
+++ b/src/app/core/components/dashboard/dashboard.component.html
@@ -1,30 +1,28 @@
 <gridstack #grid
-  [options]="gridOptions"
+  [options]="gridOptions()"
   (swipeup)="previousDashboard($event)"
   (swipedown)="nextDashboard($event)"
   (press)="addNewWidget($event)"
   (window:resize)="resizeGridColumns()"
 >
   <!-- Empty state content - shown when grid has no widgets -->
-  @if (!isLoading()) {
-    <div empty-content class="dashboard-empty-state">
-      <div class="empty-state-content">
-        <div class="empty-state-actions">
-          <mat-icon class="empty-state-icon">dashboard</mat-icon>
-          @if (!dashboard.isDashboardStatic()) {
-            <p class="empty-state-text"><strong>Long press/click and hold anywhere</strong> to add widgets</p>
-            <mat-icon class="touch-icon">touch_app</mat-icon>
-          } @else {
-            <p class="empty-state-text">This empty dashboard is ready to be customized.</p>
-            <button class="empty-state-button" mat-flat-button (click)="editDashboard()">
-              <mat-icon>lock_open</mat-icon>
-              Unlock and Customize
-            </button>
-          }
-        </div>
+  <div empty-content class="dashboard-empty-state">
+    <div class="empty-state-content">
+      <div class="empty-state-actions">
+        <mat-icon class="empty-state-icon">dashboard</mat-icon>
+        @if (!dashboard.isDashboardStatic()) {
+          <p class="empty-state-text"><strong>Long press/click and hold anywhere</strong> to add widgets</p>
+          <mat-icon class="touch-icon">touch_app</mat-icon>
+        } @else {
+          <p class="empty-state-text">This empty dashboard is ready to be customized.</p>
+          <button class="empty-state-button" mat-flat-button (click)="editDashboard()">
+            <mat-icon>lock_open</mat-icon>
+            Unlock and Customize
+          </button>
+        }
       </div>
     </div>
-  }
+  </div>
 </gridstack>
 @if (!dashboard.isDashboardStatic()) {
   <div class="edit-layout-close-icon">

--- a/src/app/core/components/dashboard/dashboard.component.ts
+++ b/src/app/core/components/dashboard/dashboard.component.ts
@@ -36,6 +36,7 @@ import { WidgetTutorialComponent } from '../../../widgets/widget-tutorial/widget
 import { WidgetWindComponent } from '../../../widgets/widget-wind/widget-wind.component';
 import { WidgetLabelComponent } from '../../../widgets/widget-label/widget-label.component';
 import { WidgetSliderComponent } from '../../../widgets/widget-slider/widget-slider.component';
+import { ActivatedRoute } from '@angular/router';
 
 
 @Component({
@@ -46,6 +47,7 @@ import { WidgetSliderComponent } from '../../../widgets/widget-slider/widget-sli
   styleUrl: './dashboard.component.scss'
 })
 export class DashboardComponent implements AfterViewInit, OnDestroy{
+  private readonly activatedRoute = inject(ActivatedRoute);
   private readonly _app = inject(AppService);
   private readonly _dialog = inject(DialogService);
   protected readonly dashboard = inject(DashboardService);
@@ -54,17 +56,16 @@ export class DashboardComponent implements AfterViewInit, OnDestroy{
   private readonly _uiEvent = inject(uiEventService);
   protected readonly notificationsInfo = toSignal(this._notifications.observerNotificationsInfo());
   protected readonly isDashboardStatic = toSignal(this.dashboard.isDashboardStatic$);
-  protected isLoading = signal(true);
   private readonly _gridstack = viewChild.required<GridstackComponent>('grid');
   private _previousIsStaticState = true;
-  protected readonly gridOptions: NgGridStackOptions = {
+  protected readonly gridOptions = signal<NgGridStackOptions>({
     margin: 4,
     minRow: 12,
     maxRow: 12,
     float: true,
     acceptWidgets: false,
     resizable: {handles: 'all'},
-  }
+  });
   private _boundHandleKeyDown = this.handleKeyDown.bind(this);
 
   constructor() {
@@ -94,6 +95,12 @@ export class DashboardComponent implements AfterViewInit, OnDestroy{
   }
 
   ngAfterViewInit(): void {
+    this.resizeGridColumns();
+    this._uiEvent.addHotkeyListener(
+      this._boundHandleKeyDown,
+      { ctrlKey: true, keys: ['arrowdown', 'arrowup'] } // Filter for arrow keys with Ctrl
+    );
+
     this.dashboard.isDashboardStatic$.pipe(takeUntilDestroyed(this._destroyRef)).subscribe((isStatic) => {
       if (isStatic) {
         this._gridstack().grid.setStatic(isStatic);
@@ -126,16 +133,14 @@ export class DashboardComponent implements AfterViewInit, OnDestroy{
       }
     });
 
-    this.resizeGridColumns();
-    this._uiEvent.addHotkeyListener(
-      this._boundHandleKeyDown,
-      { ctrlKey: true, keys: ['arrowdown', 'arrowup'] } // Filter for arrow keys with Ctrl
-    );
-
-    setTimeout(() => {
+    this.activatedRoute.params.pipe(takeUntilDestroyed(this._destroyRef)).subscribe((params) => {
+      const id = params['id'];
+      let pageIdParam : number | null = null;
+      if (id !== undefined && id !== null && id !== '' && !isNaN(Number(id))) {
+        pageIdParam = Number(id);
+      }
+      this.dashboard.setActiveDashboard(pageIdParam ?? this.dashboard.activeDashboard());
       this.loadDashboard(this.dashboard.activeDashboard());
-      // Ensure loading is set to false after GridStack is fully ready
-      this.isLoading.set(false);
     });
   }
 
@@ -162,19 +167,19 @@ export class DashboardComponent implements AfterViewInit, OnDestroy{
 
   /**
    * Load a dashboard from configuration in batch mode
-   * @protected
    * @param {number} dashboardId the ID of the dashboard to load
    *
    * @memberof DashboardComponent
    */
-  protected loadDashboard(dashboardId: number): void {
+  private loadDashboard(dashboardId: number): void {
     const dashboard = this.dashboard.dashboards()[dashboardId];
     const _gridstack = this._gridstack();
     if (_gridstack?.grid) {
-      _gridstack.grid.batchUpdate();
-      _gridstack.grid.load(dashboard.configuration as NgGridStackWidget[]);
-      _gridstack.grid.commit();
-      this.isLoading.set(false);
+      setTimeout(() => {
+        _gridstack.grid.batchUpdate();
+        _gridstack.grid.load(dashboard.configuration as NgGridStackWidget[]);
+        _gridstack.grid.commit();
+      }, 0);
     }
   }
 
@@ -271,24 +276,14 @@ export class DashboardComponent implements AfterViewInit, OnDestroy{
   protected nextDashboard(e: Event): void {
     e.preventDefault();
     if (this.dashboard.isDashboardStatic()) {
-      this.dashboard.nextDashboard();
-      if (this._gridstack()?.grid) {
-        setTimeout(() => {
-          this.loadDashboard(this.dashboard.activeDashboard());
-        }, 0);
-      }
+      this.dashboard.navigateToNextDashboard();
     }
   }
 
   protected previousDashboard(e: Event): void {
     e.preventDefault();
     if (this.dashboard.isDashboardStatic()) {
-      this.dashboard.previousDashboard();
-      if (this._gridstack()?.grid) {
-        setTimeout(() => {
-          this.loadDashboard(this.dashboard.activeDashboard());
-        }, 0);
-      }
+      this.dashboard.navigateToPreviousDashboard();
     }
   }
 

--- a/src/app/core/services/dashboard.service.ts
+++ b/src/app/core/services/dashboard.service.ts
@@ -68,21 +68,39 @@ export class DashboardService {
     });
   }
 
+  /**
+   * Toggles the static/fixed state of the dashboard layout.
+   */
   public toggleStaticDashboard(): void {
     this._isDashboardStatic.next(!this._isDashboardStatic.value);
   }
 
+  /**
+   * Adds a new dashboard with the given name and widget configuration.
+   * @param name The name of the new dashboard.
+   * @param configuration The widget configuration array.
+   */
   public add(name: string, configuration: NgGridStackWidget[]): void {
     this.dashboards.update(dashboards =>
       [ ...dashboards, {id: UUID.create(), name: name, configuration: configuration} ]
     );
   }
 
+  /**
+   * Updates the name of a dashboard at the specified index.
+   * @param itemIndex The index of the dashboard to update.
+   * @param name The new name for the dashboard.
+   */
   public update(itemIndex: number, name: string): void {
     this.dashboards.update(dashboards => dashboards.map((dashboard, i) =>
       i === itemIndex ? { ...dashboard, name: name } : dashboard));
   }
 
+  /**
+   * Deletes the dashboard at the specified index.
+   * If no dashboards remain, creates a new blank dashboard.
+   * @param itemIndex The index of the dashboard to delete.
+   */
   public delete(itemIndex: number): void {
     this.dashboards.update(dashboards => dashboards.filter((_, i) => i !== itemIndex));
 
@@ -94,6 +112,12 @@ export class DashboardService {
     }
   }
 
+  /**
+   * Duplicates the dashboard at the specified index with a new name.
+   * All widget and dashboard IDs are regenerated.
+   * @param itemIndex The index of the dashboard to duplicate.
+   * @param newName The name for the duplicated dashboard.
+   */
   public duplicate(itemIndex: number, newName: string): void {
     if (itemIndex < 0 || itemIndex >= this.dashboards().length) {
         console.error(`[Dashboard Service] Invalid itemIndex: ${itemIndex}`);
@@ -126,6 +150,12 @@ export class DashboardService {
     ]);
   }
 
+  /**
+   * Updates the widget configuration for the dashboard at the specified index.
+   * Only updates if the configuration has changed.
+   * @param itemIndex The index of the dashboard to update.
+   * @param configuration The new widget configuration array.
+   */
   public updateConfiguration(itemIndex: number, configuration: NgGridStackWidget[]): void {
     this.dashboards.update(dashboards => dashboards.map((dashboard, i) => {
       if (i === itemIndex) {
@@ -139,6 +169,11 @@ export class DashboardService {
     }));
   }
 
+  /**
+   * Switches to the previous dashboard in the list.
+   * Wraps to the last dashboard if at the beginning.
+   * This only updates the internal state and does NOT trigger navigation or URL changes.
+   */
   public previousDashboard(): void {
     if ((this.activeDashboard() + 1) > (this.dashboards().length) - 1) {
       this.activeDashboard.set(0);
@@ -147,6 +182,11 @@ export class DashboardService {
     }
   }
 
+  /**
+   * Switches to the next dashboard in the list.
+   * Wraps to the first dashboard if at the end.
+   * This only updates the internal state and does NOT trigger navigation or URL changes.
+   */
   public nextDashboard(): void {
     if ((this.activeDashboard() - 1) < 0) {
       this.activeDashboard.set(this.dashboards().length - 1);
@@ -155,31 +195,90 @@ export class DashboardService {
     }
   }
 
+  /**
+   * Sets the active dashboard index in the service.
+   * This only updates the internal state and does NOT trigger navigation or URL changes.
+   * @param itemIndex The index of the dashboard to activate.
+   */
   public setActiveDashboard(itemIndex: number): void {
     if (itemIndex >= 0 && itemIndex < this.dashboards().length) {
       this.activeDashboard.set(itemIndex);
+    } else {
+      console.error(`[Dashboard Service] Invalid dashboard ID: ${itemIndex}`);
     }
   }
 
+  /**
+   * Navigates the router to the currently active dashboard.
+   * This updates the browser URL and triggers Angular routing.
+   */
   public navigateToActive(): void {
     this._router.navigate(['/dashboard', this.activeDashboard()]);
   }
 
-  public navigateTo(index: number): void {
-    if (index < 0 || index > this.dashboards().length - 1) {
-      return;
+  /**
+   * Navigates the router to the dashboard at the specified index.
+   * This updates the browser URL and triggers Angular routing.
+   * @param itemIndex The index of the dashboard to navigate to.
+   */
+  public navigateTo(itemIndex: number): void {
+    if (itemIndex >= 0 && itemIndex < this.dashboards().length) {
+      this._router.navigate(['/dashboard', itemIndex]);
+    } else {
+      console.error(`[Dashboard Service] Invalid dashboard ID: ${itemIndex}`);
     }
-    this._router.navigate(['/dashboard', index]);
   }
 
+  /**
+   * Navigates to the next dashboard in the list.
+   * If the current dashboard is the first one, wraps around to the last dashboard.
+   * This updates the browser URL and triggers Angular routing.
+   */
+  public navigateToNextDashboard(): void {
+    let nextDashboard: number = null;
+    if ((this.activeDashboard() - 1) < 0) {
+      nextDashboard = this.dashboards().length - 1;
+    } else {
+      nextDashboard = this.activeDashboard() - 1;
+    }
+    this._router.navigate(['/dashboard', nextDashboard]);
+  }
+
+  /**
+   * Navigates to the previous dashboard in the list.
+   * If the current dashboard is the last one, wraps around to the first dashboard.
+   * This updates the browser URL and triggers Angular routing.
+   */
+  public navigateToPreviousDashboard(): void {
+    let nextDashboard: number = null;
+    if ((this.activeDashboard() + 1) >= this.dashboards().length) {
+      nextDashboard = 0;
+    } else {
+      nextDashboard = this.activeDashboard() + 1;
+    }
+    this._router.navigate(['/dashboard', nextDashboard]);
+  }
+
+  /**
+   * Emits a widget delete operation for the widget with the given ID.
+   * @param id The widget ID to delete.
+   */
   public deleteWidget(id: string): void {
     this._widgetAction.next({id: id, operation: 'delete'});
   }
 
+  /**
+   * Emits a widget duplicate operation for the widget with the given ID.
+   * @param id The widget ID to duplicate.
+   */
   public duplicateWidget(id: string): void {
     this._widgetAction.next({id: id, operation: 'duplicate'});
   }
 
+  /**
+   * Sets the static/fixed state of the dashboard layout.
+   * @param isStatic Whether the dashboard should be static.
+   */
   public setStaticDashboard(isStatic: boolean): void {
     this._isDashboardStatic.next(isStatic);
   }

--- a/src/app/widgets/widget-racer-timer/widget-racer-timer.component.ts
+++ b/src/app/widgets/widget-racer-timer/widget-racer-timer.component.ts
@@ -13,6 +13,7 @@ import { DashboardService } from '../../core/services/dashboard.service';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { getColors } from '../../core/utils/themeColors.utils';
 import { FormsModule } from '@angular/forms';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'widget-racer-timer',
@@ -21,7 +22,8 @@ import { FormsModule } from '@angular/forms';
   imports: [WidgetHostComponent, NgxResizeObserverModule, WidgetTitleComponent, MatButtonModule, MatIconModule, FormsModule]
 })
 export class WidgetRacerTimerComponent extends BaseWidgetComponent implements AfterViewInit, OnInit, OnDestroy {
-  private signalk = inject(SignalkRequestsService);
+  private readonly signalk = inject(SignalkRequestsService);
+  private readonly router = inject(Router);
   protected dashboard = inject(DashboardService);
   private timeToSCanvas = viewChild.required<ElementRef<HTMLCanvasElement>>('timeToSCanvas');
   private canvasService = inject(CanvasService);
@@ -202,7 +204,7 @@ export class WidgetRacerTimerComponent extends BaseWidgetComponent implements Af
       }
       if (this.widgetProperties.config.nextDashboard >= 0 &&
         lastTtsValue === 1 && this.ttsValue === 0 && (!this.dtsValue || this.dtsValue >= 0)) {
-        this.dashboard.setActiveDashboard(this.widgetProperties.config.nextDashboard);
+        this.router.navigate(['/dashboard', this.widgetProperties.config.nextDashboard]);
       }
     });
 


### PR DESCRIPTION
Enable selection of specific dashboards via URL, allowing users to bookmark their dashboard views. This change enhances navigation by integrating dashboard IDs into the routing structure.

Fixes #638