### PR TITLE
More straightforward widget creation

### DIFF
--- a/src/app/core/components/dashboard/dashboard.component.spec.ts
+++ b/src/app/core/components/dashboard/dashboard.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { Subject } from 'rxjs';
+import { Subject, of } from 'rxjs';
 import { signal } from '@angular/core';
 import { provideRouter } from '@angular/router';
 
@@ -29,6 +29,21 @@ describe('DashboardComponent', () => {
   let component: DashboardComponent;
   let privateApi: DashboardComponentPrivateApi;
   let mockDashboardService: jasmine.SpyObj<DashboardService>;
+  let gridMock: {
+    grid: {
+      save: jasmine.Spy;
+      offAll: jasmine.Spy;
+      destroy: jasmine.Spy;
+      addWidget: jasmine.Spy;
+      willItFit: jasmine.Spy;
+      isAreaEmpty: jasmine.Spy;
+      getGridItems: jasmine.Spy;
+      setStatic: jasmine.Spy;
+      on: jasmine.Spy;
+      removeWidget: jasmine.Spy;
+      getCellFromPixel: jasmine.Spy;
+    };
+  };
 
   beforeEach(async () => {
     mockDashboardService = jasmine.createSpyObj('DashboardService', [
@@ -52,6 +67,7 @@ describe('DashboardComponent', () => {
     const mockPluginConfigService = jasmine.createSpyObj('PluginConfigClientService', ['getPlugin', 'setPluginEnabled']);
     const mockDatasetLifecycleService = jasmine.createSpyObj('WidgetDatasetOrchestratorService', ['removeOwnedDatasets']);
     const mockDialogService = jasmine.createSpyObj('DialogService', ['openFrameDialog']);
+    mockDialogService.openFrameDialog.and.returnValue(of(null));
     const mockUiEventService = jasmine.createSpyObj('uiEventService', ['addHotkeyListener', 'removeHotkeyListener'], {
       isDragging: signal(false)
     });
@@ -74,11 +90,19 @@ describe('DashboardComponent', () => {
     privateApi = component as unknown as DashboardComponentPrivateApi;
     spyOn(component, 'ngOnDestroy').and.callFake(() => undefined);
 
-    const gridMock = {
+    gridMock = {
       grid: {
         save: jasmine.createSpy('save').and.returnValue([]),
         offAll: jasmine.createSpy('offAll'),
-        destroy: jasmine.createSpy('destroy')
+        destroy: jasmine.createSpy('destroy'),
+        addWidget: jasmine.createSpy('addWidget').and.returnValue({ gridstackNode: { subGrid: null, subGridOpts: {} } }),
+        willItFit: jasmine.createSpy('willItFit').and.returnValue(true),
+        isAreaEmpty: jasmine.createSpy('isAreaEmpty').and.returnValue(true),
+        getGridItems: jasmine.createSpy('getGridItems').and.returnValue([]),
+        setStatic: jasmine.createSpy('setStatic'),
+        on: jasmine.createSpy('on'),
+        removeWidget: jasmine.createSpy('removeWidget'),
+        getCellFromPixel: jasmine.createSpy('getCellFromPixel').and.returnValue({ x: 1, y: 1 })
       }
     };
 
@@ -118,5 +142,101 @@ describe('DashboardComponent', () => {
     privateApi.nextDashboard();
 
     expect(mockDashboardService.navigateToNextDashboard).not.toHaveBeenCalled();
+  });
+
+  it('should mark newly added host widget to auto-open options on create', () => {
+    const widget = {
+      name: 'Numeric',
+      selector: 'widget-numeric',
+      minWidth: 1,
+      minHeight: 2,
+      defaultWidth: 4,
+      defaultHeight: 6
+    };
+
+    (component as unknown as { addWidgetToGrid: (w: unknown, x: number, y: number) => void }).addWidgetToGrid(widget, 1, 1);
+
+    const addedWidget = gridMock.grid.addWidget.calls.mostRecent().args[0];
+    expect(addedWidget.input.widgetProperties.autoOpenOptionsOnCreate).toBeTrue();
+  });
+
+  it('should mark newly added group widget to auto-open options on create', () => {
+    const widget = {
+      name: 'Group Widget',
+      selector: 'group-widget',
+      minWidth: 1,
+      minHeight: 2,
+      defaultWidth: 3,
+      defaultHeight: 4
+    };
+
+    (component as unknown as { addWidgetToGrid: (w: unknown, x: number, y: number) => void }).addWidgetToGrid(widget, 1, 1);
+
+    const addedWidget = gridMock.grid.addWidget.calls.mostRecent().args[0];
+    expect(addedWidget.input.widgetProperties.autoOpenOptionsOnCreate).toBeTrue();
+  });
+
+  it('should not mark duplicated widget for auto-open options', () => {
+    const sourceConfig = { displayName: 'Source' };
+    const item = {
+      gridstackNode: {
+        w: 2,
+        h: 2,
+        selector: 'widget-host2',
+        input: {
+          widgetProperties: {
+            type: 'widget-numeric',
+            config: sourceConfig
+          }
+        }
+      }
+    };
+
+    (component as unknown as { duplicateWidget: (node: unknown) => void }).duplicateWidget(item);
+
+    const duplicatedWidget = gridMock.grid.addWidget.calls.mostRecent().args[0];
+    expect(duplicatedWidget.input.widgetProperties.autoOpenOptionsOnCreate).toBeUndefined();
+  });
+
+  it('should not mark pasted widget for auto-open options', () => {
+    mockDashboardService.isDashboardStatic.set(false);
+    mockDashboardService.widgetClipboard.set({
+      w: 2,
+      h: 3,
+      selector: 'widget-host2',
+      input: {
+        widgetProperties: {
+          type: 'widget-numeric',
+          config: { displayName: 'Clipboard' }
+        }
+      }
+    });
+
+    (component as unknown as { pasteCopiedWidget: (x?: number, y?: number) => void }).pasteCopiedWidget(1, 1);
+
+    const pastedWidget = gridMock.grid.addWidget.calls.mostRecent().args[0];
+    expect(pastedWidget.input.widgetProperties.autoOpenOptionsOnCreate).toBeUndefined();
+  });
+
+  it('should not add a widget when add-widget dialog is canceled', () => {
+    spyOn(component as unknown as { addWidgetToGrid: () => void }, 'addWidgetToGrid');
+
+    (component as unknown as { openAddWidgetDialog: (x: number, y: number) => void }).openAddWidgetDialog(1, 1);
+
+    expect((component as unknown as { addWidgetToGrid: jasmine.Spy }).addWidgetToGrid).not.toHaveBeenCalled();
+  });
+
+  it('should copy widget without creating a new grid item', () => {
+    const actionStream = mockDashboardService.widgetAction$ as Subject<{ id: string; operation: string }>;
+    const existingNode = { id: 'widget-copy-id' };
+    gridMock.grid.getGridItems.and.returnValue([
+      { gridstackNode: existingNode }
+    ]);
+
+    component.ngAfterViewInit();
+    actionStream.next({ id: 'widget-copy-id', operation: 'copy' });
+
+    expect(mockDashboardService.setWidgetClipboardFromNode).toHaveBeenCalledWith(existingNode);
+    expect(gridMock.grid.addWidget).not.toHaveBeenCalled();
   });
 });

--- a/src/app/core/components/dashboard/dashboard.component.ts
+++ b/src/app/core/components/dashboard/dashboard.component.ts
@@ -469,7 +469,8 @@ export class DashboardComponent implements AfterViewInit, OnDestroy {
             config: {
               displayName: "Group Widget",
               color: "contrast"
-            }
+            },
+            autoOpenOptionsOnCreate: true
           }
         },
         subGridOpts: {
@@ -490,6 +491,7 @@ export class DashboardComponent implements AfterViewInit, OnDestroy {
           widgetProperties: {
             type: widget.selector,
             uuid: ID,
+            autoOpenOptionsOnCreate: true,
           }
         }
       };

--- a/src/app/core/components/group-widget/group-widget.component.ts
+++ b/src/app/core/components/group-widget/group-widget.component.ts
@@ -40,8 +40,17 @@ export class GroupWidgetComponent extends BaseWidget implements OnInit {
   }
 
   ngOnInit(): void {
+    const shouldAutoOpenOptions = this.widgetProperties.autoOpenOptionsOnCreate === true;
+    if (shouldAutoOpenOptions) {
+      delete this.widgetProperties.autoOpenOptionsOnCreate;
+    }
+
     // Resolve default and user configuration
     this.runtime?.initialize?.(GroupWidgetComponent.DEFAULT_CONFIG, this.widgetProperties.config);
+
+    if (shouldAutoOpenOptions) {
+      queueMicrotask(() => this.openWidgetOptions(new Event('kip:auto-open-options')));
+    }
   }
 
   /**

--- a/src/app/core/components/widget-host2/widget-host2.component.spec.ts
+++ b/src/app/core/components/widget-host2/widget-host2.component.spec.ts
@@ -279,4 +279,38 @@ describe('WidgetHost2Component', () => {
 
 		expect(bottomSheetMock.open).not.toHaveBeenCalled();
 	});
+
+	it('auto-opens options once on init for brand-new widgets', async () => {
+		dashboard.isDashboardStatic.set(false);
+		testWidget.autoOpenOptionsOnCreate = true;
+
+		fixture.detectChanges();
+		await Promise.resolve();
+
+		expect(dialogServiceMock.openWidgetOptions).toHaveBeenCalledTimes(1);
+		expect(testWidget.autoOpenOptionsOnCreate).toBeUndefined();
+	});
+
+	it('does not auto-open options on init when create flag is absent (duplicate/paste flows)', async () => {
+		dashboard.isDashboardStatic.set(false);
+
+		fixture.detectChanges();
+		await Promise.resolve();
+
+		expect(dialogServiceMock.openWidgetOptions).not.toHaveBeenCalled();
+	});
+
+	it('keeps widget config unchanged when auto-open options dialog is canceled', async () => {
+		dashboard.isDashboardStatic.set(false);
+		testWidget.autoOpenOptionsOnCreate = true;
+		const configSnapshot = JSON.parse(JSON.stringify(testWidget.config));
+
+		dialogServiceMock.openWidgetOptions.and.returnValue({ afterClosed: () => of(null) });
+
+		fixture.detectChanges();
+		await Promise.resolve();
+
+		expect(dialogServiceMock.openWidgetOptions).toHaveBeenCalledTimes(1);
+		expect(testWidget.config).toEqual(configSnapshot);
+	});
 });

--- a/src/app/core/components/widget-host2/widget-host2.component.ts
+++ b/src/app/core/components/widget-host2/widget-host2.component.ts
@@ -116,6 +116,10 @@ export class WidgetHost2Component extends BaseWidget implements OnInit, OnDestro
   ngOnInit(): void {
     const type = this.widgetProperties.type;
     if (!type) return;
+    const shouldAutoOpenOptions = this.widgetProperties.autoOpenOptionsOnCreate === true;
+    if (shouldAutoOpenOptions) {
+      delete this.widgetProperties.autoOpenOptionsOnCreate;
+    }
     this.compType = this.widgetService.getComponentType(type) as Type<WidgetViewComponentBase> | undefined;
 
     // Resolve default configuration for this component type using helper
@@ -140,6 +144,10 @@ export class WidgetHost2Component extends BaseWidget implements OnInit, OnDestro
       });
     }
     this._hasInitialized = true;
+
+    if (shouldAutoOpenOptions) {
+      queueMicrotask(() => this.openWidgetOptions(new Event('kip:auto-open-options')));
+    }
   }
 
   ngOnDestroy(): void {

--- a/src/app/core/interfaces/widgets-interface.ts
+++ b/src/app/core/interfaces/widgets-interface.ts
@@ -45,6 +45,8 @@ export interface IWidget {
   type: string;
    /** The Widget's configuration Object */
   config: IWidgetSvcConfig;
+  /** Transient flag to auto-open options once when a widget is first created. */
+  autoOpenOptionsOnCreate?: boolean;
 }
 
 /**


### PR DESCRIPTION
Enhance the widget creation process by automatically opening the configuration dialog after adding a new widget. Adjust the widget properties and update tests to verify the new behavior, improving user guidance during widget setup.

Suggestion in feature #1002