### PR TITLE
Refactor plugin export and update version to 3.10.1

### DIFF
--- a/kip-plugin/src/index.ts
+++ b/kip-plugin/src/index.ts
@@ -2,7 +2,7 @@ import { Path, Plugin, ServerAPI, SKVersion } from '@signalk/server-api'
 import { Request, Response, NextFunction } from 'express'
 import * as openapi from './openApi.json';
 
-export default (server: ServerAPI): Plugin => {
+const start = (server: ServerAPI): Plugin => {
 
   const API_PATHS = {
     DISPLAYS: `/displays`,
@@ -245,3 +245,4 @@ export default (server: ServerAPI): Plugin => {
 
   return plugin;
 }
+module.exports = start;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mxtommy/kip",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "description": "An advanced and versatile marine instrumentation package to display Signal K data.",
   "license": "MIT",
   "author": {

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -35,7 +35,7 @@ var __importStar = (this && this.__importStar) || (function () {
 Object.defineProperty(exports, "__esModule", { value: true });
 const server_api_1 = require("@signalk/server-api");
 const openapi = __importStar(require("./openApi.json"));
-exports.default = (server) => {
+const start = (server) => {
     const API_PATHS = {
         DISPLAYS: `/displays`,
         INSTANCE: `/displays/:displayId`,
@@ -255,3 +255,4 @@ exports.default = (server) => {
     };
     return plugin;
 };
+module.exports = start;


### PR DESCRIPTION
Refactor the plugin export to use `module.exports` for consistency and update the package version to 3.10.1.