### PR TITLE
radial widget min width

### DIFF
--- a/src/app/widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component.scss
+++ b/src/app/widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component.scss
@@ -8,6 +8,7 @@
   display: block;
   position: relative;
   width: 100%;
+  min-width: 8px;
   height: 100%;
   overflow: clip;
   > canvas {


### PR DESCRIPTION
Fix Radial min width of 0px issue on small screen size to a minimum of 10px.