### PR TITLE
Chartplotter mode: map scrolling changes dashboard view

### DIFF
--- a/src/app/core/components/options/display/display.component.html
+++ b/src/app/core/components/options/display/display.component.html
@@ -33,9 +33,9 @@
           <br/>
           <mat-slider min="0" max="1" step="0.01" [disabled]="redNightModeToggle.checked" discrete>
             <input #inputBrightness matSliderThumb
-            [value]="nightBrightness()"
-            (input)="setBrightness(+inputBrightness.value)"
-            [disabled]="redNightModeToggle.checked">
+              [value]="nightBrightness()"
+              (input)="setBrightness(+inputBrightness.value)"
+              [disabled]="redNightModeToggle.checked">
           </mat-slider>
         </div>
       </mat-expansion-panel>
@@ -82,6 +82,12 @@
               <mat-option value="right">Right side</mat-option>
             </mat-select>
           </mat-form-field>
+          <mat-slide-toggle #isFskShellSwipeEnabled class="optional-field full-width"
+            name="freeboardShellSwipeEnabled"
+            [(ngModel)]="splitShellSwipeDisabled"
+            [disabled]="!isFskShellEnabled.checked">
+            Disable swipe gestures over chart panel.
+        </mat-slide-toggle>
       </mat-expansion-panel>
       <mat-expansion-panel>
         <mat-expansion-panel-header>

--- a/src/app/core/components/options/display/display.component.ts
+++ b/src/app/core/components/options/display/display.component.ts
@@ -49,6 +49,7 @@ export class SettingsDisplayComponent implements OnInit {
   // Freeboard split shell config
   protected splitShellEnabled = model<boolean>(false);
   protected splitShellSide = model<'left' | 'right'>('left');
+  protected splitShellSwipeDisabled = model<boolean>(false);
   // Guards concurrent plugin enable checks to avoid stale promise handlers mutating state
   private _pluginCheckSeq = 0;
   readonly LIGHT_THEME_NAME = "light-theme";
@@ -67,6 +68,7 @@ export class SettingsDisplayComponent implements OnInit {
     this.instanceName.set(this._settings.getInstanceName());
     this.splitShellEnabled.set(this._settings.getSplitShellEnabled());
     this.splitShellSide.set(this._settings.getSplitShellSide());
+    this.splitShellSwipeDisabled.set(this._settings.getSplitShellSwipeDisabled());
   }
 
   protected saveAllSettings():void {
@@ -91,6 +93,7 @@ export class SettingsDisplayComponent implements OnInit {
     }
     this._settings.setSplitShellEnabled(this.splitShellEnabled());
     this._settings.setSplitShellSide(this.splitShellSide());
+    this._settings.setSplitShellSwipeDisabled(this.splitShellSwipeDisabled());
 
     this.displayForm().form.markAsPristine();
     this._app.sendSnackbarNotification("Configuration saved", 3000, false);

--- a/src/app/core/components/split-shell/split-shell.component.html
+++ b/src/app/core/components/split-shell/split-shell.component.html
@@ -18,7 +18,11 @@
         </button>
       </div>
     }
-    <widget-freeboardsk class="fsk-iframe" [type]="freeboardWidgetStub.type" [id]="freeboardWidgetStub.uuid" [disableWidgetShell]="true"/>
+    <widget-freeboardsk class="fsk-iframe"
+      [type]="freeboardWidgetStub.type"
+      [id]="freeboardWidgetStub.uuid"
+      [swipeDisabled]="fskShellSwipeDisabled()"
+      [disableWidgetShell]="true" />
   </div>
   <div class="dash-container">
     <dashboard />

--- a/src/app/core/components/split-shell/split-shell.component.ts
+++ b/src/app/core/components/split-shell/split-shell.component.ts
@@ -27,6 +27,7 @@ export class SplitShellComponent implements OnDestroy {
   private originalPanelRatio: number | null = null; // captured when entering edit (non-static) mode
   public panelWidth = signal<number>(0); // derived pixels
   public panelCollapsed = computed(() => !!this._dashboard.dashboards()[this._dashboard.activeDashboard()]?.collapseSplitShell);
+  protected fskShellSwipeDisabled = toSignal(this._settings.getSplitShellSwipeDisabledAsO());
 
   // Only show toggle on handset (portrait) per requirement
   private handset$ = this.breakpointObserver.observe(Breakpoints.HandsetPortrait);

--- a/src/app/core/interfaces/app-settings.interfaces.ts
+++ b/src/app/core/interfaces/app-settings.interfaces.ts
@@ -32,6 +32,7 @@ export interface IAppConfig {
   notificationConfig: INotificationConfig;
   splitShellEnabled?: boolean;
   splitShellSide?: 'left' | 'right';
+  splitShellSwipeDisabled?: boolean;
   splitShellWidth?: number;
 }
 

--- a/src/app/core/services/app-settings.service.ts
+++ b/src/app/core/services/app-settings.service.ts
@@ -35,6 +35,7 @@ export class AppSettingsService {
   private instanceName: BehaviorSubject<string> = new BehaviorSubject<string>('');
   private splitShellEnabled: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
   private splitShellSide: BehaviorSubject<'left' | 'right'> = new BehaviorSubject<'left' | 'right'>('left');
+  private splitShellSwipeDisabled: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
   private splitShellWidth: BehaviorSubject<number> = new BehaviorSubject<number>(300);
 
   public proxyEnabled = false;
@@ -265,6 +266,12 @@ export class AppSettingsService {
       this.splitShellSide.next(this.activeConfig.app.splitShellSide);
     }
 
+    if (this.activeConfig.app.splitShellSwipeDisabled === undefined) {
+      this.setSplitShellSwipeDisabled(false);
+    } else {
+      this.splitShellSwipeDisabled.next(this.activeConfig.app.splitShellSwipeDisabled);
+    }
+
     if (this.activeConfig.app.splitShellWidth === undefined) {
       this.setSplitShellWidth(0.3); // default ratio
     } else {
@@ -469,6 +476,23 @@ export class AppSettingsService {
     }
   }
 
+  public getSplitShellSwipeDisabledAsO() {
+    return this.splitShellSwipeDisabled.asObservable();
+  }
+  public getSplitShellSwipeDisabled(): boolean {
+    return this.splitShellSwipeDisabled.getValue();
+  }
+  public setSplitShellSwipeDisabled(enabled: boolean): void {
+    this.splitShellSwipeDisabled.next(enabled);
+    const appConf = this.buildAppStorageObject();
+
+    if (this.useSharedConfig) {
+      this.storage.patchConfig('IAppConfig', appConf);
+    } else {
+      this.saveAppConfigToLocalStorage();
+    }
+  }
+
   public getSplitShellWidthAsO() {
     return this.splitShellWidth.asObservable();
   }
@@ -633,7 +657,8 @@ export class AppSettingsService {
       notificationConfig: this.kipKNotificationConfig.getValue(),
       splitShellEnabled: this.splitShellEnabled.getValue(),
       splitShellSide: this.splitShellSide.getValue() ?? 'right',
-      splitShellWidth: this.splitShellWidth.getValue() ?? 380
+      splitShellWidth: this.splitShellWidth.getValue() ?? 380,
+      splitShellSwipeDisabled: this.splitShellSwipeDisabled.getValue()
     }
     return storageObject;
   }

--- a/src/app/widgets/widget-freeboardsk/widget-freeboardsk.component.ts
+++ b/src/app/widgets/widget-freeboardsk/widget-freeboardsk.component.ts
@@ -28,6 +28,7 @@ export class WidgetFreeboardskComponent implements AfterViewInit, OnDestroy {
   protected iframe = viewChild.required<ElementRef<HTMLIFrameElement>>('freeboardSkIframe');
   public widgetUrl: string = null;
   public disableWidgetShell = input<boolean>(false);
+  public swipeDisabled = input<boolean>(false);
   private _authTokenSubscription: Subscription = null;
 
   private viewReady = signal(false);
@@ -83,6 +84,7 @@ export class WidgetFreeboardskComponent implements AfterViewInit, OnDestroy {
   };
 
   injectSwipeScript() {
+    if (this.swipeDisabled()) return;
     const iframeWindow = this.iframe().nativeElement.contentWindow;
     const iframeDocument = this.iframe().nativeElement.contentDocument;
     if (!iframeDocument || !iframeWindow) {

--- a/src/default-config/config.blank.const.ts
+++ b/src/default-config/config.blank.const.ts
@@ -15,6 +15,7 @@ export const DefaultAppConfig: IAppConfig = {
   "notificationConfig": DefaultNotificationConfig,
   "splitShellEnabled": true,
   "splitShellSide": "left",
+  "splitShellSwipeDisabled": false,
   "splitShellWidth": 0.5
 }
 

--- a/src/default-config/config.demo.const.ts
+++ b/src/default-config/config.demo.const.ts
@@ -12,6 +12,7 @@ export const DemoAppConfig: IAppConfig = {
   "instanceName": "",
   "splitShellEnabled": true,
   "splitShellSide": "left",
+  "splitShellSwipeDisabled": false,
   "splitShellWidth": 0.7,
   "dataSets": [
     {


### PR DESCRIPTION
Implement a configuration option to disable swipe gestures over the chart panel in Chartplotter mode. This change prevents unintended dashboard transitions when scrolling the map. The new setting is integrated into the application settings and UI components, ensuring that the KIP dashboard remains visible during map interactions.

Configuration upgrade service updated with new app config properties

Fixes #826