### PR TITLE
Normalize radial and linear needle options

### DIFF
--- a/src/app/core/interfaces/widgets-interface.ts
+++ b/src/app/core/interfaces/widgets-interface.ts
@@ -124,14 +124,16 @@ export interface IWidgetSvcConfig {
     subType?: string;
     /** Optional. Should gauge ticks be enabled */
     enableTicks?: boolean;
+    /** Optional. Should gauge show a progress bar */
+    enableProgressbar?: boolean;
+    /** Optional. Should gauge show a needle indicator */
+    enableNeedle?: boolean;
     /** Optional. Units formatting rule name */
     unitLabelFormat?: string;
     /** Optional. Used ny ngGauge when in compass mode */
     compassUseNumbers?: boolean;
     /** Optional. Used ny ngGauge to show/hide value box */
     showValueBox?: boolean;
-    /** Optional. Used by Linear ngGauge to use a needle indicator and no progress bar */
-    useNeedle?: boolean;
     /** Optional. Used by GaugeSteel to set face style */
     backgroundColor?: string;
     /** Optional. Used by GaugeSteel to set face style */

--- a/src/app/widget-config/modal-widget-config/modal-widget-config.component.html
+++ b/src/app/widget-config/modal-widget-config/modal-widget-config.component.html
@@ -306,8 +306,6 @@
                     Show Heeling Side Label
                   </mat-checkbox>
                 </div>
-              }
-              @if ((widgetConfig?.gauge?.type === "angle" )) {
                 <div formGroupName="gauge">
                   <mat-checkbox name="invertAngle" formControlName="invertAngle">
                     Reverse Angle
@@ -329,6 +327,29 @@
                     required
                   />
                 </mat-form-field>
+                <div formGroupName="gauge">
+                  <mat-checkbox name="enableNeedle" formControlName="enableNeedle">
+                    Show Needle Indicator
+                  </mat-checkbox>
+                </div>
+                @if (widgetConfig?.gauge?.type === 'ngRadial') {
+                  <div formGroupName="gauge">
+                    <mat-checkbox name="enableProgressbar" formControlName="enableProgressbar">
+                      Show Progress Bar
+                    </mat-checkbox>
+                  </div>
+                  <div formGroupName="gauge" class="options-grid-span2">
+                    <mat-checkbox name="enableTicks" formControlName="enableTicks">
+                      Show Ticks
+                    </mat-checkbox>
+                  </div>
+                } @else {
+                  <div formGroupName="gauge">
+                    <mat-checkbox name="enableTicks" formControlName="enableTicks">
+                      Show Ticks
+                    </mat-checkbox>
+                  </div>
+                }
               }
               @if (widgetConfig?.gauge?.type === 'ngRadial') {
                 @if (['marineCompass','baseplateCompass'].indexOf(formMaster.value.gauge.subType) > -1) {
@@ -402,16 +423,6 @@
                 }
               }
               @if (widgetConfig?.gauge?.type === 'ngLinear') {
-                <div formGroupName="gauge">
-                  <mat-checkbox name="useNeedle" formControlName="useNeedle">
-                    Use needle indicator
-                  </mat-checkbox>
-                </div>
-                <div formGroupName="gauge">
-                  <mat-checkbox name="enableTicks" formControlName="enableTicks">
-                    Enable Ticks
-                  </mat-checkbox>
-                </div>
                 <mat-form-field formGroupName="gauge" class="options-grid-span2">
                   <mat-label>Orientation</mat-label>
                   <mat-select

--- a/src/app/widgets/widget-gauge-ng-linear/widget-gauge-ng-linear.component.ts
+++ b/src/app/widgets/widget-gauge-ng-linear/widget-gauge-ng-linear.component.ts
@@ -58,9 +58,9 @@ export class WidgetGaugeNgLinearComponent implements AfterViewInit {
     gauge: {
       type: 'ngLinear',
       subType: 'vertical', // vertical | horizontal
-      enableTicks: false,
       highlightsWidth: 5,
-      useNeedle: false
+      enableTicks: true,
+      enableNeedle: false
     },
     numInt: 1,
     numDecimal: 0,
@@ -177,11 +177,11 @@ export class WidgetGaugeNgLinearComponent implements AfterViewInit {
       if (!this.viewReady()) return;
       untracked(() => {
         const opt: LinearGaugeOptions = {};
-        const useNeedle = cfg.gauge?.useNeedle;
+        const enableNeedle = cfg.gauge?.enableNeedle;
         const palette = getColors(cfg.color, theme);
         switch (state) {
           case States.Alarm:
-            if (useNeedle) {
+            if (enableNeedle) {
               opt.colorNeedle = theme.zoneAlarm;
               opt.colorValueText = theme.zoneAlarm;
             } else {
@@ -190,7 +190,7 @@ export class WidgetGaugeNgLinearComponent implements AfterViewInit {
             }
             break;
           case States.Warn:
-            if (useNeedle) {
+            if (enableNeedle) {
               opt.colorNeedle = theme.zoneWarn;
               opt.colorValueText = theme.zoneWarn;
             } else {
@@ -199,7 +199,7 @@ export class WidgetGaugeNgLinearComponent implements AfterViewInit {
             }
             break;
           case States.Alert:
-            if (useNeedle) {
+            if (enableNeedle) {
               opt.colorNeedle = theme.zoneAlert;
               opt.colorValueText = theme.zoneAlert;
             } else {
@@ -208,7 +208,7 @@ export class WidgetGaugeNgLinearComponent implements AfterViewInit {
             }
             break;
           default:
-            if (useNeedle) {
+            if (enableNeedle) {
               opt.colorNeedle = palette.color;
               opt.colorValueText = palette.color;
             } else {
@@ -226,7 +226,7 @@ export class WidgetGaugeNgLinearComponent implements AfterViewInit {
   private buildGaugeOptions(cfg: IWidgetSvcConfig, theme: ITheme, scale: IScale) {
     const opt = this.gaugeOptions = {} as LinearGaugeOptions;
     const isVertical = cfg.gauge?.subType === 'vertical';
-    const useNeedle = cfg.gauge?.useNeedle;
+    const enableNeedle = cfg.gauge?.enableNeedle;
     const ticks = cfg.gauge?.enableTicks;
     // Canvas size (defer dynamic resize until AfterViewInit)
     opt.minValue = scale.min; opt.maxValue = scale.max;
@@ -234,12 +234,12 @@ export class WidgetGaugeNgLinearComponent implements AfterViewInit {
     opt.title = this.displayName(); opt.fontTitleSize = 40; opt.fontTitle = 'Roboto'; opt.fontTitleWeight = 'bold';
     // Bar geometry (match legacy defaults)
     opt.barLength = isVertical ? 80 : 90;
-    opt.barWidth = ticks ? (useNeedle ? 0 : 30) : 60;
+    opt.barWidth = ticks ? (enableNeedle ? 0 : 30) : 60;
     opt.barProgress = true; opt.barBeginCircle = 0; opt.barStrokeWidth = 0; opt.barShadow = 0;
     // Needle geometry
-    opt.needle = !!useNeedle; opt.needleType = useNeedle ? 'arrow' : 'line';
-    opt.needleStart = useNeedle ? (isVertical ? 200 : 155) : -45;
-    opt.needleEnd = useNeedle ? (isVertical ? 175 : 180) : 55;
+    opt.needle = !!enableNeedle; opt.needleType = enableNeedle ? 'arrow' : 'line';
+    opt.needleStart = enableNeedle ? (isVertical ? 200 : 155) : -45;
+    opt.needleEnd = enableNeedle ? (isVertical ? 175 : 180) : 55;
     opt.needleShadow = true; opt.needleSide = 'both';
     opt.units = cfg.paths?.['gaugePath']?.convertUnitTo; opt.fontUnits = 'Roboto'; opt.fontUnitsWeight = 'normal';
     opt.borders = false; opt.borderOuterWidth = 0; opt.borderMiddleWidth = 0; opt.borderInnerWidth = 0; opt.borderShadowWidth = 0; opt.borderRadius = 0;
@@ -253,7 +253,7 @@ export class WidgetGaugeNgLinearComponent implements AfterViewInit {
     const palette = getColors(cfg.color, theme);
     // baseline colors
     opt.colorValueText = palette.color;
-    if (useNeedle) {
+    if (enableNeedle) {
       opt.colorNeedle = palette.color; opt.colorNeedleEnd = palette.color; opt.needleWidth = 45;
       opt.colorNeedleShadowUp = palette.color; opt.colorNeedleShadowDown = palette.color;
     } else {
@@ -264,11 +264,11 @@ export class WidgetGaugeNgLinearComponent implements AfterViewInit {
     opt.majorTicks = ticks ? scale.majorTicks as unknown as string[] : [];
     opt.majorTicksInt = cfg.numInt ?? 1; opt.majorTicksDec = cfg.numDecimal ?? 2;
     opt.strokeTicks = !!ticks; opt.minorTicks = ticks ? 2 : 0; opt.ticksWidthMinor = ticks ? 6 : 0;
-    opt.numberSide = useNeedle ? 'right' : 'left';
+    opt.numberSide = enableNeedle ? 'right' : 'left';
     opt.fontNumbersSize = ticks ? (isVertical ? 22 : 30) : 0;
-    opt.numbersMargin = isVertical ? (useNeedle ? -7 : -3) : (useNeedle ? -33 : -5);
-    opt.ticksWidth = ticks ? (useNeedle ? (isVertical ? 15 : 10) : 10) : 0;
-    opt.ticksPadding = ticks ? (isVertical ? (useNeedle ? 0 : 5) : (useNeedle ? 9 : 8)) : 0;
+    opt.numbersMargin = isVertical ? (enableNeedle ? -7 : -3) : (enableNeedle ? -33 : -5);
+    opt.ticksWidth = ticks ? (enableNeedle ? (isVertical ? 15 : 10) : 10) : 0;
+    opt.ticksPadding = ticks ? (isVertical ? (enableNeedle ? 0 : 5) : (enableNeedle ? 9 : 8)) : 0;
     opt.tickSide = 'left';
     opt.animation = true; opt.animationRule = 'linear'; opt.animatedValue = false; opt.animateOnInit = false; opt.animationDuration = (cfg.paths?.['gaugePath']?.sampleTime ?? 500) - 25;
     opt.highlights = []; opt.highlightsWidth = cfg.gauge?.highlightsWidth;

--- a/src/app/widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component.ts
+++ b/src/app/widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component.ts
@@ -58,11 +58,12 @@ export class WidgetGaugeNgRadialComponent implements AfterViewInit {
     gauge: {
       type: 'ngRadial',
       subType: 'measuring',
-      enableTicks: true,
-      compassUseNumbers: false,
       highlightsWidth: 5,
       scaleStart: 180,
-      barStartPosition: 'left'
+      barStartPosition: 'left',
+      enableTicks: true,
+      enableProgressbar: true,
+      enableNeedle: true
     },
     numInt: 1,
     numDecimal: 0,
@@ -214,6 +215,9 @@ export class WidgetGaugeNgRadialComponent implements AfterViewInit {
   private buildGaugeOptions(cfg: IWidgetSvcConfig, theme: ITheme, scale: IScale) {
     const g = this.gaugeOptions = {} as RadialGaugeOptions;
     g.title = this.displayName();
+    g.minValue = scale.min;
+    g.maxValue = scale.max;
+    g.units = cfg.paths?.['gaugePath']?.convertUnitTo;
     g.highlights = [];
     // Include initial highlights if already available (after view init effect will re-apply).
     const initialHl = this.highlights();
@@ -234,32 +238,41 @@ export class WidgetGaugeNgRadialComponent implements AfterViewInit {
     g.animation = true; g.animateOnInit = false; g.animatedValue = false; g.animationRule = 'linear';
     const st = cfg.paths?.['gaugePath']?.sampleTime ?? 500; g.animationDuration = st - 25;
     g.colorBorderShadow = false; g.colorBorderOuter = theme.cardColor; g.colorBorderOuterEnd = ''; g.colorBorderMiddle = theme.cardColor; g.colorBorderMiddleEnd = '';
-    g.colorBarProgress = getColors(cfg.color, theme).color;
-    g.colorNeedle = getColors(cfg.color, theme).dim; g.colorNeedleEnd = getColors(cfg.color, theme).dim;
-    g.colorTitle = theme.contrastDim; g.colorUnits = theme.contrastDim; g.colorValueText = getColors(cfg.color, theme).color;
-    this.colorStrokeTicks.set(theme.contrastDim); g.colorMinorTicks = theme.contrastDim; g.colorNumbers = theme.contrastDim; g.colorMajorTicks = theme.contrastDim;
     g.colorPlate = g.colorPlateEnd = theme.cardColor; g.colorBar = theme.background;
-    g.colorNeedleShadowUp = ''; g.colorNeedleShadowDown = 'black';
+
+    g.barProgress = cfg.gauge?.enableProgressbar; g.colorBarProgress = getColors(cfg.color, theme).color;
+    g.colorNeedle = getColors(cfg.color, theme).color; g.colorNeedleEnd = getColors(cfg.color, theme).color;
+    g.needleShadow = true; g.colorNeedleShadowUp = "black"; g.colorNeedleShadowDown = "black";
     g.colorNeedleCircleInner = g.colorPlate; g.colorNeedleCircleInnerEnd = g.colorPlate; g.colorNeedleCircleOuter = g.colorPlate; g.colorNeedleCircleOuterEnd = g.colorPlate;
+
+    g.colorTitle = theme.contrastDim; g.colorUnits = theme.contrastDim; g.colorValueText = getColors(cfg.color, theme).color;
+    this.colorStrokeTicks.set(theme.contrastDim); g.colorMinorTicks = theme.contrastDim;
+    g.animationTarget = this.ANIMATION_TARGET_NEEDLE; g.useMinPath = false;
+
     // subtype specific
     if (cfg.gauge?.subType === 'capacity') {
-      g.minValue = scale.min;
-      g.maxValue = scale.max;
-      g.units = cfg.paths?.['gaugePath']?.convertUnitTo;
-      g.fontTitleSize = 40; g.barProgress = true; g.barWidth = 20;
-      g.colorBarProgress = getColors(cfg.color, theme).dim;
+      g.fontTitleSize = 40;
       g.valueBox = true; g.fontValueSize = 60; g.valueBoxWidth = 10; g.valueBoxBorderRadius = 5; g.valueBoxStroke = 0; g.colorValueBoxBackground = '';
-      g.ticksAngle = 360; g.startAngle = (cfg.gauge?.scaleStart as number) || 180; g.majorTicks = 0 as unknown as string[]; g.exactTicks = true; g.strokeTicks = false; g.minorTicks = 0; g.numbersMargin = 0; g.fontNumbersSize = 0;
       g.colorMajorTicks = g.colorPlate; g.colorNumbers = g.colorMinorTicks = '' as unknown as string;
-      g.needle = true; g.needleType = this.LINE; g.needleWidth = 2; g.needleShadow = false; g.needleStart = 75; g.needleEnd = 95; g.needleCircleSize = 1; g.needleCircleInner = false; g.needleCircleOuter = false;
+
+      g.barWidth = 20; g.colorBarProgress = getColors(cfg.color, theme).dim;
+      g.needle = cfg.gauge.enableNeedle; g.needleType = this.LINE; g.needleWidth = 2; g.needleStart = 75; g.needleEnd = 95; g.needleCircleSize = 1; g.needleCircleInner = false; g.needleCircleOuter = false;
+      g.ticksAngle = 360; g.startAngle = (cfg.gauge?.scaleStart as number) || 180; g.majorTicks = 0 as unknown as string[]; g.exactTicks = true; g.strokeTicks = false; g.minorTicks = 0; g.numbersMargin = 0; g.fontNumbersSize = 0;
       g.borders = true; g.borderOuterWidth = 2; g.borderMiddleWidth = 1; g.borderInnerWidth = 0; g.borderShadowWidth = 0;
-      g.animationTarget = this.ANIMATION_TARGET_NEEDLE; g.useMinPath = false;
+
     } else { // measuring
-      g.minValue = scale.min; g.maxValue = scale.max;
-      g.units = cfg.paths?.['gaugePath']?.convertUnitTo; g.fontTitleSize = 24;
-      g.barProgress = true; g.barWidth = 15; g.valueBox = true; g.fontValueSize = 60; g.valueBoxWidth = 100; g.valueBoxBorderRadius = 0; g.valueBoxStroke = 0; g.colorValueBoxBackground = '';
-      g.exactTicks = false; g.majorTicks = scale.majorTicks as unknown as string[]; g.minorTicks = 2; g.ticksAngle = 270; g.startAngle = 45; g.barStartPosition = cfg.gauge?.barStartPosition || 'left'; g.strokeTicks = true; g.numbersMargin = 3; g.fontNumbersSize = 15;
-      g.needle = true; g.needleType = this.LINE; g.needleWidth = 2; g.needleShadow = false; g.needleStart = 0; g.needleEnd = 95; g.needleCircleSize = 10; g.needleCircleInner = false; g.needleCircleOuter = false;
+      g.fontTitleSize = 24;
+      g.barWidth = 15; g.valueBox = true; g.fontValueSize = 60; g.valueBoxWidth = 100; g.valueBoxBorderRadius = 0; g.valueBoxStroke = 0; g.colorValueBoxBackground = '';
+      g.needle = cfg.gauge.enableNeedle; g.needleType = this.LINE; g.needleWidth = 2; g.needleStart = 0; g.needleEnd = 95; g.needleCircleSize = 10; g.needleCircleInner = false; g.needleCircleOuter = false;
+      g.ticksAngle = 270; g.startAngle = 45; g.barStartPosition = cfg.gauge?.barStartPosition || 'left';
+      if (cfg.gauge.enableTicks) {
+        g.strokeTicks = true; g.majorTicks = scale.majorTicks as unknown as string[]; g.minorTicks = 2; g.exactTicks = false; g.numbersMargin = 3; g.fontNumbersSize = 15;
+        g.colorMajorTicks = theme.contrastDim; g.colorNumbers = theme.contrastDim;
+      } else {
+        g.strokeTicks = false; g.majorTicks = 0 as unknown as string[]; g.minorTicks = 0; g.exactTicks = true; g.numbersMargin = 0; g.fontNumbersSize = 0;
+        g.colorMajorTicks = g.colorPlate; g.colorNumbers = g.colorMinorTicks = '' as unknown as string;
+      }
+
       g.borders = true; g.borderOuterWidth = 2; g.borderMiddleWidth = 1; g.borderInnerWidth = 0; g.borderShadowWidth = 0; g.animationTarget = this.ANIMATION_TARGET_NEEDLE; g.useMinPath = false;
     }
   }

--- a/src/default-config/config.demo.const.ts
+++ b/src/default-config/config.demo.const.ts
@@ -301,7 +301,8 @@ export const DemoDashboardsConfig: Dashboard[] = [
                 "type": "ngRadial",
                 "subType": "measuring",
                 "enableTicks": true,
-                "compassUseNumbers": false,
+                "enableNeedle": true,
+                "enableProgressbar": true,
                 "highlightsWidth": 5,
                 "scaleStart": 180,
                 "barStartPosition": "left"


### PR DESCRIPTION
Add options to enable or disable the needle and progress bar for radial and linear gauges. This enhancement allows for more flexible usage of the gauges, such as for rudder angle and battery current variations.

Fixes #487