### PR TITLE
Feature: ability to save/close the widget editor when path is absent

### DIFF
--- a/src/app/core/components/options/display/display.component.html
+++ b/src/app/core/components/options/display/display.component.html
@@ -165,6 +165,29 @@
         }
       </mat-expansion-panel>
     </mat-accordion>
+    <br />
+    <mat-accordion>
+      <mat-expansion-panel>
+        <mat-expansion-panel-header>
+          <mat-panel-title>
+            Advanced and Testing
+          </mat-panel-title>
+          @if (!isPhonePortrait().matches) {
+          <mat-panel-description>
+            Specialized options for development, troubleshooting, and test scenarios. Most users should leave these settings
+            off.
+          </mat-panel-description>
+          }
+        </mat-expansion-panel-header>
+        <mat-slide-toggle class="full-width" [(ngModel)]="isPathValidationDisabled" name="isPathValidationDisabled"
+          aria-describedby="path-validation-helper">
+          Allow saving widgets with invalid paths (testing only)
+        </mat-slide-toggle>
+        <p id="path-validation-helper" class="dev-option-helper mat-body-small" role="note">
+          Use only for development and troubleshooting. This temporary setting is reset when the app restarts.
+        </p>
+      </mat-expansion-panel>
+    </mat-accordion>
   <div class="formActionFooter">
     <mat-divider class="formActionDivider"></mat-divider>
     <button mat-flat-button type="submit" class="formActionButton" [disabled]="!displayForm.form.dirty || displayForm.form.invalid">Save</button>

--- a/src/app/core/components/options/display/display.component.scss
+++ b/src/app/core/components/options/display/display.component.scss
@@ -35,3 +35,10 @@
   }
 
 }
+
+.dev-option-helper {
+  margin: 4px 0 0 55px;
+  font: var(--mat-sys-body-small);
+  letter-spacing: var(--mat-sys-body-small-tracking);
+  color: var(--mat-sys-on-surface-variant);
+}

--- a/src/app/core/components/options/display/display.component.ts
+++ b/src/app/core/components/options/display/display.component.ts
@@ -63,11 +63,12 @@ export class SettingsDisplayComponent implements OnInit {
   protected providerMode = model<'kip' | 'other'>('other');
   protected widgetHistoryDisabled = model<boolean>(false);
   protected isKipHistoryProviderSelectable = signal<boolean>(false);
+  protected isPathValidationDisabled = model<boolean>(this.settings.getDisablePathValidation());
   // Guards concurrent plugin enable checks to avoid stale promise handlers mutating state
   private _pluginCheckSeq = 0;
 
   constructor() {
-    this.isPhonePortrait = toSignal(this.responsive.observe(Breakpoints.HandsetPortrait));
+    this.isPhonePortrait = toSignal(this.responsive.observe(Breakpoints.HandsetPortrait), { initialValue: { matches: false, breakpoints: {} } });
   }
 
   ngOnInit() {
@@ -126,10 +127,11 @@ export class SettingsDisplayComponent implements OnInit {
     this.settings.setSplitShellSide(this.splitShellSide());
     this.settings.setSplitShellSwipeDisabled(this.splitShellSwipeDisabled());
     this.settings.setWidgetHistoryDisabled(this.widgetHistoryDisabled());
+    this.settings.setDisablePathValidation(this.isPathValidationDisabled());
     if (!this.setKipPluginConfig()) {
       this.toast.show('Failed to save KIP plugin configuration on server.', 0, false, 'error');
     }
-    this.displayForm().form.markAsPristine();
+    this.displayForm()?.form.markAsPristine();
     this.toast.show("Configuration saved", 1000, true, 'message');
   }
 
@@ -178,7 +180,7 @@ export class SettingsDisplayComponent implements OnInit {
   }
 
   protected isAutoNightModeSupported(e: MatSlideToggleChange): void {
-    this.displayForm().form.markAsDirty();
+    this.displayForm()?.form.markAsDirty();
     this.autoNightMode.set(e.checked);
   }
 
@@ -331,7 +333,7 @@ export class SettingsDisplayComponent implements OnInit {
   }
 
   protected setBrightness(value: number): void {
-    this.displayForm().form.markAsDirty();
+    this.displayForm()?.form.markAsDirty();
     this.nightBrightness.set(value);
     this.app.setBrightness(value, this.app.isNightMode());
   }

--- a/src/app/core/interfaces/app-settings.interfaces.ts
+++ b/src/app/core/interfaces/app-settings.interfaces.ts
@@ -15,8 +15,8 @@ export interface IConnectionConfig {
   sharedConfigName: string;
 }
 export interface IConfig {
-  app: IAppConfig;
-  theme: IThemeConfig;
+  app: IAppConfig | null;
+  theme: IThemeConfig | null;
   dashboards: Dashboard[];
 }
 

--- a/src/app/core/services/dialog.service.ts
+++ b/src/app/core/services/dialog.service.ts
@@ -95,7 +95,7 @@ export class DialogService {
         data: data.config,
         minWidth: "50vw",
         maxWidth: "90vw",
-        closeOnNavigation: true
+        closeOnNavigation: true,
       }
     );
   }

--- a/src/app/core/services/settings.service.ts
+++ b/src/app/core/services/settings.service.ts
@@ -47,19 +47,21 @@ export class SettingsService {
   public proxyEnabled = false;
   public signalKSubscribeAll = false;
   private useDeviceToken = false;
-  private loginName: string;
-  private loginPassword: string;
-  public useSharedConfig: boolean;
-  private sharedConfigName: string;
-  private activeConfig: IConfig = {app: null, theme: null, dashboards: null};
+  private loginName = '';
+  private loginPassword = '';
+  public useSharedConfig = true;
+  private sharedConfigName = 'default';
+  private activeConfig: IConfig = { app: null, theme: null, dashboards: [] };
 
-  private kipUUID: string;
-  public signalkUrl: ISignalKUrl;
-  private widgets: IWidget[];
+  private kipUUID = '';
+  public signalkUrl: ISignalKUrl | undefined;
+  private widgets: IWidget[] = [];
   private _dashboards: Dashboard[] = [];
   private dataSets: IDatasetServiceDatasetConfig[] = [];
   public configUpgrade = signal<boolean>(false);
-  private configVersion = undefined; // store actual config version from config version property in config
+  private configVersion: number | undefined; // store actual config version from config version property in config
+  private disablePathValidation = false; // used to disable path validation in path control component in widget options.
+
   constructor() {
     console.log("[AppSettings Service] Service startup...");
     this.storage.activeConfigFileVersion = configFileVersion;
@@ -87,7 +89,7 @@ export class SettingsService {
       this.pushSettings();
     } else {
       console.log("[AppSettings Service] LocalStorage enabled");
-      const localStorageConfig: IConfig = { app: null, theme: null, dashboards: null };
+      const localStorageConfig: IConfig = { app: null, theme: null, dashboards: [] };
       localStorageConfig.app = this.loadConfigFromLocalStorage("appConfig");
       this.configVersion = localStorageConfig.app?.configVersion;
       this.checkConfigUpgradeRequired(true, localStorageConfig.app?.configVersion);
@@ -143,7 +145,7 @@ export class SettingsService {
    * @memberof SettingsService
    */
   public loadConfigFromLocalStorage(type: string) {
-    let config = JSON.parse(localStorage.getItem(type));
+    let config = JSON.parse(localStorage.getItem(type) ?? '');
 
     if (config === null) {
       console.log(`[AppSettings Service] Error loading ${type} config. Force loading ${type} defaults`);
@@ -186,7 +188,9 @@ export class SettingsService {
   }
 
   private pushSettings(): void {
-    this.themeName.next(this.activeConfig.theme.themeName);
+    if (this.activeConfig.theme) {
+      this.themeName.next(this.activeConfig.theme.themeName);
+    }
     this.dataSets = this.activeConfig.app.dataSets;
     this.unitDefaults.next(this.activeConfig.app.unitDefaults);
     this.kipKNotificationConfig.next(this.activeConfig.app.notificationConfig);
@@ -299,7 +303,9 @@ export class SettingsService {
     this.useSharedConfig = value.useSharedConfig;
     this.proxyEnabled = value.proxyEnabled;
     this.signalKSubscribeAll = value.signalKSubscribeAll;
-    this.signalkUrl.url = value.signalKUrl;
+    if (this.signalkUrl) {
+      this.signalkUrl.url = value.signalKUrl;
+    }
     if (!value.useSharedConfig) {
       this.useDeviceToken = true;
     } else this.useDeviceToken = false;
@@ -422,6 +428,14 @@ export class SettingsService {
     } else {
       this.saveAppConfigToLocalStorage();
     }
+  }
+
+  public getDisablePathValidation(): boolean {
+    return this.disablePathValidation;
+  }
+
+  public setDisablePathValidation(disable: boolean) {
+    this.disablePathValidation = disable;
   }
 
   // --- split Shell Settings API ---
@@ -575,7 +589,7 @@ export class SettingsService {
   //Config manipulation: RAW and SignalK server - used by Settings Config Component
   public resetSettings() {
 
-    const newDefaultConfig: IConfig = {app: null, theme: null, dashboards: null};
+    const newDefaultConfig: IConfig = { app: null, theme: null, dashboards: [] };
     newDefaultConfig.app = this.getDefaultAppConfig();
     newDefaultConfig.theme = this.getDefaultThemeConfig();
     newDefaultConfig.dashboards = this.getDefaultDashboardsConfig();
@@ -654,7 +668,7 @@ export class SettingsService {
   private buildAppStorageObject() {
 
     const storageObject: IAppConfig = {
-      configVersion: this.configVersion,
+      configVersion: this.configVersion ?? latestConfigVersion,
       autoNightMode: this.autoNightMode.getValue(),
       redNightMode: this.redNightMode.getValue(),
       nightModeBrightness: this.nightModeBrightness.getValue(),
@@ -674,9 +688,9 @@ export class SettingsService {
 
   private buildConnectionStorageObject() {
     const storageObject: IConnectionConfig = {
-      configVersion: this.configVersion,
+      configVersion: this.configVersion ?? latestConfigVersion,
       kipUUID: this.kipUUID,
-      signalKUrl: this.signalkUrl.url,
+      signalKUrl: this.signalkUrl?.url ?? '',
       proxyEnabled: this.proxyEnabled,
       signalKSubscribeAll: this.signalKSubscribeAll,
       useDeviceToken: this.useDeviceToken,
@@ -739,7 +753,7 @@ export class SettingsService {
   }
 
   private getDefaultDashboardsConfig(): Dashboard[] {
-    const config = [];
+    const config: Dashboard[] = [];
     localStorage.setItem("dashboardsConfig", JSON.stringify(config));
     return config;
   }

--- a/src/app/widget-config/path-control-config/path-control-config.component.html
+++ b/src/app/widget-config/path-control-config/path-control-config.component.html
@@ -42,7 +42,8 @@
             <mat-hint>Leave blank to disable this path.</mat-hint>
           }
           @if (pathFormGroup().value.path) {
-            <button mat-icon-button matIconSuffix aria-label="Clear" (click)="pathFormGroup().controls['path'].setValue('')">
+            <button mat-icon-button type="button" matIconSuffix aria-label="Clear"
+              (click)="pathFormGroup().controls['path'].setValue('')">
               <mat-icon>close</mat-icon>
             </button>
           }

--- a/src/app/widget-config/path-control-config/path-control-config.component.scss
+++ b/src/app/widget-config/path-control-config/path-control-config.component.scss
@@ -31,8 +31,6 @@
   align-items: center;
   align-content: flex-start;
   gap: 10px;
-  // padding-left: 15px;
-  // width: 100%;
 }
 
 .fields {

--- a/src/app/widget-config/path-control-config/path-control-config.component.ts
+++ b/src/app/widget-config/path-control-config/path-control-config.component.ts
@@ -17,6 +17,7 @@ import { compare } from 'compare-versions';
 import { SignalKConnectionService } from '../../core/services/signalk-connection.service';
 import { IDynamicControl } from '../../core/interfaces/widgets-interface';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { SettingsService } from '../../core/services/settings.service';
 
 function pathRequiredOrValidMatch(getPaths: () => IPathMetaData[]): ValidatorFn {
   return (control: AbstractControl): ValidationErrors | null => {
@@ -52,6 +53,7 @@ function pathRequiredOrValidMatch(getPaths: () => IPathMetaData[]): ValidatorFn 
 export class PathControlConfigComponent implements OnInit, OnChanges {
   private readonly _data = inject(DataService);
   private readonly _units = inject(UnitsService);
+  private readonly _settings = inject(SettingsService);
   private readonly _connection = inject(SignalKConnectionService);
   private readonly _destroyRef = inject(DestroyRef);
 
@@ -59,17 +61,17 @@ export class PathControlConfigComponent implements OnInit, OnChanges {
   readonly multiCTRLArray = input.required<IDynamicControl[]>();
   readonly filterSelfPaths = input.required<boolean>();
 
-  public availablePaths: IPathMetaData[];
+  public availablePaths: IPathMetaData[] = [];
   public filteredPaths = new BehaviorSubject<IPathMetaData[] | null>(null);
 
   // Sources control
-  public availableSources: string[];
+  public availableSources: string[] = [];
 
   // Units control
   public unitList: IConversionPathList = {base: '', conversions: []};
   public showPathSkUnitsFilter = false;
   public pathSkUnitsFilterControl = new FormControl<ISkBaseUnit | null>(null);
-  public pathSkUnitsFiltersList: ISkBaseUnit[];
+  public pathSkUnitsFiltersList: ISkBaseUnit[] = [];
   public readonly unitlessUnit: ISkBaseUnit = {unit: 'unitless', properties: {display: '(null)', quantity: 'Unitless', quantityDisplay: '(null)', description: '', }};
 
   ngOnInit() {
@@ -84,17 +86,20 @@ export class PathControlConfigComponent implements OnInit, OnChanges {
     this.pathSkUnitsFiltersList.unshift(this.unitlessUnit);
 
     if (pathFormGroup.value.pathSkUnitsFilter) {
-      this.pathSkUnitsFilterControl.setValue(this.pathSkUnitsFiltersList.find(item => item.unit === this.pathFormGroup().value.pathSkUnitsFilter), {onlySelf: true});
+      this.pathSkUnitsFilterControl.setValue(this.pathSkUnitsFiltersList.find(item => item.unit === this.pathFormGroup().value.pathSkUnitsFilter) ?? null, { onlySelf: true });
     }
 
     if (pathFormGroup.value.showPathSkUnitsFilter) {
       this.showPathSkUnitsFilter = pathFormGroup.value.showPathSkUnitsFilter;
     }
 
-    // add path validator fn and validate
-    pathFormGroup.controls['path'].setValidators([
-      pathRequiredOrValidMatch(() => this.getPaths())
-    ]);
+    // if not disabled, add path validator fn and validate
+    if (!this._settings.getDisablePathValidation()) {
+      pathFormGroup.controls['path'].setValidators([
+        pathRequiredOrValidMatch(() => this.getPaths())
+      ]);
+    }
+
     pathFormGroup.controls['path'].updateValueAndValidity({onlySelf: true, emitEvent: false});
     // Subscribe to pathRequired changes to re-validate path
     if (pathFormGroup.controls['pathRequired']) {
@@ -111,7 +116,7 @@ export class PathControlConfigComponent implements OnInit, OnChanges {
     // If SampleTime control is not present because the path property is missing, add it.
     if (!pathFormGroup.controls['sampleTime']) {
       pathFormGroup.addControl('sampleTime', new UntypedFormControl('500', Validators.required));
-      pathFormGroup.controls['sampleTime'].updateValueAndValidity({onlySelf: true, emitEvent: false});
+      (pathFormGroup.controls['sampleTime'] as AbstractControl).updateValueAndValidity({ onlySelf: true, emitEvent: false });
     }
 
     // subscribe to path formControl changes
@@ -187,7 +192,7 @@ export class PathControlConfigComponent implements OnInit, OnChanges {
       filteredPaths = filteredPaths.filter(item => {
         const hasUnits = !!item.meta && !!item.meta.units;
         const isUnitless = selectedUnit === 'unitless';
-        const matchesUnit = hasUnits && item.meta.units === selectedUnit;
+        const matchesUnit = hasUnits && item.meta?.units === selectedUnit;
         const isActuallyUnitless = !hasUnits && isUnitless;
         return matchesUnit || isActuallyUnitless;
       });
@@ -247,20 +252,21 @@ export class PathControlConfigComponent implements OnInit, OnChanges {
 
   private updatePathMetaBoundDisplayName(path: string) {
     const pathFormGroup = this.pathFormGroup();
-    if (!Object.prototype.hasOwnProperty.call(pathFormGroup.parent.parent.value, 'displayName')) {return;}
+    if (!pathFormGroup.parent?.parent?.value || !Object.prototype.hasOwnProperty.call(pathFormGroup.parent.parent.value, 'displayName')) { return; }
     const meta = this._data.getPathMeta(path);
-    if (meta?.displayName) {
-      pathFormGroup.parent.parent.controls['displayName'].setValue(meta.displayName);
+    if (meta?.displayName && 'displayName' in pathFormGroup.parent.parent.controls) {
+      (pathFormGroup.parent.parent.get('displayName') as AbstractControl | null)?.setValue(meta.displayName);
     }
   }
 
   private updatePathMetaBoundDisplayScale(path: string) {
     const pathFormGroup = this.pathFormGroup();
-    if (!Object.prototype.hasOwnProperty.call(pathFormGroup.parent.parent.value, 'displayScale')) {return;}
+    if (!pathFormGroup.parent?.parent?.value || !Object.prototype.hasOwnProperty.call(pathFormGroup.parent.parent.value, 'displayScale')) { return; }
 
     const meta = this._data.getPathMeta(path);
     if (meta?.displayScale) {
-      const displayScale = pathFormGroup.parent.parent.get('displayScale') as FormGroup;
+      const displayScale = pathFormGroup.parent.parent.get('displayScale') as FormGroup | null;
+      if (!displayScale) { return; }
       const unit = pathFormGroup.controls['convertUnitTo'].value;
 
       if (meta.displayScale.lower !== null && meta.displayScale.lower !== undefined) {


### PR DESCRIPTION
Remove the restriction preventing saving changes to the widget editor when required paths are absent. Introduce a warning instead of blocking the save action. Add a toggle option in the settings to allow saving widgets with invalid paths for testing purposes. Update relevant components and services to accommodate these changes.

Fixes #944