### PR TITLE
Bug: 4.0.7 Options ->  Configurations -> Truncated in large browser window.

### DIFF
--- a/src/app/core/components/options/configuration/config.component.scss
+++ b/src/app/core/components/options/configuration/config.component.scss
@@ -6,10 +6,9 @@
 
 .page-content {
   width: 100%;
-  height: calc(100% - 63px);
   overflow-y: auto;
   scroll-behavior: smooth;
-  padding: 0px 24px 10px 24px;
+  padding: 0px 0px 10px 0px;
 }
 
 .flex-item-copy {


### PR DESCRIPTION
Fix page content hight to take full hight and removed side margins offering more screen realestate and align with other tab layouts. Fixes #874