### PR TITLE
Place autopilot SVG menu above widget overlay

### DIFF
--- a/src/app/widgets/widget-autopilot/widget-autopilot.component.scss
+++ b/src/app/widgets/widget-autopilot/widget-autopilot.component.scss
@@ -241,7 +241,7 @@
   position: absolute;
   top: 0; left: 0; right: 0; bottom: 0;
   background: rgba(0,0,0,0.8);
-  z-index: 19;
+  z-index: 30;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -258,7 +258,7 @@
   background: transparent;
   border-radius: 12px;
   box-shadow: 0 4px 24px rgba(0,0,0,0.15);
-  z-index: 20;
+  z-index: 31;
   display: block;
   font-family: Roboto;
   font-size: 1.1rem;


### PR DESCRIPTION
## Summary

Make the autopilot SVG mode menu clickable by placing it above the widget overlay.

## Why this is needed

When the autopilot widget opens its SVG menu, the menu can be visible but its items are not clickable. The widget-level overlay currently has a higher `z-index` than the SVG menu layers, so it sits above the menu in the pointer/click stack and intercepts interaction.

Current layering:

- `.widgetOverlay`: `z-index: 21`
- `.svg-menu-overlay`: `z-index: 19`
- `.svg-menu`: `z-index: 20`

This means the overlay wins over the menu even though the menu is shown.

## Change

- Raises `.svg-menu-overlay` to `z-index: 30`
- Raises `.svg-menu` to `z-index: 31`

The change is intentionally CSS-only and keeps the existing menu behavior otherwise unchanged.

## Validation

- `git diff --check master..codex-autopilot-menu-overlay-zindex`
