### PR TITLE
Add options to invert pitch and roll axes in Horizon gauge widget

### DIFF
--- a/src/app/core/interfaces/widgets-interface.ts
+++ b/src/app/core/interfaces/widgets-interface.ts
@@ -151,6 +151,10 @@ export interface IWidgetSvcConfig {
     barStartPosition?: "left" | "right" | "middle";
     /** Optional. Used by Horizon steelgauge to show or hide the frame */
     noFrameVisible?: boolean;
+    /** Optional. Invert the pitch path data */
+    invertPitch?: boolean;
+    /** Optional. Invert the roll path data*/
+    invertRoll?: boolean;
   }
   /** Used by numeric data Widget: Display minimum registered value since started */
   showMin?: boolean;
@@ -258,10 +262,8 @@ export interface IWidgetSvcConfig {
 
   /** Use by racetimer widget */
   timerLength?: number;
-
   /** The next dashboard to display when the racer-timer-widget counts to 0 and the boat is not OCS*/
   nextDashboard?: number;
-
   /** If true, play beeps when the racer-timer-widget counts to through the minutes, 10s and each of the last 10s. */
   playBeeps?: boolean;
 }

--- a/src/app/widget-config/modal-widget-config/modal-widget-config.component.html
+++ b/src/app/widget-config/modal-widget-config/modal-widget-config.component.html
@@ -556,6 +556,16 @@
                 }
                 @if (widgetConfig?.gauge?.type === 'horizon') {
                   <div formGroupName="gauge">
+                    <mat-checkbox name="invertPitch" formControlName="invertPitch">
+                      Reverse Pitch Axis
+                    </mat-checkbox>
+                  </div>
+                  <div formGroupName="gauge">
+                    <mat-checkbox name="invertRoll" formControlName="invertRoll">
+                      Reverse Roll Axis
+                    </mat-checkbox>
+                  </div>
+                  <div formGroupName="gauge">
                     <mat-checkbox name="noFrameVisible" formControlName="noFrameVisible">
                       Show Frame
                     </mat-checkbox>

--- a/src/app/widgets/widget-horizon/widget-horizon.component.ts
+++ b/src/app/widgets/widget-horizon/widget-horizon.component.ts
@@ -86,7 +86,9 @@ export class WidgetHorizonComponent extends BaseWidgetComponent implements OnIni
       gauge: {
         type: 'horizon',
         noFrameVisible: false,
-        faceColor: 'anthracite'
+        faceColor: 'anthracite',
+        invertPitch: false,
+        invertRoll: false
       },
       enableTimeout: false,
       dataTimeout: 5,
@@ -115,19 +117,13 @@ export class WidgetHorizonComponent extends BaseWidgetComponent implements OnIni
 
     if (!this.streamsInitialized) {
       this.observeDataStream('gaugePitchPath', newValue => {
-        if (newValue.data.value == null) {
-          this.gauge.setPitchAnimated(0);
-        } else {
-          this.gauge.setPitchAnimated(newValue.data.value);
-        }
+        const v = newValue.data.value ?? 0;
+        this.gauge.setPitchAnimated(this.widgetProperties.config.gauge.invertPitch ? -v : v);
       });
 
       this.observeDataStream('gaugeRollPath', newValue => {
-        if (newValue.data.value == null) {
-          this.gauge.setRollAnimated(0);
-        } else {
-          this.gauge.setRollAnimated(newValue.data.value);
-        }
+        const v = newValue.data.value ?? 0;
+        this.gauge.setRollAnimated(this.widgetProperties.config.gauge.invertRoll ? -v : v);
       });
 
       this.streamsInitialized = true;


### PR DESCRIPTION
Introduce options to invert the pitch and roll axes in the Horizon gauge widget, enhancing user control over gauge behavior. Update the widget configuration interface and modal to include these new options. Adjust data handling in the widget to respect the inversion settings.