### PR TITLE
[codex] Fix autopilot standby button label

### DIFF
--- a/src/app/widgets/widget-autopilot/widget-autopilot.component.html
+++ b/src/app/widgets/widget-autopilot/widget-autopilot.component.html
@@ -15,7 +15,7 @@
         <svg width="100%" height="100%" viewBox="0 0 100 14" preserveAspectRatio="xMidYMid meet" class="svg-element svg-modes">
           <text xml:space="preserve"
             x="50.090435"
-            y="10.743966">Disengage</text>
+            y="10.743966">{{ standbyButtonLabel() }}</text>
         </svg>
       </mat-icon>
     </button>

--- a/src/app/widgets/widget-autopilot/widget-autopilot.component.spec.ts
+++ b/src/app/widgets/widget-autopilot/widget-autopilot.component.spec.ts
@@ -1,0 +1,102 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClient } from '@angular/common/http';
+import { EMPTY, of } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { WidgetAutopilotComponent } from './widget-autopilot.component';
+import { WidgetRuntimeDirective } from '../../core/directives/widget-runtime.directive';
+import { WidgetStreamsDirective } from '../../core/directives/widget-streams.directive';
+import { SignalkRequestsService } from '../../core/services/signalk-requests.service';
+import { DashboardService } from '../../core/services/dashboard.service';
+import { UnitsService } from '../../core/services/units.service';
+import { DataService } from '../../core/services/data.service';
+
+describe('WidgetAutopilotComponent', () => {
+  let component: WidgetAutopilotComponent;
+
+  const runtimeOptions = {
+    autopilot: {
+      apiVersion: 'v2' as 'v1' | 'v2',
+      instanceId: 'test-autopilot',
+      pluginId: 'autopilot',
+      modes: ['auto', 'wind', 'route'],
+      invertRudder: true,
+      headingDirectionTrue: false,
+      courseDirectionTrue: false
+    }
+  };
+
+  const runtimeMock = {
+    options: () => runtimeOptions
+  };
+
+  const streamsMock = {
+    observe: vi.fn()
+  };
+
+  const requestsMock = {
+    subscribeRequest: () => EMPTY,
+    putRequest: vi.fn()
+  };
+
+  const httpMock = {
+    post: vi.fn(() => of({ statusCode: 200 })),
+    put: vi.fn(() => of({ statusCode: 200 })),
+    delete: vi.fn(() => of({ statusCode: 200 }))
+  };
+
+  const dashboardMock = {
+    isDashboardStatic: () => true
+  };
+
+  const unitsMock = {
+    convertToUnit: (_unit: string, value: unknown) => value
+  };
+
+  const dataMock = {
+    subscribePath: vi.fn(() => EMPTY)
+  };
+
+  beforeEach(async () => {
+    runtimeOptions.autopilot.apiVersion = 'v2';
+    streamsMock.observe.mockClear();
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: WidgetRuntimeDirective, useValue: runtimeMock },
+        { provide: WidgetStreamsDirective, useValue: streamsMock },
+        { provide: SignalkRequestsService, useValue: requestsMock },
+        { provide: HttpClient, useValue: httpMock },
+        { provide: DashboardService, useValue: dashboardMock },
+        { provide: UnitsService, useValue: unitsMock },
+        { provide: DataService, useValue: dataMock }
+      ]
+    });
+
+    component = TestBed.runInInjectionContext(() => new WidgetAutopilotComponent());
+  });
+
+  it('labels the v2 standby toggle as Engage when autopilot is not engaged', () => {
+    (component as unknown as { apEngaged: { set: (value: boolean) => void } }).apEngaged.set(false);
+
+    const label = (component as unknown as { standbyButtonLabel: () => string }).standbyButtonLabel();
+
+    expect(label).toBe('Engage');
+  });
+
+  it('labels the v2 standby toggle as Disengage when autopilot is engaged', () => {
+    (component as unknown as { apEngaged: { set: (value: boolean) => void } }).apEngaged.set(true);
+
+    const label = (component as unknown as { standbyButtonLabel: () => string }).standbyButtonLabel();
+
+    expect(label).toBe('Disengage');
+  });
+
+  it('keeps the v1 standby command label as Disengage', () => {
+    runtimeOptions.autopilot.apiVersion = 'v1';
+    (component as unknown as { apEngaged: { set: (value: boolean) => void } }).apEngaged.set(false);
+
+    const label = (component as unknown as { standbyButtonLabel: () => string }).standbyButtonLabel();
+
+    expect(label).toBe('Disengage');
+  });
+});

--- a/src/app/widgets/widget-autopilot/widget-autopilot.component.ts
+++ b/src/app/widgets/widget-autopilot/widget-autopilot.component.ts
@@ -311,6 +311,15 @@ export class WidgetAutopilotComponent implements OnInit, OnDestroy {
 
   // Keypad buttons & layout
   protected apGrid = computed(() => this.apMode() ? 'grid' : 'none');
+  protected readonly standbyButtonLabel = computed(() => {
+    const apiVersion = this.runtime.options().autopilot.apiVersion;
+
+    if (apiVersion === "v2" && this.apEngaged() === false) {
+      return "Engage";
+    }
+
+    return "Disengage";
+  });
   protected readonly apEngageBtnDisabled = computed(() => {
     const state = this.apState();
     // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
## Summary

Fixes the Autopilot widget standby toggle label for Signal K Autopilot API v2.

The v2 standby button already toggles the REST endpoint based on the current engaged state:

- not engaged: POST `/engage`
- engaged: POST `/disengage`

However, the SVG label was hard-coded to `Disengage`, so the button could show a green disengaged state while the actual action was `Engage`.

## Change

- Adds a computed `standbyButtonLabel`.
- Shows `Engage` for API v2 when `apEngaged()` is explicitly `false`.
- Keeps `Disengage` for API v2 when engaged, and for API v1.

## API v1 impact

This intentionally preserves the existing API v1 behavior. In v1, the button sends the `standby` command and is disabled when the state is already `standby` or `off-line`; it is not an engage/disengage toggle based on `apEngaged`.

## Validation

- `npx ng test --watch=false --include=src/app/widgets/widget-autopilot/widget-autopilot.component.spec.ts`
- `npm run lint`
