### PR TITLE
Enhance page header with SVG icon support and layout refactor

### DIFF
--- a/src/app/core/components/app-help/app-help.component.html
+++ b/src/app/core/components/app-help/app-help.component.html
@@ -1,5 +1,13 @@
 <div class="fullpage-header">
-  <h6 class="fullpage-header-title">{{ pageTitle }}</h6>
+  <div class="page-icon">
+    <mat-icon
+      svgIcon="help-center"
+      [style.width.px]="24"
+      [style.height.px]="24"
+      aria-hidden="false">
+    </mat-icon>
+    <h6 class="page-title">{{ pageTitle }}</h6>
+  </div>
   <button mat-flat-button [matMenuTriggerFor]="helpMenu" [disabled]="isLoading() || hasError() || helpFiles().length === 0">
     @if (isLoading()) { Loading... } @else { Table of Content }
   </button>

--- a/src/app/core/components/app-help/app-help.component.scss
+++ b/src/app/core/components/app-help/app-help.component.scss
@@ -4,10 +4,19 @@
   align-items: center;
 }
 
-.fullpage-header-title {
+.page-icon {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  justify-content: flex-start;
+  align-items: center;
+  margin-left: 15px;
+
+}
+.page-title {
   margin-block-start: 0px;
   margin-block-end: 0px;
-  padding: 18px 24px 13px 24px;
+  padding: 18px 0px 13px 5px;
   color: var(--mat-dialog-subhead-color, var(--mat-sys-on-surface, rgba(0, 0, 0, 0.87)));
   font-family: var(--mat-dialog-subhead-font, var(--mat-sys-headline-small-font, inherit));
   line-height: var(--mat-dialog-subhead-line-height, var(--mat-sys-headline-small-line-height, 1.5rem));

--- a/src/app/core/components/data-inspector/data-inspector.component.html
+++ b/src/app/core/components/data-inspector/data-inspector.component.html
@@ -1,4 +1,4 @@
-<page-header [pageTitle]="pageTitle" />
+<page-header [pageTitle]="pageTitle" svgIconId="troubleshoot" />
 <div class="data-inspector-container">
   <mat-form-field class="filter-field">
     <mat-label>Filter</mat-label>

--- a/src/app/core/components/options/tabs/tabs.component.html
+++ b/src/app/core/components/options/tabs/tabs.component.html
@@ -1,4 +1,4 @@
-<page-header [pageTitle]="pageTitle" />
+<page-header [pageTitle]="pageTitle" svgIconId="settings" />
 <mat-tab-group class="content-area">
   <mat-tab label="Connectivity">
       <settings-signalk class="tab-content" />

--- a/src/app/core/components/page-header/page-header.component.html
+++ b/src/app/core/components/page-header/page-header.component.html
@@ -1,11 +1,17 @@
-<div class="fullpage-header">
-  <h6 class="fullpage-header-title">{{pageTitle()}}</h6>
-  <div class="dialog-close-icon">
-    <button mat-icon-button (click)="backPage()">
-      <mat-icon>arrow_back_ios</mat-icon>
-    </button>
-    <button mat-icon-button (click)="closePage()">
-      <mat-icon>close</mat-icon>
-    </button>
-  </div>
+<div class="page-icon-container">
+  <mat-icon
+    [svgIcon]="svgIconId()"
+    [style.width.px]="24"
+    [style.height.px]="24"
+    aria-hidden="false">
+  </mat-icon>
+</div>
+<h6 class="page-title">{{pageTitle()}}</h6>
+<div class="dialog-close-icon">
+  <button mat-icon-button (click)="backPage()">
+    <mat-icon>arrow_back_ios</mat-icon>
+  </button>
+  <button mat-icon-button (click)="closePage()">
+    <mat-icon>close</mat-icon>
+  </button>
 </div>

--- a/src/app/core/components/page-header/page-header.component.scss
+++ b/src/app/core/components/page-header/page-header.component.scss
@@ -1,13 +1,22 @@
-.fullpage-header {
+:host {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  flex-direction: row;
+  flex-wrap: nowrap;
 }
 
-.fullpage-header-title {
+.page-icon-container {
+    width: 100px;
+    height: max-content;
+    padding-left: 15px;
+    padding-top: 6px
+}
+
+.page-title {
   margin-block-start: 0px;
   margin-block-end: 0px;
-  padding: 18px 24px 13px 24px;
+  padding: 18px 0px 13px 0px;
   color: var(--mat-dialog-subhead-color, var(--mat-sys-on-surface, rgba(0, 0, 0, 0.87)));
   font-family: var(--mat-dialog-subhead-font, var(--mat-sys-headline-small-font, inherit));
   line-height: var(--mat-dialog-subhead-line-height, var(--mat-sys-headline-small-line-height, 1.5rem));

--- a/src/app/core/components/page-header/page-header.component.ts
+++ b/src/app/core/components/page-header/page-header.component.ts
@@ -11,7 +11,8 @@ import { Router } from '@angular/router';
   styleUrl: './page-header.component.scss'
 })
 export class PageHeaderComponent {
-  protected readonly pageTitle = input<string>();
+  protected readonly pageTitle = input.required<string>();
+  protected readonly svgIconId = input.required<string>();
   private _router = inject(Router);
 
   protected backPage() {

--- a/src/app/core/components/remote-control/remote-control.component.html
+++ b/src/app/core/components/remote-control/remote-control.component.html
@@ -1,4 +1,4 @@
-<page-header [pageTitle]="pageTitle" />
+<page-header [pageTitle]="pageTitle" svgIconId="remote-control" />
 <mat-sidenav-container class="sidenav-remote-control-container">
   <mat-sidenav mode="side" opened>
     <mat-action-list>


### PR DESCRIPTION
Introduce SVG icon support in the page header component and refactor the layout for improved styling compatibility with Freeboard. This change enhances the visual presentation and usability of the header.