### PR TITLE
Fix canvas rendering by adding checks for bitmap dimensions

### DIFF
--- a/src/app/core/services/canvas.service.ts
+++ b/src/app/core/services/canvas.service.ts
@@ -42,9 +42,13 @@ export class CanvasService {
     canvas.style.width = '100%';
     canvas.style.height = '100%';
 
-    // Store the callback for this canvas (if provided)
+    // Store the callback for this canvas (if provided), wrapping to ignore zero-size
     if (opts.onResize) {
-      this.resizeCallbacks.set(canvas, opts.onResize);
+      const filteredResize = (w: number, h: number) => {
+        if (w === 0 || h === 0) return;
+        opts.onResize(w, h);
+      };
+      this.resizeCallbacks.set(canvas, filteredResize);
     }
 
     if (!this.sharedResizeObserver) {

--- a/src/app/widgets/widget-datetime/widget-datetime.component.ts
+++ b/src/app/widgets/widget-datetime/widget-datetime.component.ts
@@ -157,7 +157,7 @@ export class WidgetDatetimeComponent extends BaseWidgetComponent implements Afte
 
     // Draw the title bitmap at the top. Request an explicit target size in
     // CSS pixels to avoid any ambiguity with device-pixel intrinsic sizes.
-    if (this.titleBitmap) {
+    if (this.titleBitmap && this.titleBitmap.width > 0 && this.titleBitmap.height > 0) {
       this.canvasCtx.drawImage(this.titleBitmap, 0, 0, this.cssWidth, this.cssHeight);
     }
 

--- a/src/app/widgets/widget-numeric/widget-numeric.component.ts
+++ b/src/app/widgets/widget-numeric/widget-numeric.component.ts
@@ -271,7 +271,11 @@ export class WidgetNumericComponent extends BaseWidgetComponent implements After
 
     this.canvas.clearCanvas(this.canvasCtx, this.cssWidth, this.cssHeight);
 
-    if (this.backgroundBitmap) {
+    if (
+      this.backgroundBitmap &&
+      this.backgroundBitmap.width > 0 &&
+      this.backgroundBitmap.height > 0
+    ) {
       this.canvasCtx.drawImage(this.backgroundBitmap, 0, 0, this.cssWidth, this.cssHeight);
     }
     this.drawValue();

--- a/src/app/widgets/widget-position/widget-position.component.ts
+++ b/src/app/widgets/widget-position/widget-position.component.ts
@@ -168,7 +168,7 @@ export class WidgetPositionComponent extends BaseWidgetComponent implements Afte
 
     this.canvas.clearCanvas(this.canvasCtx, this.cssWidth, this.cssHeight);
 
-    if (this.titleBitmap) {
+    if (this.titleBitmap && this.titleBitmap.width > 0 && this.titleBitmap.height > 0) {
       this.canvasCtx.drawImage(this.titleBitmap, 0, 0, this.cssWidth, this.cssHeight);
     }
     this.canvas.drawText(

--- a/src/app/widgets/widget-racer-line/widget-racer-line.component.ts
+++ b/src/app/widgets/widget-racer-line/widget-racer-line.component.ts
@@ -251,7 +251,7 @@ export class WidgetRacerLineComponent extends BaseWidgetComponent implements Aft
 
     this.canvas.clearCanvas(this.canvasCtx, this.cssWidth, this.cssHeight);
 
-    if (this.titleBitmap) {
+    if (this.titleBitmap && this.titleBitmap.width > 0 && this.titleBitmap.height > 0) {
       this.canvasCtx.drawImage(this.titleBitmap, 0, 0, this.cssWidth, this.cssHeight);
     }
     this.drawDToLine();

--- a/src/app/widgets/widget-racer-timer/widget-racer-timer.component.ts
+++ b/src/app/widgets/widget-racer-timer/widget-racer-timer.component.ts
@@ -291,7 +291,7 @@ export class WidgetRacerTimerComponent extends BaseWidgetComponent implements Af
 
     this.canvas.clearCanvas(this.canvasCtx, this.cssWidth, this.cssHeight);
 
-    if (this.titleBitmap) {
+    if (this.titleBitmap && this.titleBitmap.width > 0 && this.titleBitmap.height > 0) {
       this.canvasCtx.drawImage(this.titleBitmap, 0, 0, this.cssWidth, this.cssHeight);
     }
 

--- a/src/app/widgets/widget-text/widget-text.component.ts
+++ b/src/app/widgets/widget-text/widget-text.component.ts
@@ -126,7 +126,7 @@ export class WidgetTextComponent extends BaseWidgetComponent implements AfterVie
     }
 
     this.canvas.clearCanvas(this.canvasCtx, this.cssWidth, this.cssHeight);
-    if (this.titleBitmap) {
+    if (this.titleBitmap && this.titleBitmap.width > 0 && this.titleBitmap.height > 0) {
       this.canvasCtx.drawImage(this.titleBitmap, 0, 0, this.cssWidth, this.cssHeight);
     }
 


### PR DESCRIPTION
Implement checks for bitmap dimensions before drawing to prevent rendering issues with zero-size bitmaps. This enhances the stability of canvas rendering across various components.