### PR TITLE
Fix the startAt time selection when using mobile browser

### DIFF
--- a/src/app/widgets/widget-racer-timer/widget-racer-timer.component.html
+++ b/src/app/widgets/widget-racer-timer/widget-racer-timer.component.html
@@ -89,7 +89,7 @@
           </mat-icon>
         </button>
       } @case (4) {
-        <input matInput class="set-start-at" type="time" step="1" [(ngModel)]="startAtTimeEdit" (keyup.enter)="setStartTime()">
+        <input matInput class="set-start-at" type="time" step="1" [(ngModel)]="startAtTimeEdit" (change)="setStartTime()">
       }
     }
   </div>


### PR DESCRIPTION
The startAt time cannot be set on android browser as there is no enter key.
This fixes that issue