### PR TITLE
Update version to 3.5.1 and enhance changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# V 3.5.1
+## Fixes
+* Dashboard ID URL not redirecting to dashboard instance (/mxtommy/kip/#/dashboard/1)
+* Widget resize handles too small to operate with fingers on smaller screens
+* Display network connection and socket error messages only
+* WebSocket retry should not stop after five attempts
 # V 3.5.0
 ## New features
 * Gain tactical racing advantages with new signalk-racer plugin integrated widgets for start line analysis and  race countdowns. _Contribution by @gregw_

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mxtommy/kip",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "An advanced and versatile marine instrumentation package to display Signal K data.",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
Bump the package version to 3.5.1 and add recent fixes to the changelog, including improvements to dashboard redirection, widget usability on smaller screens, error message display, and WebSocket retry behavior.