### PR TITLE
Fix dashboard swipe gesture functionality in Freeboard-SK and Embed widgets

### DIFF
--- a/src/app/widgets/widget-freeboardsk/widget-freeboardsk.component.ts
+++ b/src/app/widgets/widget-freeboardsk/widget-freeboardsk.component.ts
@@ -56,12 +56,12 @@ export class WidgetFreeboardskComponent extends BaseWidgetComponent implements O
       switch (event.data.gesture) {
         case 'swipeup':
           if (this.dashboard.isDashboardStatic()) {
-            this.dashboard.previousDashboard();
+            this.dashboard.navigateToPreviousDashboard();
           }
           break;
         case 'swipedown':
           if (this.dashboard.isDashboardStatic()) {
-            this.dashboard.nextDashboard();
+            this.dashboard.navigateToNextDashboard();
           }
           break;
         case 'swipeleft': {

--- a/src/app/widgets/widget-iframe/widget-iframe.component.ts
+++ b/src/app/widgets/widget-iframe/widget-iframe.component.ts
@@ -63,10 +63,10 @@ export class WidgetIframeComponent extends BaseWidgetComponent implements OnInit
     if (event.data.gesture && event.data.eventData.instanceId === this.widgetProperties.uuid) {
       switch (event.data.gesture) {
         case 'swipeup':
-          this._dashboard.previousDashboard();
+          this._dashboard.navigateToPreviousDashboard();
           break;
         case 'swipedown':
-          this._dashboard.nextDashboard();
+          this._dashboard.navigateToNextDashboard();
           break;
         case 'swipeleft': {
           const leftSidebarEvent = new Event('openLeftSidenav', { bubbles: true, cancelable: true });


### PR DESCRIPTION
Updated the swipe gesture handling for the Freeboard-SK and Embed widgets to correctly navigate between dashboards. This resolves the issue where swipe gestures were recognized but did not change the displayed dashboard.

Fixes #743