### PR TITLE
Update help documentation for clarity and detail

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@
 
 Unlike many dashboards, KIP comes **automatically included with Signal K distributions**, so there’s nothing extra to install or configure. Simply start your [Signal K](https://signalk.org) server, open KIP in a browser, and it’s ready to go. A single instance works everywhere — no per-device deployment is needed.
 
+[![Help Docs](https://img.shields.io/badge/Help-Docs-blue)](src/assets/help-docs/welcome.md)
+[![Community Videos](https://img.shields.io/badge/Community-Videos-purple)](src/assets/help-docs/community.md)
+[![Contact](https://img.shields.io/badge/Contact-Get_in_touch-success)](src/assets/help-docs/contact-us.md)
+
+Help: [Basics](src/assets/help-docs/welcome.md) · [Dashboards](src/assets/help-docs/dashboards.md) · [Widgets](src/assets/help-docs/dashboards.md#4-widget-gallery-overview) · [Datasets](src/assets/help-docs/datasets.md) · [Remote Control](src/assets/help-docs/welcome.md#remote-control-other-kip-displays) · [Contact](src/assets/help-docs/contact-us.md)
+
+<h2 id="help">Documentation & Help</h2>
+
 KIP is designed for sailors and boaters who want:
 
 - A **ready-to-use, classic marine app experience** with minimal setup.

--- a/src/assets/help-docs/community.md
+++ b/src/assets/help-docs/community.md
@@ -1,0 +1,78 @@
+# Online Community Content
+
+> Want to contribute a video or resource? Share your links by [submitting a PR to this page](https://github.com/mxtommy/Kip/blob/master/src/assets/help-docs/community.md), use the [KIP Discord channel](https://discord.gg/AMDYT2DQga) or open a [GitHub issue](https://github.com/mxtommy/Kip/issues)**!
+
+Explore KIP in action and learn from the community. Below are curated videos, creator channels, and related ecosystem resources.
+
+## Community Video Library
+Curated videos created by community members. Ordered to highlight broad onboarding value first.
+
+| Thumbnail | Video | Focus | Author / Channel |
+|-----------|-------|-------|------------------|
+| ![KIP v3 Overview](https://i.ytimg.com/vi/53s4JsivXjU/hqdefault.jpg) | [KIP v3 – New Features, Setup & Configuration Walkthrough (Full Overview)](https://www.youtube.com/watch?v=53s4JsivXjU) | Full platform overview & configuration | Boating with the Baileys |
+| ![Raspberry Pi Dashboard Review](https://i.ytimg.com/vi/vDWr8qbK55s/hqdefault.jpg) | [Full review raspberry PI dashboard for sailboats. SV GOAT teach](https://www.youtube.com/watch?v=vDWr8qbK55s) | Hardware + dashboard review (Raspberry Pi) | sailing sv goat |
+| ![Open Source Boat Build Part IV](https://i.ytimg.com/vi/BOPwfBOE1DE/hqdefault.jpg) | [Building an Open Source Boat with Raspberry Pi & NMEA 2000 - Part IV - OpenPlotter, Signal K, KIP](https://www.youtube.com/watch?v=BOPwfBOE1DE) | Integration & onboard system build | The Florida Captain |
+| ![SignalK Racer Widgets](https://i.ytimg.com/vi/oFX2F0z5xqU/hqdefault.jpg) | [SignalK racer plugin KIP widgets – July 2025](https://www.youtube.com/watch?v=oFX2F0z5xqU) | Racing plugin KIP widgets demo | Gregory J Wilkins |
+| ![Charla Nautica Friki](https://i.ytimg.com/vi/3pnVsj44VO4/hqdefault.jpg) | [I Charla Náutica Friki: Raspberry, Domótica, Signal K, Interconexión de Equipos…](https://www.youtube.com/watch?v=3pnVsj44VO4) | Spanish session: ecosystem & integration | Luisloflipa Sailing |
+
+Improve or add entries: PR or Discord #showcase.
+
+---
+
+## Authors & Channels
+Creator channels producing helpful KIP or Signal K related content.
+
+### Boating with the Baileys
+- Channel: https://www.youtube.com/@BoatingwiththeBaileys
+- Focus: End‑user onboarding, feature walkthroughs, configuration best practices.
+- Featured Video: [KIP v3 – New Features, Setup & Configuration Walkthrough](https://www.youtube.com/watch?v=53s4JsivXjU)
+
+### Sailing sv goat
+- Channel: https://www.youtube.com/@sv_goat
+- Focus: Practical onboard installs, Raspberry Pi builds, real‑world usage.
+- Featured Video: [Full review Raspberry Pi dashboard for sailboats](https://www.youtube.com/watch?v=vDWr8qbK55s)
+
+### The Florida Captain
+- Channel: https://www.youtube.com/@TheFloridaCaptain
+- Focus: Open source boat build series, NMEA 2000 integration, system architecture.
+- Featured Video: [Open Source Boat Build Part IV](https://www.youtube.com/watch?v=BOPwfBOE1DE)
+
+### Gregory J Wilkins
+- Channel: https://www.youtube.com/@gregoryjwilkins6001
+- Focus: Racing plugin experimentation, tactical visualization, performance tooling.
+- Featured Video: [SignalK Racer Plugin KIP Widgets](https://www.youtube.com/watch?v=oFX2F0z5xqU)
+
+### Luisloflipa Sailing
+- Channel: https://www.youtube.com/@luisloflipa
+- Focus: Spanish-language coverage, integration discussions, DIY marine electronics.
+- Featured Video: [Charla Náutica Friki](https://www.youtube.com/watch?v=3pnVsj44VO4)
+
+### Want to Be Listed?
+Open a PR or post in Discord #showcase with:
+- Channel name + link
+- Focus summary (1 line)
+- One featured video (link + short purpose sentence)
+
+---
+
+---
+
+## More Community Resources
+
+- [Signal K Home page](https://signalk.org/) — The open marine data standard powering KIP
+- [Signal K Discord](https://discord.com/invite/uuZrwz4dCS) — Live chat server: questions, support, contribute and collaborate
+- [Signal K GutHub Project](https://github.com/SignalK) — Feature requests, bug reports, and feedback
+- [SensESP](https://signalk.org/SensESP/) — A Signal K sensor development toolkit for the ESP32 platform
+- [OpenMarine Community](https://openmarine.net/) — OpenPlotter, MacArthur HAT and open source marine tech
+
+## More Community Resources
+
+- [Signal K Home page](https://signalk.org/) — The open marine data standard powering KIP
+- [Signal K Discord](https://discord.com/invite/uuZrwz4dCS) — Live chat server: questions, support, contribute and collaborate
+- [Signal K GutHub Project](https://github.com/SignalK) — Feature requests, bug reports, and feedback
+- [SensESP](https://signalk.org/SensESP/) — A Signal K sensor development toolkit for the ESP32 platform
+- [OpenMarine Community](https://openmarine.net/) — OpenPlotter, MacArthur HAT and open source marine tech
+
+---
+
+> Want to contribute a video or resource? Share your link in the Discord #showcase channel or open a GitHub issue!

--- a/src/assets/help-docs/configuration.md
+++ b/src/assets/help-docs/configuration.md
@@ -1,4 +1,4 @@
-# Configuration Management
+## Configuration Management
 
 KIP provides a "Login to Server" option that determines where your configuration is stored. It is **strongly recommended** to enable server login in the **Settings** under the **Connectivity** tab. This ensures your configurations are stored remotely on the Signal K server and allows automatic loading of configuration from any device. See the "Creating a Signal K user" section below for information on how to create a user.
 

--- a/src/assets/help-docs/contact-us.md
+++ b/src/assets/help-docs/contact-us.md
@@ -1,16 +1,66 @@
-# Get in Touch
+## Get in Touch
 
-We’d love to hear from you! KIP has an active community on the Signal K Discord server. Join us to get help, explore what others are doing with KIP and Signal K, stay updated with the latest news, and share your ideas.
+We’d love to hear from you. The KIP community is active and friendly—whether you are just getting started, troubleshooting an installation, or brainstorming a new idea.
 
-👉 **Join the conversation in the [KIP Discord channel](https://discord.gg/AMDYT2DQga).**
+👉 **Chat with the community in the [KIP Discord channel](https://discord.gg/AMDYT2DQga).**
+
+Use Discord for quick questions, sharing dashboards, comparing hardware setups, and learning how others integrate KIP with Signal K.
 
 ---
 
-## Feature Requests and Bug Reports
+## When to Use GitHub Issues
 
-Have a great idea for a new feature? Found a bug? Let us know!  
-Submit your feature requests or report issues directly on our GitHub project page:
+Please open a GitHub issue anytime you:
+- Want to request a feature or enhancement
+- Find a bug or regression
+- Notice incorrect documentation
+- Have a reproducible performance or stability problem
 
-🔗 **[KIP GitHub Issues](https://github.com/mxtommy/Kip/issues)**
+🔗 **Create or review issues here: [KIP GitHub Issues](https://github.com/mxtommy/Kip/issues)**
 
-Your feedback helps us make KIP even better. Thank you for contributing!
+Before creating a new issue:
+1. Use the search box to see if it already exists (add keywords like the widget name, setting, or error text).
+2. If you find an existing issue, add a comment or reaction instead of opening a duplicate.
+
+### What to Include in a Bug Report
+Provide clear, specific details so we can reproduce and fix the problem faster:
+- What you expected vs. what happened
+- Steps to reproduce (numbered list if possible)
+- KIP version (see About / build info) and deployment method (e.g. Signal K app store, manual build)
+- Signal K server version
+- Browser + version (e.g. Firefox 128, Chrome 129, Safari 18)
+- Relevant widget(s) or data paths (e.g. `navigation.speedOverGround`)
+- Screenshots or a short GIF (if visual)
+- Console errors (from browser dev tools) if any
+
+### Feature Requests
+Tell us:
+- The problem you want to solve (not only the solution you imagine)
+- Why it matters / how it improves use onboard
+- Any related Signal K paths or data sources
+- Rough idea of UI needs (new widget? setting? config option?)
+
+If you’re willing to help test or prototype—say so. That speeds things up.
+
+---
+
+## Response Expectations
+- Discord: often same-day community responses; core maintainer availability may vary.
+- GitHub issues: triage typically within a few days; complex features may be discussed before acceptance.
+- Pull requests: reviews depend on scope—small fixes are faster.
+
+If something critical slips through, feel free to politely bump the issue after about a week.
+
+---
+
+## Contributing Beyond Issues
+- Share dashboards, layouts, or usage patterns. Use the Discord #showcase chanel with a few pictures (great inspiration for others!).
+- Help answer other users’ questions on Discord.
+- Test new widgets or configuration flows and give feedback.
+
+---
+
+## Thank You
+Your feedback, curiosity, and ideas directly shape KIP. Whether it’s a tiny typo fix or a major feature concept—every contribution moves the project forward.
+
+Fair winds, and happy hacking.

--- a/src/assets/help-docs/dashboards.md
+++ b/src/assets/help-docs/dashboards.md
@@ -1,42 +1,117 @@
-# Managing Dashboards
-You can organize your dashboards from the Dashboards page. To edit a dashboard layout, first visualize the dashboard and unlock it.
+## Managing Dashboards
+Dashboards let you group widgets by task—navigation, engines, energy, weather, racing, night watch, and more. This guide covers creating, organizing, and editing dashboards, plus an overview of available widget types.
 
-## Dashboard Pages
-On the Dashboards page, you can add, reorder, delete, rename, and duplicate dashboards. Each dashboard can have a custom name and icon for easy identification. The dashboard name is briefly visible when you cycle through dashboards. Available actions include:
-- **Long press** a dashboard to delete or duplicate it.
-- **Double tap** a dashboard to rename it and select an icon.
-- **Touch and drag** to reorder dashboards.
-- Use the **(+)** button to add a new dashboard.
+---
 
-When renaming or creating a dashboard, you can choose from a variety of icons to visually represent the dashboard's purpose (e.g., navigation, engine monitoring, weather). Icons are displayed in the dashboard menu for quick recognition.
+## 1. Dashboard Pages Panel
+Open the Actions menu and select Settings.
 
-## Editing Layout
-To edit a dashboard's widgets and arrangement, you need to unlock its layout. View the desired dashboard, access the **Actions menu** on the right-hand side, and tap the bottom **unlock button**. The widgets will become surrounded by dashed borders, indicating you are in edit mode. Actions you can perform while editing a layout include:
-- **Long press** an empty area of the dashboard to add a widget (you may need to free up space first).
-- **Double tap** a widget to edit its configuration.
-- **Touch and drag** a widget to reposition it.
-- **Touch and drag** the edges of a widget to resize it.
-- **Long press** a widget to delete or duplicate it.
-- Use the lower right **Check button** to save changes or the **X button** to discard layout changes.
+Here you can:
+- Add a new dashboard (+ button)
+- Reorder dashboards (drag with touch or mouse)
+- Rename and pick an icon (double tap or double click)
+- Duplicate a dashboard (long press or long click → Duplicate)
+- Delete a dashboard (long press or long click → Delete)
 
-## Widget Gallery
-KIP's widgets are versatile visual presentation controls with advanced configuration options to suit your needs. Below is a list of available widgets:
+Choose icons that reflect each dashboard’s purpose (e.g. compass for navigation, droplet for tanks, bolt for power). Icons appear wherever dashboards are listed.
 
-- **Numeric Display**: Create gauges to display any numerical data sent by your system, such as SOG, depth, wind speed, VMG, refrigerator temperature, or weather data.
-- **Text Display**: Display textual data sent by your system, such as MPPT state, vessel details, next waypoint, Fusion radio song information, system component statuses, or configuration details.
-- **Date Display**: A timezone-aware control with flexible presentation formatting support.
-- **Boolean Control Panel**: A switchboard to configure and operate remote devices, such as light switches, bilge pumps, solenoids, or any Signal K path that supports boolean PUT operations.
-- **Position**: Displays the vessel's longitude and latitude based on available GPS devices.
-- **Static Label**: A static text widget that allows you to add customizable labels to your dashboard, helping to organize and clarify your layout effectively.
-- **Simple Linear Gauge**: A simple horizontal visual display ideal for electrical numerical data, such as chargers, MPPT, or shunts.
-- **Linear Gauge**: Visually display any numerical data on a vertical or horizontal scale, such as tank and reservoir levels or battery remaining capacity.
-- **Radial Gauge**: Visually display any numerical data on a radial scale, such as boat speed, wind speed, or engine RPM.
-- **Compass Gauge**: A card or marine compass to display directional data, such as heading, bearing to the next waypoint, or wind angle.
-- **Steel Style Gauge**: An old-school look-and-feel radial and linear gauge.
-- **Pitch & Roll**: Horizon-style attitude indicator showing live pitch and roll to monitor trim, heel, and sea-state response.
-- **Wind Steering Display**: A typical sailboat wind gauge.
-- **Freeboard-SK Chart Plotter**: A high-quality Signal K implementation of the Freeboard integration widget.
-- **Autopilot Head**: Operate your autopilot remotely from any device.
-- **Data Chart**: Visualize data trends over time.
-- **Race Timer**: Track regatta start sequences.
-- **Embedded Webpage**: Integrate any web-based content or application into your KIP layout, such as Grafana dashboards, Node-RED dashboards, or your own standalone web app. This widget supports any content that does not cross domains.
+### Gesture / Action Summary
+| Action         | Touch / Mobile         | Mouse / Desktop         |
+|---------------|-----------------------|------------------------|
+| Add dashboard | Tap (+)               | Click (+)              |
+| Reorder       | Drag tile              | Drag tile              |
+| Rename/Icon   | Double tap             | Double click           |
+| Duplicate     | Long press → Duplicate | Long click → Duplicate |
+| Delete        | Long press → Delete    | Long click → Delete    |
+
+---
+
+## 2. Editing Dashboard Layouts
+1. Navigate to the dashboard you want to change (swipe or use dashboard selector).
+2. Open the Actions menu.
+3. Tap the Unlock/Lock button at the bottom to toggle edit mode.
+
+In edit mode, widgets show dashed outlines.
+
+### What You Can Do in Edit Mode
+- Add a widget (long press empty space → Add Widget)
+- Move a widget (drag)
+- Resize a widget (drag edges/corners)
+- Configure a widget (double tap/double click)
+- Duplicate a widget (long press → Duplicate)
+- Delete a widget (long press → Delete, then confirm)
+- Save changes (Check button) or discard (X button) in the lower right
+
+Tip: If you can’t add a widget, free up space by resizing or moving existing ones first.
+
+---
+
+## 3. Workflow: From Idea to Dashboard
+1. Define the purpose (e.g. “Night Nav” = heading, COG, SOG, depth, wind, batteries, minimal brightness)
+2. Create or duplicate a dashboard similar to what you want
+3. Enter edit mode and add required widgets
+4. Configure each widget’s data paths (keep sample times reasonable to reduce churn)
+5. Arrange and size for readability at your viewing distance
+6. Exit edit mode and test switching at real brightness/environment
+
+---
+
+## 4. Widget Gallery (Overview)
+KIP widgets turn Signal K data into readable visuals and controls. Available widget types:
+
+- **Numeric** – Displays numeric data in a clear and concise format, with options to show min/max values and a background minichart for trends.
+- **Text** – Displays text data with customizable color formatting.
+- **Date & Time** – Shows date and time with custom formatting and timezone correction.
+- **Position** – Displays latitude and longitude for location tracking and navigation.
+- **Static Label** – Add customizable labels to organize and clarify your dashboard layout.
+- **Switch Panel** – Group of toggle switches, indicator lights, and press buttons for digital switching and operations.
+- **Slider** – Range slider for adjusting values (e.g. lighting intensity).
+- **Compact Linear** – Simple horizontal linear gauge with a large value label and modern look.
+- **Linear** – Horizontal or vertical linear gauge with zone highlighting.
+- **Radial** – Radial gauge with configurable dials and zone highlighting.
+- **Compass** – Rotating compass gauge with multiple cardinal indicator options.
+- **Level Gauge** – Dual-scale heel angle indicator for trim tuning and sea-state monitoring.
+- **Pitch & Roll** – Horizon-style attitude indicator showing live pitch and roll degrees.
+- **Classic Steel** – Traditional steel-look linear & radial gauges with range sizes and zone highlights.
+- **Windsteer** – Combines wind, wind sectors, heading, COG, and waypoint info for wind steering.
+- **Wind Trends** – Real-time True Wind trends with dual axes for direction and speed, live values, and averages.
+- **Freeboard-SK** – Adds the Freeboard-SK chart plotter as a widget with automatic sign-in.
+- **Autopilot Head** – Typical autopilot controls for compatible Signal K Autopilot devices.
+- **Realtime Data Chart** – Visualizes data on a real-time chart with actuals, averages, and min/max.
+- **Embed Webpage Viewer** – Embeds external web apps (Grafana, Node-RED, etc.) into your dashboard.
+- **Racesteer** – Race steering display fusing polar performance data with live conditions for optimal tactics.
+- **Racer - Start Line Insight** – Set and adjust start line ends, see distance, favored end, and line bias; integrates with Freeboard SK.
+- **Racer - Start Timer** – Advanced racing countdown timer with OCS status and auto dashboard switching.
+- **Countdown Timer** – Simple race start countdown timer with start, pause, sync, and reset options.
+
+---
+
+## 5. Performance & Layout Tips
+- Favor clarity over cramming: leave space around high‑priority values
+- Group related widgets (navigation, energy, engines, environment)
+- Use consistent units per dashboard (e.g. all speeds in knots, all temps in °C or °F—don’t mix)
+- For night dashboards, adjust brightness or use the all‑red theme in Settings → Options → Display
+- Duplicate a working layout before making major changes (easy rollback)
+- Keep sampling intervals modest (1000 ms+) unless fast reaction is essential
+- Know your device’s hardware limits and adjust widget count per dashboard accordingly
+- Avoid embedding too many external webpages—each adds load
+
+---
+
+## 6. Troubleshooting
+| Issue                  | Possible Cause                        | Fix                                                                 |
+|------------------------|---------------------------------------|---------------------------------------------------------------------|
+| Data shows “—” or blank| Path missing/not configured/null value | Open widget config, verify Signal K path exists and updates. Use Data Inspector and Signal K Data Browser to view raw data from the server. |
+| Wrong units            | Default convert unit used              | Edit widget config paths and set the desired target unit.            |
+| Slow dashboard switching| Excessive data sampling/too many widgets| Increase sample times; remove unused widgets. Split widgets into separate dashboards. Optimize system resource usage. |
+| Embedded page blank    | Cross‑origin blocked                   | See "Embed Page Viewer" help section.                               |
+
+---
+
+## 7. Next Steps
+See also:
+- Remote Control (switch dashboards on unattended displays)
+- Night Mode (automatic theme + brightness)
+- Contact / Issues (report widget feature ideas)
+
+Refine incrementally—small improvements keep dashboards readable and reliable.

--- a/src/assets/help-docs/datainspector.md
+++ b/src/assets/help-docs/datainspector.md
@@ -1,4 +1,4 @@
-# Data Inspector
+## Data Inspector
 
 The Data Inspector is a powerful tool in KIP that allows you to view all Signal K paths and the data received from the server in real time. It provides detailed insights into the data being transmitted, including metadata, sources, and supported operations. This guide explains how to use the Data Inspector effectively.
 

--- a/src/assets/help-docs/datasets.md
+++ b/src/assets/help-docs/datasets.md
@@ -1,4 +1,4 @@
-# Datasets and Data Chart Widget
+## Datasets and Data Chart Widget
 
 Datasets and the Data Chart widget work together to provide real-time data visualization in KIP. They allow you to collect and display historical data trends for Signal K paths, enabling better decision-making and monitoring. This guide explains how to configure and use Datasets and the Data Chart widget effectively.
 

--- a/src/assets/help-docs/embedwidget.md
+++ b/src/assets/help-docs/embedwidget.md
@@ -1,4 +1,4 @@
-# Using the Embed Page Viewer Widget
+## Using the Embed Page Viewer Widget
 
 The Embed Page Viewer widget allows you to display external web pages or web applications directly within your dashboard. By default, the Embed Page Viewer widget does not allow input (touch, mouse and keyboard interactions) with the content in the Embed. To enable interactions, check the setting the widget's options. 
 

--- a/src/assets/help-docs/grafana.md
+++ b/src/assets/help-docs/grafana.md
@@ -1,4 +1,4 @@
-# 5 Minutes with Graphana
+## 5 Minutes with Graphana
 Introduction to using Graphana (by Boating with the Baileys)
 
 [![Watch the video](https://img.youtube.com/vi/b3lHwLnYgx0/0.jpg)](https://www.youtube.com/watch?v=b3lHwLnYgx0)

--- a/src/assets/help-docs/influxdb.md
+++ b/src/assets/help-docs/influxdb.md
@@ -1,4 +1,4 @@
-# Signal K to InfluxDB
+## Signal K to InfluxDB
 Database to store historical data (by Boating with the Baileys)
 
 [![Watch the video](https://img.youtube.com/vi/ULnN-cByQXE/0.jpg)](https://www.youtube.com/watch?v=ULnN-cByQXE)

--- a/src/assets/help-docs/kiosk.md
+++ b/src/assets/help-docs/kiosk.md
@@ -1,4 +1,4 @@
-# Raspberry Pi Kiosk Mode (Chromium)
+## Raspberry Pi Kiosk Mode (Chromium)
 
 This guide launches Chromium in kiosk mode to display KIP at:
 http://<sk_server_IP>:3000/@mxtommy/kip/#/page/0

--- a/src/assets/help-docs/menu.json
+++ b/src/assets/help-docs/menu.json
@@ -4,10 +4,10 @@
   { "title": "Dashboards and Layout", "file": "dashboards.md" },
   { "title": "Zones, Notifications and Highlights", "file": "zones.md" },
   { "title": "Data Inspector", "file": "datainspector.md" },
-  { "title": "Updating Signal K data", "file": "putcontrols.md" },
+  { "title": "Digital Switching and PUT", "file": "putcontrols.md" },
   { "title": "The Embed Page Viewer", "file": "embedwidget.md" },
   { "title": "Datasets and Data Chart Widget", "file": "datasets.md" },
-  { "title": "Gafana Integration", "file": "grafana.md" },
+  { "title": "Grafana Integration", "file": "grafana.md" },
   { "title": "InfluxDB and Signal K", "file": "influxdb.md" },
   { "title": "Kiosk Mode", "file": "kiosk.md" },
   { "title": "Contact Us", "file": "contact-us.md" }

--- a/src/assets/help-docs/menu.json
+++ b/src/assets/help-docs/menu.json
@@ -10,5 +10,6 @@
   { "title": "Kiosk Mode", "file": "kiosk.md" },
   { "title": "Grafana Integration", "file": "grafana.md" },
   { "title": "InfluxDB and Signal K", "file": "influxdb.md" },
+  { "title": "Online Community Content", "file": "community.md" },
   { "title": "Contact Us", "file": "contact-us.md" }
 ]

--- a/src/assets/help-docs/menu.json
+++ b/src/assets/help-docs/menu.json
@@ -7,8 +7,8 @@
   { "title": "Digital Switching and PUT", "file": "putcontrols.md" },
   { "title": "The Embed Page Viewer", "file": "embedwidget.md" },
   { "title": "Datasets and Data Chart Widget", "file": "datasets.md" },
+  { "title": "Kiosk Mode", "file": "kiosk.md" },
   { "title": "Grafana Integration", "file": "grafana.md" },
   { "title": "InfluxDB and Signal K", "file": "influxdb.md" },
-  { "title": "Kiosk Mode", "file": "kiosk.md" },
   { "title": "Contact Us", "file": "contact-us.md" }
 ]

--- a/src/assets/help-docs/putcontrols.md
+++ b/src/assets/help-docs/putcontrols.md
@@ -1,14 +1,14 @@
-# Updating Signal K Data with PUT Commands
+# Digital Switching and using PUT Commands
 
 Signal K allows users to update data paths and trigger device reactions. This can include turning a light on or off, dimming it, activating a bilge pump, or other similar actions. This guide explains how to use the Switch Panel or Slider widgets to achieve this, how to verify if a path supports data reception (known as PUT-enabled in Signal K terms), and what is required to enable PUT functionality.
 
 ## What is Required to Trigger Device Reactions
-For Signal K to accept any data from a client application, the application must be authenticated with a valid security token. Read the **Login & Configurations** help section for details on how to setup login in KIP. By default, sending data to a Signal K path only updates the value and broadcasts it to the network. No actions are taken unless a plugin or handler is configured to respond to the updated value. For example:
-- Sending a PUT 'engage' command to `self.steering.autopilot.state` will update the state value, but the autopilot will not engage unless a plugin or handler is set up to process the command and communicate with the hardware.
+For Signal K to accept any data from a client application, the application must be authenticated with a valid security token. Read the **Login & Configurations** help section for details on how to setup login in KIP. By default, sending data to a Signal K path only updates the value and broadcasts it to the network. No actions are taken unless an action handler is configured to respond to the updated value. For example:
+- Sending a PUT 'engage' command to `self.steering.autopilot.state` will update the state value, but the autopilot will not engage unless a handler (the autopilot plugin in this case) is set up to process the command and communicate with the hardware.
 
-To enable actions, you have several options:
+To enable action handles, you have several options:
 1. **Install a Plugin**:
-   - The simplest option is to look in Signal K's Appstore. There are many plugins already available in the Signal K ecosystem. Search for the plugin you need, install it, and configure it.
+   - The simplest option is to look in Signal K's Appstore. There are many plugins already available in the Signal K ecosystem such as plugins for (Shelly)[https://www.shelly.com], (Sonoff)[https://sonoff.tech/collections/diy-smart-switches] and standard N2K, like the (Yacht Devices)[https://www.yachtd.com] YDCC. Search for the plugin you need, install it, and configure it.
    
 2. **Use Node-RED's Signal K PUT Handler**:
    - Node-RED is a visual and easy-to-learn automation platform installed with Signal K. The Signal K team has created Signal K-specific Node-RED nodes, allowing you to easily automate your vessel. You can find Node-RED in the Webapps section of the Signal K Admin site.

--- a/src/assets/help-docs/putcontrols.md
+++ b/src/assets/help-docs/putcontrols.md
@@ -1,4 +1,4 @@
-# Digital Switching and using PUT Commands
+## Digital Switching and using PUT Commands
 
 Signal K allows users to update data paths and trigger device reactions. This can include turning a light on or off, dimming it, activating a bilge pump, or other similar actions. This guide explains how to use the Switch Panel or Slider widgets to achieve this, how to verify if a path supports data reception (known as PUT-enabled in Signal K terms), and what is required to enable PUT functionality.
 

--- a/src/assets/help-docs/welcome.md
+++ b/src/assets/help-docs/welcome.md
@@ -60,26 +60,49 @@ Save your night vision by automatically switching KIP to day or night mode based
 KIP supports multiple user profiles, allowing different roles on board—such as captain, skipper, tactician, navigator, or engineer—to tailor the interface to their needs. Profiles can also be used to tie specific configuration arrangements to use cases or device form factors. See the Login & Configurations help sections for mode details.
 
 ## Remote Control Other KIP Displays
-Control which dashboard is shown on another KIP instance (e.g., a mast display, hard-to-reach screen, or a non‑touch device).
+Control which dashboard is shown on another KIP instance (for example: a mast display, a TV or pilot‑house screen that is hard to reach, or a device with no local input hardware).
 
-Use cases
-- Mast display: change dashboards from the cockpit.
-- Wall/helm screens: toggle dashboards without standing up or reaching for controls.
-- Headless/non‑touch: select dashboards when no keyboard/mouse is connected.
+### Typical Use Cases
+- Mast display: change dashboards from the cockpit without going forward.
+- Salon / TV screen: rotate between navigation and status dashboards easily.
+- Headless / no input device: select dashboards when there is no keyboard/mouse or touch is disabled.
 
-Setup
-1) On the device you want to control (Target KIP)
-- Open Options → Display → Remote Control.
-- Enable “Allow this KIP dashboard to be managed remotely.”
-- Set an Instance Name (easier to recognize later).
+### Requirements
+- Both devices must be connected to the same Signal K server.
+- You must be logged in (authenticated) on both devices (Connectivity tab → Login to Server enabled).
+- The target device must explicitly allow remote control (Display tab → Remote Control option group).
 
-2) On the device you’ll control from (Controller KIP)
-- Open the Actions menu, access Settings and choose Remote Control.
-- Pick a device from the list (by Instance Name).
-- Choose a dashboard tile to set it active on the target device.
+### Good Naming Practice
+If multiple devices log in with the same Signal K user to share configuration, they inevitably share the same Instance Name. Whilst being confusing, it will still work. To fix this, you must use different Signal K users and set a descriptive name on each configuration (e.g. Mast Display, Helm Port, Nav Station) so you can identify them quickly.
 
-Notes and tips
-- Both devices must connect to the same Signal K server.
-- Permissions: you must use an authenticated connection to Signal K user (Connectivity Login to Server toggle).
-- If the device list is empty, verify the Target KIP has “Allow this dashboard to be managed remotely” enabled and a name set.
-- Changes are sent instantly; the UI shows the currently active dashboard.
+### Setup
+1. On the device you want to control (Target KIP)
+  - Open: Options → Display → Remote Control.
+  - Enable: Allow this KIP dashboard to be managed remotely.
+  - Set: Instance Name (this is what will appear in the controller list).
+2. On the controlling device
+  - Open: Actions menu → Settings → Remote Control.
+  - Select the target device by its Instance Name.
+  - Click / tap a dashboard tile to activate it on the target device.
+
+### Using Remote Control
+- The currently active dashboard on the target device is highlighted.
+- Switching is usually instantaneous; brief delays can indicate network latency.
+- You can leave the Remote Control panel open to “page” through dashboards live.
+
+### Troubleshooting
+| Problem | What to Check |
+|---------|----------------|
+| Target device not listed | Is remote control enabled there? Is Instance Name set? Both on same Signal K server? |
+| No highlight / not switching | Confirm target device stays online (no sleep / browser closed). Refresh controller panel. |
+| Wrong device switched | Two devices share same Instance Name—rename one. |
+| Works, then stops | Network drop or Signal K reconnect in progress—wait a few seconds or reload. |
+
+### Tips
+- Keep Instance Names short but meaningful (e.g. Mast, Helm, NavTV).
+- For unattended displays, enable the browser’s keep‑awake / no‑sleep features if supported.
+- Combine with Night Mode + per‑profile layouts for role‑specific remote switching.
+- Use different Signal K users if you want fully isolated configurations.
+
+### Privacy / Safety Note
+Anyone with access to a logged‑in controlling KIP instance can switch dashboards on enabled targets. Only enable remote management on displays where that is acceptable.

--- a/src/assets/help-docs/zones.md
+++ b/src/assets/help-docs/zones.md
@@ -1,4 +1,4 @@
-# Harness the Power of Data State Notifications
+## Harness the Power of Data State Notifications
 
 Stay informed about your vessel’s data with Signal K’s state notifications. For example, Signal K can flag certain sensor readings—such as depth or temperature—when they reach critical levels. KIP can then visually or audibly alert you. For instance, if the depth drops to 3 meters or less, KIP can highlight this with a warning sound or visual cue. This powerful feature combines **Zones Configuration** and **Notification Methods** in Signal K.
 


### PR DESCRIPTION
Enhance the 'Contact Us', 'Dashboards', 'Digital Switching', and 'Welcome' sections to improve user understanding and engagement. Adjust titles and content for better clarity and usability.