### PR TITLE
Add MCP dashboard-schema generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "test:plugin": "npm run build:plugin && node --test --test-concurrency=1 kip-plugin/tests/index.test.cjs",
     "test:interactive": "ng test",
     "test:headless": "CI=1 ng test --watch=false",
+    "test:mcp-schema": "vitest run --config tools/gen-mcp-schema/vitest.config.ts",
     "lint": "ng lint",
     "dev": "ng serve --configuration=dev --serve-path=/@mxtommy/kip/",
     "build:plugin": "tsc -p ./kip-plugin/tsconfig.plugin.json",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "test:interactive": "ng test",
     "test:headless": "CI=1 ng test --watch=false",
     "test:mcp-schema": "vitest run --config tools/gen-mcp-schema/vitest.config.ts",
+    "gen:mcp-schema": "UPDATE_SCHEMA=1 npm run test:mcp-schema",
     "lint": "ng lint",
     "dev": "ng serve --configuration=dev --serve-path=/@mxtommy/kip/",
     "build:plugin": "tsc -p ./kip-plugin/tsconfig.plugin.json",

--- a/src/assets/kip-dashboard-schema.json
+++ b/src/assets/kip-dashboard-schema.json
@@ -1,0 +1,2955 @@
+{
+  "designSystem": {
+    "colors": [
+      {
+        "label": "Contrast",
+        "value": "contrast"
+      },
+      {
+        "label": "Blue",
+        "value": "blue"
+      },
+      {
+        "label": "Green",
+        "value": "green"
+      },
+      {
+        "label": "Orange",
+        "value": "orange"
+      },
+      {
+        "label": "Yellow",
+        "value": "yellow"
+      },
+      {
+        "label": "Pink",
+        "value": "pink"
+      },
+      {
+        "label": "Purple",
+        "value": "purple"
+      },
+      {
+        "label": "Grey",
+        "value": "grey"
+      }
+    ],
+    "grid": {
+      "cellHeight": "auto",
+      "column": 24,
+      "float": true,
+      "margin": 4,
+      "row": 24
+    },
+    "icons": [
+      "dashboard-activity-chart",
+      "dashboard-anchor",
+      "dashboard-anchored-boat",
+      "dashboard-beach",
+      "dashboard-beating-port",
+      "dashboard-beating-starboard",
+      "dashboard-bedtime",
+      "dashboard-burger",
+      "dashboard-car-battery",
+      "dashboard-chart",
+      "dashboard-chart-Area",
+      "dashboard-compass2",
+      "dashboard-dashboard",
+      "dashboard-dashboard1",
+      "dashboard-dashboard2",
+      "dashboard-diesel-pump",
+      "dashboard-digital-meter",
+      "dashboard-digital-speed",
+      "dashboard-dining",
+      "dashboard-engine",
+      "dashboard-entertainement",
+      "dashboard-fishing",
+      "dashboard-green-energy",
+      "dashboard-hurricane",
+      "dashboard-map",
+      "dashboard-motor-boat",
+      "dashboard-night",
+      "dashboard-panel",
+      "dashboard-pin",
+      "dashboard-pin2",
+      "dashboard-propeller",
+      "dashboard-reaching-port",
+      "dashboard-reaching-starboard",
+      "dashboard-refrigerator",
+      "dashboard-road",
+      "dashboard-running-port",
+      "dashboard-running-starboard",
+      "dashboard-sailing",
+      "dashboard-saturn",
+      "dashboard-snorkle",
+      "dashboard-snow",
+      "dashboard-solar-console",
+      "dashboard-Solar-Panel",
+      "dashboard-sos",
+      "dashboard-speedometer",
+      "dashboard-steering-wheel",
+      "dashboard-switchboard",
+      "dashboard-tide-current",
+      "dashboard-weather",
+      "dashboard-Wind-generator"
+    ],
+    "themeNames": [
+      "",
+      "light-theme",
+      "night-theme"
+    ],
+    "unitGroups": [
+      {
+        "group": "Unitless",
+        "measures": [
+          {
+            "description": "As-Is numeric value",
+            "measure": "unitless"
+          },
+          {
+            "description": "No unit label - As-Is numeric value",
+            "measure": " "
+          }
+        ]
+      },
+      {
+        "group": "Speed",
+        "measures": [
+          {
+            "description": "Knots - Nautical miles per hour",
+            "measure": "knots"
+          },
+          {
+            "description": "kph - Kilometers per hour",
+            "measure": "kph"
+          },
+          {
+            "description": "mph - Miles per hour",
+            "measure": "mph"
+          },
+          {
+            "description": "m/s - Meters per second (base)",
+            "measure": "m/s"
+          }
+        ]
+      },
+      {
+        "group": "Flow",
+        "measures": [
+          {
+            "description": "Cubic meters per second (base)",
+            "measure": "m3/s"
+          },
+          {
+            "description": "Liters per minute",
+            "measure": "l/min"
+          },
+          {
+            "description": "Liters per hour",
+            "measure": "l/h"
+          },
+          {
+            "description": "Gallons per minute",
+            "measure": "g/min"
+          },
+          {
+            "description": "Gallons per hour",
+            "measure": "g/h"
+          }
+        ]
+      },
+      {
+        "group": "Fuel Distance",
+        "measures": [
+          {
+            "description": "Meters per cubic meter (base)",
+            "measure": "m/m3"
+          },
+          {
+            "description": "Nautical Miles per liter",
+            "measure": "nm/l"
+          },
+          {
+            "description": "Nautical Miles per gallon",
+            "measure": "nm/g"
+          },
+          {
+            "description": "Kilometers per liter",
+            "measure": "km/l"
+          },
+          {
+            "description": "Miles per Gallon",
+            "measure": "mpg"
+          }
+        ]
+      },
+      {
+        "group": "Energy Distance",
+        "measures": [
+          {
+            "description": "Meters per Joule (base)",
+            "measure": "m/J"
+          },
+          {
+            "description": "Nautical Miles per Joule",
+            "measure": "nm/J"
+          },
+          {
+            "description": "Kilometers per Joule",
+            "measure": "km/J"
+          },
+          {
+            "description": "Nautical Miles per Kilowatt-hour",
+            "measure": "nm/kWh"
+          },
+          {
+            "description": "Kilometers per Kilowatt-hour",
+            "measure": "km/kWh"
+          }
+        ]
+      },
+      {
+        "group": "Temperature",
+        "measures": [
+          {
+            "description": "Kelvin (base)",
+            "measure": "K"
+          },
+          {
+            "description": "Celsius",
+            "measure": "celsius"
+          },
+          {
+            "description": "Fahrenheit",
+            "measure": "fahrenheit"
+          }
+        ]
+      },
+      {
+        "group": "Length",
+        "measures": [
+          {
+            "description": "Meters (base)",
+            "measure": "m"
+          },
+          {
+            "description": "Millimeters",
+            "measure": "mm"
+          },
+          {
+            "description": "Fathoms",
+            "measure": "fathom"
+          },
+          {
+            "description": "Nautical Miles",
+            "measure": "nm"
+          },
+          {
+            "description": "Kilometers",
+            "measure": "km"
+          },
+          {
+            "description": "Miles",
+            "measure": "mi"
+          },
+          {
+            "description": "Feet",
+            "measure": "feet"
+          },
+          {
+            "description": "Inches",
+            "measure": "inch"
+          }
+        ]
+      },
+      {
+        "group": "Volume",
+        "measures": [
+          {
+            "description": "Liters (base)",
+            "measure": "liter"
+          },
+          {
+            "description": "Cubic Meters",
+            "measure": "m3"
+          },
+          {
+            "description": "Gallons",
+            "measure": "gallon"
+          }
+        ]
+      },
+      {
+        "group": "Current",
+        "measures": [
+          {
+            "description": "Amperes (base)",
+            "measure": "A"
+          },
+          {
+            "description": "Milliamperes",
+            "measure": "mA"
+          }
+        ]
+      },
+      {
+        "group": "Potential",
+        "measures": [
+          {
+            "description": "Volts (base)",
+            "measure": "V"
+          },
+          {
+            "description": "Millivolts",
+            "measure": "mV"
+          }
+        ]
+      },
+      {
+        "group": "Charge",
+        "measures": [
+          {
+            "description": "Coulomb (base)",
+            "measure": "C"
+          },
+          {
+            "description": "Ampere*Hours",
+            "measure": "Ah"
+          }
+        ]
+      },
+      {
+        "group": "Power",
+        "measures": [
+          {
+            "description": "Watts (base)",
+            "measure": "W"
+          },
+          {
+            "description": "Milliwatts",
+            "measure": "mW"
+          }
+        ]
+      },
+      {
+        "group": "Energy",
+        "measures": [
+          {
+            "description": "Joules (base)",
+            "measure": "J"
+          },
+          {
+            "description": "Kilowatt*Hours",
+            "measure": "kWh"
+          }
+        ]
+      },
+      {
+        "group": "Resistance",
+        "measures": [
+          {
+            "description": "Ω (base)",
+            "measure": "ohm"
+          },
+          {
+            "description": "kΩ",
+            "measure": "kiloohm"
+          }
+        ]
+      },
+      {
+        "group": "Pressure",
+        "measures": [
+          {
+            "description": "Pa (base)",
+            "measure": "Pa"
+          },
+          {
+            "description": "kPa",
+            "measure": "kPa"
+          },
+          {
+            "description": "hPa",
+            "measure": "hPa"
+          },
+          {
+            "description": "mbar",
+            "measure": "mbar"
+          },
+          {
+            "description": "Bars",
+            "measure": "bar"
+          },
+          {
+            "description": "psi",
+            "measure": "psi"
+          },
+          {
+            "description": "mmHg",
+            "measure": "mmHg"
+          },
+          {
+            "description": "inHg",
+            "measure": "inHg"
+          }
+        ]
+      },
+      {
+        "group": "Density",
+        "measures": [
+          {
+            "description": "Air density - kg/cubic meter (base)",
+            "measure": "kg/m3"
+          }
+        ]
+      },
+      {
+        "group": "Time",
+        "measures": [
+          {
+            "description": "Seconds (base)",
+            "measure": "s"
+          },
+          {
+            "description": "Minutes",
+            "measure": "Minutes"
+          },
+          {
+            "description": "Hours",
+            "measure": "Hours"
+          },
+          {
+            "description": "Days",
+            "measure": "Days"
+          },
+          {
+            "description": "Day Hour:Minute:sec",
+            "measure": "D HH:MM:SS"
+          }
+        ]
+      },
+      {
+        "group": "Angular Velocity",
+        "measures": [
+          {
+            "description": "Radians per second (base)",
+            "measure": "rad/s"
+          },
+          {
+            "description": "Degrees per second",
+            "measure": "deg/s"
+          },
+          {
+            "description": "Degrees per minute",
+            "measure": "deg/min"
+          }
+        ]
+      },
+      {
+        "group": "Angle",
+        "measures": [
+          {
+            "description": "Radians (base)",
+            "measure": "rad"
+          },
+          {
+            "description": "Degrees",
+            "measure": "deg"
+          },
+          {
+            "description": "Gradians",
+            "measure": "grad"
+          }
+        ]
+      },
+      {
+        "group": "Frequency",
+        "measures": [
+          {
+            "description": "RPM - Rotations per minute",
+            "measure": "rpm"
+          },
+          {
+            "description": "Hz - Hertz (base)",
+            "measure": "Hz"
+          },
+          {
+            "description": "KHz - Kilohertz",
+            "measure": "KHz"
+          },
+          {
+            "description": "MHz - Megahertz",
+            "measure": "MHz"
+          },
+          {
+            "description": "GHz - Gigahertz",
+            "measure": "GHz"
+          }
+        ]
+      },
+      {
+        "group": "Ratio",
+        "measures": [
+          {
+            "description": "As percentage value",
+            "measure": "percent"
+          },
+          {
+            "description": "As ratio 0-1 with % sign",
+            "measure": "percentraw"
+          },
+          {
+            "description": "Ratio 0-1 (base)",
+            "measure": "ratio"
+          }
+        ]
+      },
+      {
+        "group": "Position",
+        "measures": [
+          {
+            "description": "Position Degrees",
+            "measure": "pdeg"
+          },
+          {
+            "description": "Latitude in minutes",
+            "measure": "latitudeMin"
+          },
+          {
+            "description": "Latitude in seconds",
+            "measure": "latitudeSec"
+          },
+          {
+            "description": "Longitude in minutes",
+            "measure": "longitudeMin"
+          },
+          {
+            "description": "Longitude in seconds",
+            "measure": "longitudeSec"
+          }
+        ]
+      }
+    ]
+  },
+  "meta": {
+    "configFileVersion": 11,
+    "configVersion": 12,
+    "kipVersion": "4.8.0",
+    "schemaVersion": 1
+  },
+  "widgets": [
+    {
+      "bindingKind": "none",
+      "category": "Component",
+      "componentClassName": "WidgetAisRadarComponent",
+      "defaultConfig": {
+        "ais": {
+          "cogVectorsMinutes": 10,
+          "filters": {
+            "allAton": false,
+            "allButSar": false,
+            "allVessels": false,
+            "anchoredMoored": false,
+            "noCollisionRisk": false,
+            "vesselTypes": []
+          },
+          "rangeIndex": "3",
+          "rangeRings": [
+            1,
+            3,
+            6,
+            12,
+            24,
+            48
+          ],
+          "showCogVectors": true,
+          "showLostTargets": true,
+          "showSelf": true,
+          "showUnconfirmedTargets": true,
+          "viewMode": "course-up"
+        },
+        "color": "grey",
+        "dataTimeout": 5,
+        "enableTimeout": false,
+        "filterSelfPaths": false
+      },
+      "defaultHeight": 8,
+      "defaultWidth": 5,
+      "description": "Displays AIS targets with range rings, interactive target details, and quick zoom and filtering controls.",
+      "icon": "aisradar",
+      "minHeight": 4,
+      "minWidth": 4,
+      "name": "AIS Radar",
+      "pathSlots": [],
+      "requiredPlugins": [],
+      "selector": "widget-ais-radar"
+    },
+    {
+      "bindingKind": "none",
+      "category": "Component",
+      "componentClassName": "WidgetAnchorAlarmComponent",
+      "defaultConfig": {},
+      "defaultHeight": 14,
+      "defaultWidth": 6,
+      "description": "Monitors your anchor position and triggers an alarm if you drift outside a configured radius (anchor drag). Set the anchor point, watch radius, and alarm behavior (sound/notification) in the widget config. Requires internet connectivity to view map.",
+      "icon": "anchorWatch",
+      "minHeight": 8,
+      "minWidth": 6,
+      "name": "Anchor Watch",
+      "pathSlots": [],
+      "requiredPlugins": [
+        "anchoralarm"
+      ],
+      "selector": "widget-anchor-alarm"
+    },
+    {
+      "anyOfPlugins": [
+        "autopilot",
+        "pypilot-autopilot-provider"
+      ],
+      "bindingKind": "paths-record",
+      "category": "Component",
+      "componentClassName": "WidgetAutopilotComponent",
+      "defaultConfig": {
+        "autopilot": {
+          "apiVersion": null,
+          "courseDirectionTrue": false,
+          "headingDirectionTrue": false,
+          "instanceId": null,
+          "invertRudder": true,
+          "modes": null,
+          "pluginId": null
+        },
+        "dataTimeout": 5,
+        "enableTimeout": false,
+        "filterSelfPaths": true,
+        "paths": {
+          "autopilotEngaged": {
+            "convertUnitTo": "",
+            "description": "Autopilot Engaged",
+            "isPathConfigurable": false,
+            "path": "self.steering.autopilot.engaged",
+            "pathType": "boolean",
+            "sampleTime": 500,
+            "showPathSkUnitsFilter": false,
+            "source": "default"
+          },
+          "autopilotMode": {
+            "convertUnitTo": "",
+            "description": "Autopilot Mode",
+            "isPathConfigurable": false,
+            "path": "self.steering.autopilot.mode",
+            "pathType": "string",
+            "sampleTime": 500,
+            "showPathSkUnitsFilter": false,
+            "source": "default"
+          },
+          "autopilotState": {
+            "convertUnitTo": "",
+            "description": "Autopilot State",
+            "isPathConfigurable": false,
+            "path": "self.steering.autopilot.state",
+            "pathType": "string",
+            "sampleTime": 500,
+            "showPathSkUnitsFilter": false,
+            "source": "default"
+          },
+          "autopilotTargetHeading": {
+            "convertUnitTo": "deg",
+            "description": "Autopilot Target Magnetic Heading",
+            "isPathConfigurable": false,
+            "path": "self.steering.autopilot.target.headingMagnetic",
+            "pathSkUnitsFilter": "rad",
+            "pathType": "number",
+            "sampleTime": 500,
+            "showPathSkUnitsFilter": false,
+            "source": "default"
+          },
+          "autopilotTargetWindHeading": {
+            "convertUnitTo": "deg",
+            "description": "Autopilot Target Apparent Wind Angle",
+            "isPathConfigurable": false,
+            "path": "self.steering.autopilot.target.windAngleApparent",
+            "pathSkUnitsFilter": "rad",
+            "pathType": "number",
+            "sampleTime": 500,
+            "showPathSkUnitsFilter": false,
+            "source": "default"
+          },
+          "autopilotV2Target": {
+            "convertUnitTo": "deg",
+            "description": "Autopilot API v2 Target",
+            "isPathConfigurable": false,
+            "path": "self.steering.autopilot.target",
+            "pathSkUnitsFilter": "rad",
+            "pathType": "number",
+            "sampleTime": 500,
+            "showPathSkUnitsFilter": false,
+            "source": "default"
+          },
+          "courseXte": {
+            "convertUnitTo": "m",
+            "description": "Cross Track Error",
+            "isPathConfigurable": false,
+            "path": "self.navigation.course.calcValues.crossTrackError",
+            "pathRequired": false,
+            "pathSkUnitsFilter": "m",
+            "pathType": "number",
+            "sampleTime": 500,
+            "showPathSkUnitsFilter": true,
+            "source": "default"
+          },
+          "headingMag": {
+            "convertUnitTo": "deg",
+            "description": "Magnetic Heading",
+            "isPathConfigurable": true,
+            "path": "self.navigation.headingMagnetic",
+            "pathRequired": false,
+            "pathSkUnitsFilter": "rad",
+            "pathType": "number",
+            "sampleTime": 500,
+            "showConvertUnitTo": false,
+            "showPathSkUnitsFilter": false,
+            "source": "default"
+          },
+          "headingTrue": {
+            "convertUnitTo": "deg",
+            "description": "True Heading",
+            "isPathConfigurable": true,
+            "path": "self.navigation.headingTrue",
+            "pathRequired": false,
+            "pathSkUnitsFilter": "rad",
+            "pathType": "number",
+            "sampleTime": 500,
+            "showConvertUnitTo": false,
+            "showPathSkUnitsFilter": false,
+            "source": "default"
+          },
+          "rudderAngle": {
+            "convertUnitTo": "deg",
+            "description": "Rudder Angle",
+            "isPathConfigurable": false,
+            "path": "self.steering.rudderAngle",
+            "pathSkUnitsFilter": "rad",
+            "pathType": "number",
+            "sampleTime": 500,
+            "showPathSkUnitsFilter": false,
+            "source": "default"
+          },
+          "windAngleApparent": {
+            "convertUnitTo": "deg",
+            "description": "Apparent Wind Angle",
+            "isPathConfigurable": true,
+            "path": "self.environment.wind.angleApparent",
+            "pathRequired": false,
+            "pathSkUnitsFilter": "rad",
+            "pathType": "number",
+            "sampleTime": 500,
+            "showConvertUnitTo": false,
+            "showPathSkUnitsFilter": false,
+            "source": "default"
+          },
+          "windAngleTrueWater": {
+            "convertUnitTo": "deg",
+            "description": "Wind Angle True Water",
+            "isPathConfigurable": true,
+            "path": "self.environment.wind.angleTrueWater",
+            "pathRequired": false,
+            "pathSkUnitsFilter": "rad",
+            "pathType": "number",
+            "sampleTime": 500,
+            "showConvertUnitTo": false,
+            "showPathSkUnitsFilter": false,
+            "source": "default"
+          }
+        },
+        "supportAutomaticHistoricalSeries": false
+      },
+      "defaultHeight": 10,
+      "defaultWidth": 4,
+      "description": "Provides typical autopilot controls for Signal K v1 & v2 Autopilot API devices. Requires a compatible hardware-specific Autopilot plugin for full functionality.",
+      "icon": "autopilotWidget",
+      "minHeight": 9,
+      "minWidth": 3,
+      "name": "Autopilot Head",
+      "pathSlots": [
+        {
+          "defaultConvertUnitTo": "",
+          "defaultPath": "self.steering.autopilot.state",
+          "description": "Autopilot State",
+          "expectedSkUnit": null,
+          "isPathConfigurable": false,
+          "pathRequired": false,
+          "pathType": "string",
+          "sampleTime": 500,
+          "slot": "autopilotState",
+          "source": "default"
+        },
+        {
+          "defaultConvertUnitTo": "",
+          "defaultPath": "self.steering.autopilot.mode",
+          "description": "Autopilot Mode",
+          "expectedSkUnit": null,
+          "isPathConfigurable": false,
+          "pathRequired": false,
+          "pathType": "string",
+          "sampleTime": 500,
+          "slot": "autopilotMode",
+          "source": "default"
+        },
+        {
+          "defaultConvertUnitTo": "",
+          "defaultPath": "self.steering.autopilot.engaged",
+          "description": "Autopilot Engaged",
+          "expectedSkUnit": null,
+          "isPathConfigurable": false,
+          "pathRequired": false,
+          "pathType": "boolean",
+          "sampleTime": 500,
+          "slot": "autopilotEngaged",
+          "source": "default"
+        },
+        {
+          "defaultConvertUnitTo": "deg",
+          "defaultPath": "self.steering.autopilot.target",
+          "description": "Autopilot API v2 Target",
+          "expectedSkUnit": "rad",
+          "isPathConfigurable": false,
+          "pathRequired": false,
+          "pathType": "number",
+          "sampleTime": 500,
+          "slot": "autopilotV2Target",
+          "source": "default"
+        },
+        {
+          "defaultConvertUnitTo": "deg",
+          "defaultPath": "self.steering.autopilot.target.headingMagnetic",
+          "description": "Autopilot Target Magnetic Heading",
+          "expectedSkUnit": "rad",
+          "isPathConfigurable": false,
+          "pathRequired": false,
+          "pathType": "number",
+          "sampleTime": 500,
+          "slot": "autopilotTargetHeading",
+          "source": "default"
+        },
+        {
+          "defaultConvertUnitTo": "deg",
+          "defaultPath": "self.steering.autopilot.target.windAngleApparent",
+          "description": "Autopilot Target Apparent Wind Angle",
+          "expectedSkUnit": "rad",
+          "isPathConfigurable": false,
+          "pathRequired": false,
+          "pathType": "number",
+          "sampleTime": 500,
+          "slot": "autopilotTargetWindHeading",
+          "source": "default"
+        },
+        {
+          "defaultConvertUnitTo": "deg",
+          "defaultPath": "self.steering.rudderAngle",
+          "description": "Rudder Angle",
+          "expectedSkUnit": "rad",
+          "isPathConfigurable": false,
+          "pathRequired": false,
+          "pathType": "number",
+          "sampleTime": 500,
+          "slot": "rudderAngle",
+          "source": "default"
+        },
+        {
+          "defaultConvertUnitTo": "m",
+          "defaultPath": "self.navigation.course.calcValues.crossTrackError",
+          "description": "Cross Track Error",
+          "expectedSkUnit": "m",
+          "isPathConfigurable": false,
+          "pathRequired": false,
+          "pathType": "number",
+          "sampleTime": 500,
+          "slot": "courseXte",
+          "source": "default"
+        },
+        {
+          "defaultConvertUnitTo": "deg",
+          "defaultPath": "self.navigation.headingMagnetic",
+          "description": "Magnetic Heading",
+          "expectedSkUnit": "rad",
+          "isPathConfigurable": true,
+          "pathRequired": false,
+          "pathType": "number",
+          "sampleTime": 500,
+          "slot": "headingMag",
+          "source": "default"
+        },
+        {
+          "defaultConvertUnitTo": "deg",
+          "defaultPath": "self.navigation.headingTrue",
+          "description": "True Heading",
+          "expectedSkUnit": "rad",
+          "isPathConfigurable": true,
+          "pathRequired": false,
+          "pathType": "number",
+          "sampleTime": 500,
+          "slot": "headingTrue",
+          "source": "default"
+        },
+        {
+          "defaultConvertUnitTo": "deg",
+          "defaultPath": "self.environment.wind.angleApparent",
+          "description": "Apparent Wind Angle",
+          "expectedSkUnit": "rad",
+          "isPathConfigurable": true,
+          "pathRequired": false,
+          "pathType": "number",
+          "sampleTime": 500,
+          "slot": "windAngleApparent",
+          "source": "default"
+        },
+        {
+          "defaultConvertUnitTo": "deg",
+          "defaultPath": "self.environment.wind.angleTrueWater",
+          "description": "Wind Angle True Water",
+          "expectedSkUnit": "rad",
+          "isPathConfigurable": true,
+          "pathRequired": false,
+          "pathType": "number",
+          "sampleTime": 500,
+          "slot": "windAngleTrueWater",
+          "source": "default"
+        }
+      ],
+      "requiredPlugins": [],
+      "selector": "widget-autopilot"
+    },
+    {
+      "bindingKind": "none",
+      "category": "Gauge",
+      "componentClassName": "WidgetBmsComponent",
+      "defaultConfig": {
+        "bms": {
+          "banks": [],
+          "groups": [],
+          "trackedDevices": []
+        },
+        "color": "contrast",
+        "ignoreZones": false
+      },
+      "defaultHeight": 6,
+      "defaultWidth": 6,
+      "description": "Displays battery banks and individual batteries with aggregated bank totals plus per-battery detail cards. See key BMS values such as state of charge, current, voltage, power, temperature, capacity, and time remaining for a clearer view of overall bank health and individual battery status.",
+      "icon": "battery_charging",
+      "minHeight": 2,
+      "minWidth": 2,
+      "name": "Battery Monitor",
+      "pathSlots": [],
+      "requiredPlugins": [],
+      "selector": "widget-bms"
+    },
+    {
+      "bindingKind": "paths-array",
+      "category": "Core",
+      "componentClassName": "WidgetBooleanSwitchComponent",
+      "defaultConfig": {
+        "color": "contrast",
+        "dataTimeout": 5,
+        "displayName": "Switch Panel Label",
+        "enableTimeout": false,
+        "filterSelfPaths": true,
+        "multiChildCtrls": [],
+        "paths": [],
+        "putEnable": true,
+        "putMomentary": false,
+        "showLabel": true,
+        "zonesOnlyPaths": false
+      },
+      "defaultHeight": 6,
+      "defaultWidth": 4,
+      "description": "A Digital Switching panel group with multiple controls including toggle switches, indicator lights, and press buttons to send Signal K paths values and other operations.",
+      "icon": "switchpanelWidget",
+      "minHeight": 2,
+      "minWidth": 1,
+      "name": "Switch Panel",
+      "pathSlots": [],
+      "requiredPlugins": [],
+      "selector": "widget-boolean-switch"
+    },
+    {
+      "bindingKind": "none",
+      "category": "Gauge",
+      "componentClassName": "WidgetChargerComponent",
+      "defaultConfig": {
+        "charger": {
+          "optionsById": {},
+          "trackedDevices": []
+        },
+        "color": "contrast",
+        "ignoreZones": false
+      },
+      "defaultHeight": 6,
+      "defaultWidth": 6,
+      "description": "Track charger output and charging state with voltage, current, power, and temperature monitoring, including real-time charging stage indicators.",
+      "icon": "charger",
+      "minHeight": 2,
+      "minWidth": 2,
+      "name": "AC/DC Charger",
+      "pathSlots": [],
+      "requiredPlugins": [],
+      "selector": "widget-charger"
+    },
+    {
+      "bindingKind": "datachart",
+      "category": "Component",
+      "componentClassName": "WidgetDataChartComponent",
+      "defaultConfig": {
+        "color": "contrast",
+        "convertUnitTo": null,
+        "datachartPath": null,
+        "datachartSource": null,
+        "datasetAverageArray": "sma",
+        "displayName": "Chart Label",
+        "enableMinMaxScaleLimit": false,
+        "filterSelfPaths": true,
+        "inverseYAxis": false,
+        "numDecimal": 1,
+        "period": 10,
+        "showAverageData": true,
+        "showDataPoints": false,
+        "showDatasetAngleAverageValueLine": false,
+        "showDatasetAverageValueLine": true,
+        "showDatasetMaximumValueLine": false,
+        "showDatasetMinimumValueLine": false,
+        "showLabel": true,
+        "showTimeScale": false,
+        "showYScale": false,
+        "startScaleAtZero": false,
+        "timeScale": "minute",
+        "trackAgainstAverage": false,
+        "verticalChart": false,
+        "yScaleMax": null,
+        "yScaleMin": null,
+        "yScaleSuggestedMax": null,
+        "yScaleSuggestedMin": null
+      },
+      "defaultHeight": 6,
+      "defaultWidth": 6,
+      "description": "Visualizes data on a real-time chart with multiple preconfigured series including actuals, SMA and period overall averages and Min/Max. Requires the KIP Dataset to be configured.",
+      "icon": "datachartWidget",
+      "minHeight": 3,
+      "minWidth": 2,
+      "name": "Realtime Data Chart",
+      "pathSlots": [],
+      "requiredPlugins": [],
+      "selector": "widget-data-chart"
+    },
+    {
+      "bindingKind": "paths-record",
+      "category": "Core",
+      "componentClassName": "WidgetDatetimeComponent",
+      "defaultConfig": {
+        "color": "contrast",
+        "dataTimeout": 5,
+        "dateFormat": "dd/MM/yyyy HH:mm:ss",
+        "dateTimezone": "Atlantic/Azores",
+        "displayName": "Time Label",
+        "enableTimeout": false,
+        "filterSelfPaths": true,
+        "paths": {
+          "gaugePath": {
+            "description": "Date / Time",
+            "isPathConfigurable": true,
+            "path": null,
+            "pathType": "Date",
+            "sampleTime": 1000,
+            "source": null
+          }
+        }
+      },
+      "defaultHeight": 6,
+      "defaultWidth": 4,
+      "description": "Displays date and time data with fully custom formatting options and timezone correction.",
+      "icon": "datetimeWidget",
+      "minHeight": 2,
+      "minWidth": 1,
+      "name": "Date & Time",
+      "pathSlots": [
+        {
+          "defaultConvertUnitTo": null,
+          "defaultPath": null,
+          "description": "Date / Time",
+          "expectedSkUnit": null,
+          "isPathConfigurable": true,
+          "pathRequired": false,
+          "pathType": "Date",
+          "sampleTime": 1000,
+          "slot": "gaugePath",
+          "source": null
+        }
+      ],
+      "requiredPlugins": [],
+      "selector": "widget-datetime"
+    },
+    {
+      "bindingKind": "none",
+      "category": "Component",
+      "componentClassName": "WidgetFreeboardskComponent",
+      "defaultConfig": {},
+      "defaultHeight": 14,
+      "defaultWidth": 6,
+      "description": "Adds the Freeboard-SK chart plotter as a widget with automatic sign-in to your dashboard.",
+      "icon": "freeboardWidget",
+      "minHeight": 8,
+      "minWidth": 6,
+      "name": "Freeboard-SK",
+      "pathSlots": [],
+      "requiredPlugins": [
+        "course-provider",
+        "freeboard-sk",
+        "resources-provider",
+        "tracks"
+      ],
+      "selector": "widget-freeboardsk"
+    },
+    {
+      "bindingKind": "paths-record",
+      "category": "Gauge",
+      "componentClassName": "WidgetGaugeNgCompassComponent",
+      "defaultConfig": {
+        "color": "contrast",
+        "dataTimeout": 5,
+        "displayName": "Gauge Label",
+        "enableTimeout": false,
+        "filterSelfPaths": true,
+        "gauge": {
+          "compassUseNumbers": false,
+          "enableTicks": true,
+          "showValueBox": false,
+          "subType": "baseplateCompass",
+          "type": "ngRadial"
+        },
+        "paths": {
+          "gaugePath": {
+            "convertUnitTo": "deg",
+            "description": "Numeric Data",
+            "isPathConfigurable": true,
+            "path": null,
+            "pathSkUnitsFilter": "rad",
+            "pathType": "number",
+            "sampleTime": 500,
+            "showConvertUnitTo": false,
+            "showPathSkUnitsFilter": false,
+            "source": null,
+            "suppressBootstrapNull": true
+          }
+        },
+        "supportAutomaticHistoricalSeries": true
+      },
+      "defaultHeight": 6,
+      "defaultWidth": 4,
+      "description": "A faceplate or card-style rotating compass gauge with multiple cardinal point indicator options.",
+      "icon": "compassGauge",
+      "minHeight": 2,
+      "minWidth": 1,
+      "name": "Compass",
+      "pathSlots": [
+        {
+          "defaultConvertUnitTo": "deg",
+          "defaultPath": null,
+          "description": "Numeric Data",
+          "expectedSkUnit": "rad",
+          "isPathConfigurable": true,
+          "pathRequired": false,
+          "pathType": "number",
+          "sampleTime": 500,
+          "slot": "gaugePath",
+          "source": null
+        }
+      ],
+      "requiredPlugins": [],
+      "selector": "widget-gauge-ng-compass"
+    },
+    {
+      "bindingKind": "paths-record",
+      "category": "Gauge",
+      "componentClassName": "WidgetGaugeNgLinearComponent",
+      "defaultConfig": {
+        "color": "contrast",
+        "dataTimeout": 5,
+        "displayName": "Gauge Label",
+        "displayScale": {
+          "lower": 0,
+          "type": "linear",
+          "upper": 100
+        },
+        "enableTimeout": false,
+        "filterSelfPaths": true,
+        "gauge": {
+          "enableNeedle": false,
+          "enableTicks": true,
+          "highlightsWidth": 5,
+          "subType": "vertical",
+          "type": "ngLinear"
+        },
+        "ignoreZones": false,
+        "numDecimal": 0,
+        "numInt": 1,
+        "paths": {
+          "gaugePath": {
+            "convertUnitTo": "unitless",
+            "description": "Numeric Data",
+            "isPathConfigurable": true,
+            "path": null,
+            "pathSkUnitsFilter": null,
+            "pathType": "number",
+            "sampleTime": 500,
+            "showPathSkUnitsFilter": true,
+            "source": null,
+            "suppressBootstrapNull": true
+          }
+        },
+        "supportAutomaticHistoricalSeries": true
+      },
+      "defaultHeight": 6,
+      "defaultWidth": 4,
+      "description": "A horizontal or vertical linear gauge that supports zone highlighting.",
+      "icon": "linearGauge",
+      "minHeight": 2,
+      "minWidth": 1,
+      "name": "Linear",
+      "pathSlots": [
+        {
+          "defaultConvertUnitTo": "unitless",
+          "defaultPath": null,
+          "description": "Numeric Data",
+          "expectedSkUnit": null,
+          "isPathConfigurable": true,
+          "pathRequired": false,
+          "pathType": "number",
+          "sampleTime": 500,
+          "slot": "gaugePath",
+          "source": null
+        }
+      ],
+      "requiredPlugins": [],
+      "selector": "widget-gauge-ng-linear"
+    },
+    {
+      "bindingKind": "paths-record",
+      "category": "Gauge",
+      "componentClassName": "WidgetGaugeNgRadialComponent",
+      "defaultConfig": {
+        "color": "contrast",
+        "dataTimeout": 5,
+        "displayName": "Gauge Label",
+        "displayScale": {
+          "lower": 0,
+          "type": "linear",
+          "upper": 100
+        },
+        "enableTimeout": false,
+        "filterSelfPaths": true,
+        "gauge": {
+          "barStartPosition": "left",
+          "enableNeedle": true,
+          "enableProgressbar": true,
+          "enableTicks": true,
+          "highlightsWidth": 5,
+          "scaleStart": 180,
+          "subType": "measuring",
+          "type": "ngRadial"
+        },
+        "ignoreZones": false,
+        "numDecimal": 0,
+        "numInt": 1,
+        "paths": {
+          "gaugePath": {
+            "convertUnitTo": "unitless",
+            "description": "Numeric Data",
+            "isPathConfigurable": true,
+            "path": null,
+            "pathSkUnitsFilter": null,
+            "pathType": "number",
+            "sampleTime": 500,
+            "showPathSkUnitsFilter": true,
+            "source": null,
+            "suppressBootstrapNull": true
+          }
+        },
+        "supportAutomaticHistoricalSeries": true
+      },
+      "defaultHeight": 6,
+      "defaultWidth": 4,
+      "description": "A radial gauge with configurable capacity and measurement dials plus zone highlighting.",
+      "icon": "radialGauge",
+      "minHeight": 2,
+      "minWidth": 1,
+      "name": "Radial",
+      "pathSlots": [
+        {
+          "defaultConvertUnitTo": "unitless",
+          "defaultPath": null,
+          "description": "Numeric Data",
+          "expectedSkUnit": null,
+          "isPathConfigurable": true,
+          "pathRequired": false,
+          "pathType": "number",
+          "sampleTime": 500,
+          "slot": "gaugePath",
+          "source": null
+        }
+      ],
+      "requiredPlugins": [],
+      "selector": "widget-gauge-ng-radial"
+    },
+    {
+      "bindingKind": "paths-record",
+      "category": "Gauge",
+      "componentClassName": "WidgetSteelGaugeComponent",
+      "defaultConfig": {
+        "dataTimeout": 5,
+        "displayName": "Gauge Label",
+        "displayScale": {
+          "lower": 0,
+          "type": "linear",
+          "upper": 100
+        },
+        "enableTimeout": false,
+        "filterSelfPaths": true,
+        "gauge": {
+          "backgroundColor": "carbon",
+          "digitalMeter": false,
+          "faceColor": "anthracite",
+          "radialSize": "full",
+          "rotateFace": false,
+          "subType": "radial",
+          "type": "steel"
+        },
+        "ignoreZones": false,
+        "numDecimal": 2,
+        "paths": {
+          "gaugePath": {
+            "convertUnitTo": "unitless",
+            "description": "Numeric Data",
+            "isPathConfigurable": true,
+            "path": null,
+            "pathSkUnitsFilter": null,
+            "pathType": "number",
+            "sampleTime": 500,
+            "showPathSkUnitsFilter": true,
+            "source": null
+          }
+        },
+        "supportAutomaticHistoricalSeries": true
+      },
+      "defaultHeight": 6,
+      "defaultWidth": 4,
+      "description": "A traditional steel looking linear & radial gauges replica that supports range sizes and zones highlights.",
+      "icon": "steelGauge",
+      "minHeight": 2,
+      "minWidth": 1,
+      "name": "Classic Steel",
+      "pathSlots": [
+        {
+          "defaultConvertUnitTo": "unitless",
+          "defaultPath": null,
+          "description": "Numeric Data",
+          "expectedSkUnit": null,
+          "isPathConfigurable": true,
+          "pathRequired": false,
+          "pathType": "number",
+          "sampleTime": 500,
+          "slot": "gaugePath",
+          "source": null
+        }
+      ],
+      "requiredPlugins": [],
+      "selector": "widget-gauge-steel"
+    },
+    {
+      "bindingKind": "paths-record",
+      "category": "Gauge",
+      "componentClassName": "WidgetHeelGaugeComponent",
+      "defaultConfig": {
+        "color": "contrast",
+        "dataTimeout": 5,
+        "displayName": "Heel",
+        "enableTimeout": false,
+        "filterSelfPaths": true,
+        "gauge": {
+          "invertAngle": false,
+          "sideLabel": true,
+          "type": "angle"
+        },
+        "numDecimal": 0,
+        "numInt": 2,
+        "paths": {
+          "angle": {
+            "convertUnitTo": "deg",
+            "description": "Heel / Roll / Other Angle",
+            "isPathConfigurable": true,
+            "path": "self.navigation.attitude.roll",
+            "pathRequired": true,
+            "pathType": "number",
+            "sampleTime": 1000,
+            "source": "default"
+          }
+        },
+        "supportAutomaticHistoricalSeries": true
+      },
+      "defaultHeight": 6,
+      "defaultWidth": 4,
+      "description": "Dual-scale heel angle indicator combining a high‑precision ±5° fine level with a wide ±40° coarse arc for fast trim tuning and broader heel / sea‑state monitoring.",
+      "icon": "level",
+      "minHeight": 2,
+      "minWidth": 1,
+      "name": "Level Gauge",
+      "pathSlots": [
+        {
+          "defaultConvertUnitTo": "deg",
+          "defaultPath": "self.navigation.attitude.roll",
+          "description": "Heel / Roll / Other Angle",
+          "expectedSkUnit": null,
+          "isPathConfigurable": true,
+          "pathRequired": true,
+          "pathType": "number",
+          "sampleTime": 1000,
+          "slot": "angle",
+          "source": "default"
+        }
+      ],
+      "requiredPlugins": [],
+      "selector": "widget-heel-gauge"
+    },
+    {
+      "bindingKind": "paths-record",
+      "category": "Gauge",
+      "componentClassName": "WidgetHorizonComponent",
+      "defaultConfig": {
+        "dataTimeout": 5,
+        "displayName": "Horizon",
+        "enableTimeout": false,
+        "filterSelfPaths": true,
+        "gauge": {
+          "faceColor": "anthracite",
+          "invertPitch": false,
+          "invertRoll": false,
+          "noFrameVisible": false,
+          "type": "horizon"
+        },
+        "paths": {
+          "gaugePitchPath": {
+            "convertUnitTo": "deg",
+            "description": "Attitude Pitch Data",
+            "isPathConfigurable": true,
+            "path": "self.navigation.attitude.pitch",
+            "pathRequired": false,
+            "pathSkUnitsFilter": "rad",
+            "pathType": "number",
+            "sampleTime": 1000,
+            "showPathSkUnitsFilter": false,
+            "source": "default"
+          },
+          "gaugeRollPath": {
+            "convertUnitTo": "deg",
+            "description": "Attitude Roll Data",
+            "isPathConfigurable": true,
+            "path": "self.navigation.attitude.roll",
+            "pathRequired": false,
+            "pathSkUnitsFilter": "rad",
+            "pathType": "number",
+            "sampleTime": 1000,
+            "showPathSkUnitsFilter": false,
+            "source": "default"
+          }
+        },
+        "supportAutomaticHistoricalSeries": true
+      },
+      "defaultHeight": 6,
+      "defaultWidth": 4,
+      "description": "Horizon-style attitude indicator showing live pitch and roll degrees with smooth animation—ideal for monitoring trim, heel, and sea-state response.",
+      "icon": "pitchRollGauge",
+      "minHeight": 2,
+      "minWidth": 1,
+      "name": "Pitch & Roll",
+      "pathSlots": [
+        {
+          "defaultConvertUnitTo": "deg",
+          "defaultPath": "self.navigation.attitude.pitch",
+          "description": "Attitude Pitch Data",
+          "expectedSkUnit": "rad",
+          "isPathConfigurable": true,
+          "pathRequired": false,
+          "pathType": "number",
+          "sampleTime": 1000,
+          "slot": "gaugePitchPath",
+          "source": "default"
+        },
+        {
+          "defaultConvertUnitTo": "deg",
+          "defaultPath": "self.navigation.attitude.roll",
+          "description": "Attitude Roll Data",
+          "expectedSkUnit": "rad",
+          "isPathConfigurable": true,
+          "pathRequired": false,
+          "pathType": "number",
+          "sampleTime": 1000,
+          "slot": "gaugeRollPath",
+          "source": "default"
+        }
+      ],
+      "requiredPlugins": [],
+      "selector": "widget-horizon"
+    },
+    {
+      "bindingKind": "none",
+      "category": "Component",
+      "componentClassName": "WidgetIframeComponent",
+      "defaultConfig": {
+        "allowInput": false,
+        "widgetUrl": null
+      },
+      "defaultHeight": 6,
+      "defaultWidth": 4,
+      "description": "Embeds external web-based applications—such as Grafana graphs or other Signal K apps—into your dashboard for seamless integration. Interaction is disabled by default but can be enabled.",
+      "icon": "embedWidget",
+      "minHeight": 2,
+      "minWidth": 1,
+      "name": "Embed Webpage Viewer",
+      "pathSlots": [],
+      "requiredPlugins": [],
+      "selector": "widget-iframe"
+    },
+    {
+      "bindingKind": "none",
+      "category": "Core",
+      "componentClassName": "WidgetLabelComponent",
+      "defaultConfig": {
+        "bgColor": "grey",
+        "color": "green",
+        "displayName": "Static Label",
+        "noBgColor": true,
+        "noColor": false
+      },
+      "defaultHeight": 6,
+      "defaultWidth": 4,
+      "description": "A static text widget that allows you to add customizable labels to your dashboard, helping to organize and clarify your layout effectively.",
+      "icon": "labelWidget",
+      "minHeight": 2,
+      "minWidth": 1,
+      "name": "Static Label",
+      "pathSlots": [],
+      "requiredPlugins": [],
+      "selector": "widget-label"
+    },
+    {
+      "bindingKind": "paths-record",
+      "category": "Core",
+      "componentClassName": "WidgetMultiStateSwitchComponent",
+      "defaultConfig": {
+        "color": "contrast",
+        "dataTimeout": 5,
+        "displayName": "Switch Label",
+        "enableTimeout": false,
+        "filterSelfPaths": true,
+        "paths": {
+          "controlPath": {
+            "convertUnitTo": null,
+            "description": "Multi-state control path",
+            "isPathConfigurable": true,
+            "path": null,
+            "pathRequired": true,
+            "pathSkUnitsFilter": null,
+            "pathType": "multiple",
+            "sampleTime": 500,
+            "showConvertUnitTo": false,
+            "showPathSkUnitsFilter": false,
+            "source": null,
+            "supportsPut": true
+          }
+        },
+        "showLabel": true
+      },
+      "defaultHeight": 4,
+      "defaultWidth": 4,
+      "description": "Lists all available device/path operating modes/states (e.g., On, Off, Charge Only, Invert Only), highlights the current state, and lets you select a new state to send to the device and see the result.",
+      "icon": "multiStateSwitchWidget",
+      "minHeight": 2,
+      "minWidth": 2,
+      "name": "Multi-State Switch",
+      "pathSlots": [
+        {
+          "defaultConvertUnitTo": null,
+          "defaultPath": null,
+          "description": "Multi-state control path",
+          "expectedSkUnit": null,
+          "isPathConfigurable": true,
+          "pathRequired": true,
+          "pathType": "multiple",
+          "sampleTime": 500,
+          "slot": "controlPath",
+          "source": null
+        }
+      ],
+      "requiredPlugins": [],
+      "selector": "widget-multi-state-switch"
+    },
+    {
+      "bindingKind": "paths-record",
+      "category": "Core",
+      "componentClassName": "WidgetNumericComponent",
+      "defaultConfig": {
+        "color": "contrast",
+        "dataTimeout": 5,
+        "displayName": "Gauge Label",
+        "enableTimeout": false,
+        "filterSelfPaths": true,
+        "ignoreZones": false,
+        "inverseYAxis": false,
+        "numDecimal": 1,
+        "paths": {
+          "numericPath": {
+            "convertUnitTo": "unitless",
+            "description": "Numeric Data",
+            "isPathConfigurable": true,
+            "path": null,
+            "pathSkUnitsFilter": null,
+            "pathType": "number",
+            "sampleTime": 500,
+            "showPathSkUnitsFilter": true,
+            "source": null,
+            "suppressBootstrapNull": true
+          }
+        },
+        "showMax": false,
+        "showMin": false,
+        "showMiniChart": false,
+        "supportAutomaticHistoricalSeries": true,
+        "verticalChart": false,
+        "yScaleMax": 10,
+        "yScaleMin": 0
+      },
+      "defaultHeight": 6,
+      "defaultWidth": 4,
+      "description": "Displays numeric data in a clear and concise format, with options to show minimum and/or maximum recorded values. Includes an optional background minichart for quick visual trend insights.",
+      "icon": "numericWidget",
+      "minHeight": 2,
+      "minWidth": 1,
+      "name": "Numeric",
+      "pathSlots": [
+        {
+          "defaultConvertUnitTo": "unitless",
+          "defaultPath": null,
+          "description": "Numeric Data",
+          "expectedSkUnit": null,
+          "isPathConfigurable": true,
+          "pathRequired": false,
+          "pathType": "number",
+          "sampleTime": 500,
+          "slot": "numericPath",
+          "source": null
+        }
+      ],
+      "requiredPlugins": [],
+      "selector": "widget-numeric"
+    },
+    {
+      "bindingKind": "paths-record",
+      "category": "Core",
+      "componentClassName": "WidgetPositionComponent",
+      "defaultConfig": {
+        "color": "contrast",
+        "dataTimeout": 5,
+        "displayName": "Position",
+        "enableTimeout": false,
+        "filterSelfPaths": true,
+        "paths": {
+          "latPath": {
+            "convertUnitTo": "latitudeMin",
+            "description": "Latitude",
+            "isPathConfigurable": true,
+            "path": "self.navigation.position.latitude",
+            "pathSkUnitsFilter": null,
+            "pathType": "number",
+            "sampleTime": 500,
+            "showPathSkUnitsFilter": true,
+            "source": "default"
+          },
+          "longPath": {
+            "convertUnitTo": "longitudeMin",
+            "description": "Longitude",
+            "isPathConfigurable": true,
+            "path": "self.navigation.position.longitude",
+            "pathSkUnitsFilter": null,
+            "pathType": "number",
+            "sampleTime": 500,
+            "showPathSkUnitsFilter": true,
+            "source": "default"
+          }
+        },
+        "supportAutomaticHistoricalSeries": false
+      },
+      "defaultHeight": 6,
+      "defaultWidth": 4,
+      "description": "Displays latitude and longitude for location tracking and navigation.",
+      "icon": "positionWidget",
+      "minHeight": 2,
+      "minWidth": 1,
+      "name": "Position",
+      "pathSlots": [
+        {
+          "defaultConvertUnitTo": "longitudeMin",
+          "defaultPath": "self.navigation.position.longitude",
+          "description": "Longitude",
+          "expectedSkUnit": null,
+          "isPathConfigurable": true,
+          "pathRequired": false,
+          "pathType": "number",
+          "sampleTime": 500,
+          "slot": "longPath",
+          "source": "default"
+        },
+        {
+          "defaultConvertUnitTo": "latitudeMin",
+          "defaultPath": "self.navigation.position.latitude",
+          "description": "Latitude",
+          "expectedSkUnit": null,
+          "isPathConfigurable": true,
+          "pathRequired": false,
+          "pathType": "number",
+          "sampleTime": 500,
+          "slot": "latPath",
+          "source": "default"
+        }
+      ],
+      "requiredPlugins": [],
+      "selector": "widget-position"
+    },
+    {
+      "bindingKind": "paths-record",
+      "category": "Racing",
+      "componentClassName": "WidgetRacerLineComponent",
+      "defaultConfig": {
+        "color": "contrast",
+        "convertUnitTo": "m",
+        "convertUnitToGroup": "Length",
+        "dataTimeout": 5,
+        "displayName": "DTS",
+        "enableTimeout": false,
+        "filterSelfPaths": true,
+        "ignoreZones": true,
+        "numDecimal": 0,
+        "paths": {
+          "dtsPath": {
+            "convertUnitTo": "m",
+            "description": "Distance to Start Line",
+            "isPathConfigurable": false,
+            "path": "self.navigation.racing.distanceStartline",
+            "pathRequired": false,
+            "pathSkUnitsFilter": "m",
+            "pathType": "number",
+            "sampleTime": 500,
+            "showPathSkUnitsFilter": true,
+            "source": "default"
+          },
+          "lineBiasPath": {
+            "convertUnitTo": "m",
+            "description": "Bias of the start line to starboard end",
+            "isPathConfigurable": false,
+            "path": "self.navigation.racing.stbLineBias",
+            "pathRequired": false,
+            "pathSkUnitsFilter": "m",
+            "pathType": "number",
+            "sampleTime": 1000,
+            "showPathSkUnitsFilter": true,
+            "source": "default"
+          },
+          "lineLengthPath": {
+            "convertUnitTo": "m",
+            "description": "Length of the start line",
+            "isPathConfigurable": false,
+            "path": "self.navigation.racing.startLineLength",
+            "pathRequired": false,
+            "pathSkUnitsFilter": "m",
+            "pathType": "number",
+            "sampleTime": 1000,
+            "showPathSkUnitsFilter": true,
+            "source": "default"
+          },
+          "linesPath": {
+            "convertUnitTo": null,
+            "description": "The known named lines",
+            "isPathConfigurable": false,
+            "path": "self.navigation.racing.lines.lines",
+            "pathRequired": false,
+            "pathSkUnitsFilter": null,
+            "pathType": null,
+            "sampleTime": 1000,
+            "showPathSkUnitsFilter": false,
+            "source": "default"
+          },
+          "startLineNamePath": {
+            "convertUnitTo": null,
+            "description": "The current named start line",
+            "isPathConfigurable": false,
+            "path": "self.navigation.racing.lines.startLineName",
+            "pathRequired": false,
+            "pathSkUnitsFilter": null,
+            "pathType": "string",
+            "sampleTime": 1000,
+            "showPathSkUnitsFilter": false,
+            "source": "default"
+          },
+          "ttbPath": {
+            "convertUnitTo": "s",
+            "description": "Time to delay before sailing to the start line in seconds",
+            "isPathConfigurable": false,
+            "path": "self.navigation.racing.timeToBurn",
+            "pathRequired": false,
+            "pathSkUnitsFilter": "s",
+            "pathType": "number",
+            "sampleTime": 500,
+            "showConvertUnitTo": false,
+            "showPathSkUnitsFilter": false,
+            "source": "default"
+          },
+          "ttlPath": {
+            "convertUnitTo": "s",
+            "description": "Time to sail to the start line in seconds",
+            "isPathConfigurable": false,
+            "path": "self.navigation.racing.timeToLine",
+            "pathRequired": false,
+            "pathSkUnitsFilter": "s",
+            "pathType": "number",
+            "sampleTime": 500,
+            "showConvertUnitTo": false,
+            "showPathSkUnitsFilter": false,
+            "source": "default"
+          }
+        },
+        "playBeeps": true,
+        "supportAutomaticHistoricalSeries": false
+      },
+      "defaultHeight": 4,
+      "defaultWidth": 4,
+      "description": "Gain a tactical advantage for racing starts: set and adjust the port and starboard ends of the start line, see your distance to the line, the favored end, and how much the line is favored or unfavored. Includes visual integration with Freeboard SK for interactive line adjustment and display.",
+      "icon": "racerlineWidget",
+      "minHeight": 4,
+      "minWidth": 4,
+      "name": "Racer - Start Line Insight",
+      "pathSlots": [
+        {
+          "defaultConvertUnitTo": "m",
+          "defaultPath": "self.navigation.racing.distanceStartline",
+          "description": "Distance to Start Line",
+          "expectedSkUnit": "m",
+          "isPathConfigurable": false,
+          "pathRequired": false,
+          "pathType": "number",
+          "sampleTime": 500,
+          "slot": "dtsPath",
+          "source": "default"
+        },
+        {
+          "defaultConvertUnitTo": "m",
+          "defaultPath": "self.navigation.racing.startLineLength",
+          "description": "Length of the start line",
+          "expectedSkUnit": "m",
+          "isPathConfigurable": false,
+          "pathRequired": false,
+          "pathType": "number",
+          "sampleTime": 1000,
+          "slot": "lineLengthPath",
+          "source": "default"
+        },
+        {
+          "defaultConvertUnitTo": "m",
+          "defaultPath": "self.navigation.racing.stbLineBias",
+          "description": "Bias of the start line to starboard end",
+          "expectedSkUnit": "m",
+          "isPathConfigurable": false,
+          "pathRequired": false,
+          "pathType": "number",
+          "sampleTime": 1000,
+          "slot": "lineBiasPath",
+          "source": "default"
+        },
+        {
+          "defaultConvertUnitTo": null,
+          "defaultPath": "self.navigation.racing.lines.startLineName",
+          "description": "The current named start line",
+          "expectedSkUnit": null,
+          "isPathConfigurable": false,
+          "pathRequired": false,
+          "pathType": "string",
+          "sampleTime": 1000,
+          "slot": "startLineNamePath",
+          "source": "default"
+        },
+        {
+          "defaultConvertUnitTo": null,
+          "defaultPath": "self.navigation.racing.lines.lines",
+          "description": "The known named lines",
+          "expectedSkUnit": null,
+          "isPathConfigurable": false,
+          "pathRequired": false,
+          "pathType": null,
+          "sampleTime": 1000,
+          "slot": "linesPath",
+          "source": "default"
+        },
+        {
+          "defaultConvertUnitTo": "s",
+          "defaultPath": "self.navigation.racing.timeToLine",
+          "description": "Time to sail to the start line in seconds",
+          "expectedSkUnit": "s",
+          "isPathConfigurable": false,
+          "pathRequired": false,
+          "pathType": "number",
+          "sampleTime": 500,
+          "slot": "ttlPath",
+          "source": "default"
+        },
+        {
+          "defaultConvertUnitTo": "s",
+          "defaultPath": "self.navigation.racing.timeToBurn",
+          "description": "Time to delay before sailing to the start line in seconds",
+          "expectedSkUnit": "s",
+          "isPathConfigurable": false,
+          "pathRequired": false,
+          "pathType": "number",
+          "sampleTime": 500,
+          "slot": "ttbPath",
+          "source": "default"
+        }
+      ],
+      "requiredPlugins": [
+        "signalk-racer"
+      ],
+      "selector": "widget-racer-line"
+    },
+    {
+      "bindingKind": "paths-record",
+      "category": "Racing",
+      "componentClassName": "WidgetRacerTimerComponent",
+      "defaultConfig": {
+        "color": "contrast",
+        "dataTimeout": 5,
+        "displayName": "TTS",
+        "enableTimeout": false,
+        "filterSelfPaths": true,
+        "ignoreZones": true,
+        "nextDashboard": 0,
+        "paths": {
+          "dtsPath": {
+            "convertUnitTo": "m",
+            "description": "Distance to Start Line path, used to determine OCS",
+            "isPathConfigurable": false,
+            "path": "self.navigation.racing.distanceStartline",
+            "pathRequired": false,
+            "pathSkUnitsFilter": "m",
+            "pathType": "number",
+            "sampleTime": 500,
+            "showPathSkUnitsFilter": false,
+            "source": "default"
+          },
+          "startTimePath": {
+            "description": "Time of the start",
+            "isPathConfigurable": false,
+            "path": "self.navigation.racing.startTime",
+            "pathRequired": false,
+            "pathType": "Date",
+            "sampleTime": 500,
+            "source": "default"
+          },
+          "ttsPath": {
+            "convertUnitTo": "s",
+            "description": "Time to the Start in seconds",
+            "isPathConfigurable": false,
+            "path": "self.navigation.racing.timeToStart",
+            "pathRequired": false,
+            "pathSkUnitsFilter": "s",
+            "pathType": "number",
+            "sampleTime": 500,
+            "showConvertUnitTo": false,
+            "showPathSkUnitsFilter": false,
+            "source": "default"
+          }
+        },
+        "playBeeps": true,
+        "supportAutomaticHistoricalSeries": false
+      },
+      "defaultHeight": 4,
+      "defaultWidth": 4,
+      "description": "An advanced racing countdown timer that indicates OCS (On Course Side) status. Set the start line, choose or adjust the duration, or specify the exact start time. Automatically switches to the target dashboard at the start unless over early.",
+      "icon": "racertimerWidget",
+      "minHeight": 4,
+      "minWidth": 4,
+      "name": "Racer - Start Timer",
+      "pathSlots": [
+        {
+          "defaultConvertUnitTo": "s",
+          "defaultPath": "self.navigation.racing.timeToStart",
+          "description": "Time to the Start in seconds",
+          "expectedSkUnit": "s",
+          "isPathConfigurable": false,
+          "pathRequired": false,
+          "pathType": "number",
+          "sampleTime": 500,
+          "slot": "ttsPath",
+          "source": "default"
+        },
+        {
+          "defaultConvertUnitTo": null,
+          "defaultPath": "self.navigation.racing.startTime",
+          "description": "Time of the start",
+          "expectedSkUnit": null,
+          "isPathConfigurable": false,
+          "pathRequired": false,
+          "pathType": "Date",
+          "sampleTime": 500,
+          "slot": "startTimePath",
+          "source": "default"
+        },
+        {
+          "defaultConvertUnitTo": "m",
+          "defaultPath": "self.navigation.racing.distanceStartline",
+          "description": "Distance to Start Line path, used to determine OCS",
+          "expectedSkUnit": "m",
+          "isPathConfigurable": false,
+          "pathRequired": false,
+          "pathType": "number",
+          "sampleTime": 500,
+          "slot": "dtsPath",
+          "source": "default"
+        }
+      ],
+      "requiredPlugins": [
+        "signalk-racer"
+      ],
+      "selector": "widget-racer-timer"
+    },
+    {
+      "bindingKind": "paths-record",
+      "category": "Racing",
+      "componentClassName": "WidgetRacesteerComponent",
+      "defaultConfig": {
+        "awsEnable": true,
+        "courseOverGroundEnable": true,
+        "dataTimeout": 5,
+        "driftEnable": true,
+        "enableTimeout": false,
+        "filterSelfPaths": true,
+        "laylineAngle": 40,
+        "laylineEnable": true,
+        "paths": {
+          "VMG": {
+            "convertUnitTo": "knots",
+            "description": "Velocity Made Good",
+            "isPathConfigurable": false,
+            "path": "self.performance.velocityMadeGood",
+            "pathRequired": false,
+            "pathType": "number",
+            "sampleTime": 500,
+            "source": "default"
+          },
+          "appWindAngle": {
+            "convertUnitTo": "deg",
+            "description": "Apparent Wind Angle",
+            "isPathConfigurable": true,
+            "path": "self.environment.wind.angleApparent",
+            "pathSkUnitsFilter": "rad",
+            "pathType": "number",
+            "sampleTime": 500,
+            "source": "default"
+          },
+          "appWindSpeed": {
+            "convertUnitTo": "knots",
+            "description": "Apparent Wind Speed",
+            "isPathConfigurable": true,
+            "path": "self.environment.wind.speedApparent",
+            "pathSkUnitsFilter": "m/s",
+            "pathType": "number",
+            "sampleTime": 500,
+            "source": "default"
+          },
+          "courseOverGround": {
+            "convertUnitTo": "deg",
+            "description": "True Course Over Ground",
+            "isPathConfigurable": true,
+            "path": "self.navigation.courseOverGroundTrue",
+            "pathRequired": false,
+            "pathSkUnitsFilter": "rad",
+            "pathType": "number",
+            "sampleTime": 500,
+            "source": "default"
+          },
+          "drift": {
+            "convertUnitTo": "knots",
+            "description": "Drift Speed Impact",
+            "isPathConfigurable": true,
+            "path": "self.environment.current.drift",
+            "pathRequired": false,
+            "pathSkUnitsFilter": "m/s",
+            "pathType": "number",
+            "sampleTime": 500,
+            "source": "default"
+          },
+          "headingPath": {
+            "convertUnitTo": "deg",
+            "description": "True Heading",
+            "isPathConfigurable": true,
+            "path": "self.navigation.headingTrue",
+            "pathSkUnitsFilter": "rad",
+            "pathType": "number",
+            "sampleTime": 500,
+            "source": "default"
+          },
+          "nextWaypointBearing": {
+            "convertUnitTo": "deg",
+            "description": "Next Waypoint True Bearing",
+            "isPathConfigurable": true,
+            "path": "self.navigation.course.calcValues.bearingTrue",
+            "pathRequired": false,
+            "pathSkUnitsFilter": "rad",
+            "pathType": "number",
+            "sampleTime": 500,
+            "source": "default"
+          },
+          "optimalWindAngle": {
+            "convertUnitTo": "deg",
+            "description": "Optimal Wind Angle",
+            "isPathConfigurable": false,
+            "path": "self.performance.optimumWindAngle",
+            "pathRequired": false,
+            "pathType": "number",
+            "sampleTime": 500,
+            "source": "default"
+          },
+          "polarSpeedRatio": {
+            "convertUnitTo": "ratio",
+            "description": "Polar Speed Ratio",
+            "isPathConfigurable": false,
+            "path": "self.performance.polarSpeedRatio",
+            "pathRequired": false,
+            "pathType": "number",
+            "sampleTime": 500,
+            "source": "default"
+          },
+          "set": {
+            "convertUnitTo": "deg",
+            "description": "True Drift Set",
+            "isPathConfigurable": true,
+            "path": "self.environment.current.setTrue",
+            "pathRequired": false,
+            "pathSkUnitsFilter": "rad",
+            "pathType": "number",
+            "sampleTime": 500,
+            "source": "default"
+          },
+          "tackTrue": {
+            "convertUnitTo": "deg",
+            "description": "True Tack",
+            "isPathConfigurable": false,
+            "path": "self.performance.tackTrue",
+            "pathRequired": true,
+            "pathSkUnitsFilter": "rad",
+            "pathType": "number",
+            "sampleTime": 500,
+            "source": "default"
+          },
+          "targetAngle": {
+            "convertUnitTo": "deg",
+            "description": "Target Angle",
+            "isPathConfigurable": false,
+            "path": "self.performance.targetAngle",
+            "pathRequired": false,
+            "pathType": "number",
+            "sampleTime": 500,
+            "source": "default"
+          },
+          "targetVMG": {
+            "convertUnitTo": "knots",
+            "description": "Target Velocity Made Good",
+            "isPathConfigurable": false,
+            "path": "self.performance.targetVelocityMadeGood",
+            "pathRequired": false,
+            "pathType": "number",
+            "sampleTime": 500,
+            "source": "default"
+          },
+          "trueWindAngle": {
+            "convertUnitTo": "deg",
+            "description": "True Wind Angle",
+            "isPathConfigurable": true,
+            "path": "self.environment.wind.angleTrueWater",
+            "pathRequired": false,
+            "pathSkUnitsFilter": "rad",
+            "pathType": "number",
+            "sampleTime": 500,
+            "source": "default"
+          },
+          "trueWindSpeed": {
+            "convertUnitTo": "knots",
+            "description": "True Wind Speed",
+            "isPathConfigurable": true,
+            "path": "self.environment.wind.speedTrue",
+            "pathRequired": false,
+            "pathSkUnitsFilter": "m/s",
+            "pathType": "number",
+            "sampleTime": 500,
+            "source": "default"
+          },
+          "vmgToWaypoint": {
+            "convertUnitTo": "knots",
+            "description": "Velocity Made Good to Waypoint",
+            "isPathConfigurable": false,
+            "path": "self.performance.velocityMadeGoodToWaypoint",
+            "pathRequired": false,
+            "pathType": "number",
+            "sampleTime": 500,
+            "source": "default"
+          }
+        },
+        "sailSetupEnable": false,
+        "supportAutomaticHistoricalSeries": false,
+        "twsEnable": true,
+        "waypointEnable": true,
+        "windSectorEnable": true,
+        "windSectorWindowSeconds": 5
+      },
+      "defaultHeight": 6,
+      "defaultWidth": 4,
+      "description": "A dynamic race steering display that fuses polar performance data with live conditions to guide optimal steering, tacking, and gybing angles for maximum speed. Instantly compare performance against competition polars for smarter tactical decisions.",
+      "icon": "racesteeringWidget",
+      "minHeight": 2,
+      "minWidth": 1,
+      "name": "Racesteer (BETA)",
+      "pathSlots": [
+        {
+          "defaultConvertUnitTo": "deg",
+          "defaultPath": "self.navigation.headingTrue",
+          "description": "True Heading",
+          "expectedSkUnit": "rad",
+          "isPathConfigurable": true,
+          "pathRequired": false,
+          "pathType": "number",
+          "sampleTime": 500,
+          "slot": "headingPath",
+          "source": "default"
+        },
+        {
+          "defaultConvertUnitTo": "deg",
+          "defaultPath": "self.performance.tackTrue",
+          "description": "True Tack",
+          "expectedSkUnit": "rad",
+          "isPathConfigurable": false,
+          "pathRequired": true,
+          "pathType": "number",
+          "sampleTime": 500,
+          "slot": "tackTrue",
+          "source": "default"
+        },
+        {
+          "defaultConvertUnitTo": "ratio",
+          "defaultPath": "self.performance.polarSpeedRatio",
+          "description": "Polar Speed Ratio",
+          "expectedSkUnit": null,
+          "isPathConfigurable": false,
+          "pathRequired": false,
+          "pathType": "number",
+          "sampleTime": 500,
+          "slot": "polarSpeedRatio",
+          "source": "default"
+        },
+        {
+          "defaultConvertUnitTo": "deg",
+          "defaultPath": "self.performance.targetAngle",
+          "description": "Target Angle",
+          "expectedSkUnit": null,
+          "isPathConfigurable": false,
+          "pathRequired": false,
+          "pathType": "number",
+          "sampleTime": 500,
+          "slot": "targetAngle",
+          "source": "default"
+        },
+        {
+          "defaultConvertUnitTo": "deg",
+          "defaultPath": "self.performance.optimumWindAngle",
+          "description": "Optimal Wind Angle",
+          "expectedSkUnit": null,
+          "isPathConfigurable": false,
+          "pathRequired": false,
+          "pathType": "number",
+          "sampleTime": 500,
+          "slot": "optimalWindAngle",
+          "source": "default"
+        },
+        {
+          "defaultConvertUnitTo": "knots",
+          "defaultPath": "self.performance.targetVelocityMadeGood",
+          "description": "Target Velocity Made Good",
+          "expectedSkUnit": null,
+          "isPathConfigurable": false,
+          "pathRequired": false,
+          "pathType": "number",
+          "sampleTime": 500,
+          "slot": "targetVMG",
+          "source": "default"
+        },
+        {
+          "defaultConvertUnitTo": "knots",
+          "defaultPath": "self.performance.velocityMadeGood",
+          "description": "Velocity Made Good",
+          "expectedSkUnit": null,
+          "isPathConfigurable": false,
+          "pathRequired": false,
+          "pathType": "number",
+          "sampleTime": 500,
+          "slot": "VMG",
+          "source": "default"
+        },
+        {
+          "defaultConvertUnitTo": "deg",
+          "defaultPath": "self.environment.wind.angleApparent",
+          "description": "Apparent Wind Angle",
+          "expectedSkUnit": "rad",
+          "isPathConfigurable": true,
+          "pathRequired": false,
+          "pathType": "number",
+          "sampleTime": 500,
+          "slot": "appWindAngle",
+          "source": "default"
+        },
+        {
+          "defaultConvertUnitTo": "knots",
+          "defaultPath": "self.environment.wind.speedApparent",
+          "description": "Apparent Wind Speed",
+          "expectedSkUnit": "m/s",
+          "isPathConfigurable": true,
+          "pathRequired": false,
+          "pathType": "number",
+          "sampleTime": 500,
+          "slot": "appWindSpeed",
+          "source": "default"
+        },
+        {
+          "defaultConvertUnitTo": "deg",
+          "defaultPath": "self.environment.wind.angleTrueWater",
+          "description": "True Wind Angle",
+          "expectedSkUnit": "rad",
+          "isPathConfigurable": true,
+          "pathRequired": false,
+          "pathType": "number",
+          "sampleTime": 500,
+          "slot": "trueWindAngle",
+          "source": "default"
+        },
+        {
+          "defaultConvertUnitTo": "knots",
+          "defaultPath": "self.environment.wind.speedTrue",
+          "description": "True Wind Speed",
+          "expectedSkUnit": "m/s",
+          "isPathConfigurable": true,
+          "pathRequired": false,
+          "pathType": "number",
+          "sampleTime": 500,
+          "slot": "trueWindSpeed",
+          "source": "default"
+        },
+        {
+          "defaultConvertUnitTo": "deg",
+          "defaultPath": "self.navigation.courseOverGroundTrue",
+          "description": "True Course Over Ground",
+          "expectedSkUnit": "rad",
+          "isPathConfigurable": true,
+          "pathRequired": false,
+          "pathType": "number",
+          "sampleTime": 500,
+          "slot": "courseOverGround",
+          "source": "default"
+        },
+        {
+          "defaultConvertUnitTo": "deg",
+          "defaultPath": "self.navigation.course.calcValues.bearingTrue",
+          "description": "Next Waypoint True Bearing",
+          "expectedSkUnit": "rad",
+          "isPathConfigurable": true,
+          "pathRequired": false,
+          "pathType": "number",
+          "sampleTime": 500,
+          "slot": "nextWaypointBearing",
+          "source": "default"
+        },
+        {
+          "defaultConvertUnitTo": "knots",
+          "defaultPath": "self.performance.velocityMadeGoodToWaypoint",
+          "description": "Velocity Made Good to Waypoint",
+          "expectedSkUnit": null,
+          "isPathConfigurable": false,
+          "pathRequired": false,
+          "pathType": "number",
+          "sampleTime": 500,
+          "slot": "vmgToWaypoint",
+          "source": "default"
+        },
+        {
+          "defaultConvertUnitTo": "deg",
+          "defaultPath": "self.environment.current.setTrue",
+          "description": "True Drift Set",
+          "expectedSkUnit": "rad",
+          "isPathConfigurable": true,
+          "pathRequired": false,
+          "pathType": "number",
+          "sampleTime": 500,
+          "slot": "set",
+          "source": "default"
+        },
+        {
+          "defaultConvertUnitTo": "knots",
+          "defaultPath": "self.environment.current.drift",
+          "description": "Drift Speed Impact",
+          "expectedSkUnit": "m/s",
+          "isPathConfigurable": true,
+          "pathRequired": false,
+          "pathType": "number",
+          "sampleTime": 500,
+          "slot": "drift",
+          "source": "default"
+        }
+      ],
+      "requiredPlugins": [
+        "signalk-polar-performance-plugin"
+      ],
+      "selector": "widget-racesteer"
+    },
+    {
+      "bindingKind": "none",
+      "category": "Racing",
+      "componentClassName": "WidgetRaceTimerComponent",
+      "defaultConfig": {
+        "color": "contrast",
+        "playBeeps": true,
+        "timerLength": -300
+      },
+      "defaultHeight": 7,
+      "defaultWidth": 6,
+      "description": "A simple race start countdown timer that can be started, paused, synced, reset, and configured for duration.",
+      "icon": "racetimerWidget",
+      "minHeight": 4,
+      "minWidth": 4,
+      "name": "Countdown Timer",
+      "pathSlots": [],
+      "requiredPlugins": [],
+      "selector": "widget-racetimer"
+    },
+    {
+      "bindingKind": "paths-record",
+      "category": "Gauge",
+      "componentClassName": "WidgetSimpleLinearComponent",
+      "defaultConfig": {
+        "color": "contrast",
+        "dataTimeout": 5,
+        "displayName": "Gauge Label",
+        "displayScale": {
+          "lower": 0,
+          "type": "linear",
+          "upper": 15
+        },
+        "enableTimeout": false,
+        "filterSelfPaths": true,
+        "gauge": {
+          "type": "simpleLinear",
+          "unitLabelFormat": "full"
+        },
+        "ignoreZones": false,
+        "numDecimal": 2,
+        "numInt": 1,
+        "paths": {
+          "gaugePath": {
+            "convertUnitTo": "V",
+            "description": "Numeric Data",
+            "isPathConfigurable": true,
+            "path": null,
+            "pathSkUnitsFilter": "V",
+            "pathType": "number",
+            "sampleTime": 500,
+            "showPathSkUnitsFilter": true,
+            "source": null
+          }
+        },
+        "supportAutomaticHistoricalSeries": true
+      },
+      "defaultHeight": 6,
+      "defaultWidth": 4,
+      "description": "A simple horizontal linear gauge with a large value label offering a clean, compact modern look.",
+      "icon": "simpleLinearGauge",
+      "minHeight": 2,
+      "minWidth": 1,
+      "name": "Compact Linear",
+      "pathSlots": [
+        {
+          "defaultConvertUnitTo": "V",
+          "defaultPath": null,
+          "description": "Numeric Data",
+          "expectedSkUnit": "V",
+          "isPathConfigurable": true,
+          "pathRequired": false,
+          "pathType": "number",
+          "sampleTime": 500,
+          "slot": "gaugePath",
+          "source": null
+        }
+      ],
+      "requiredPlugins": [],
+      "selector": "widget-simple-linear"
+    },
+    {
+      "bindingKind": "paths-record",
+      "category": "Core",
+      "componentClassName": "WidgetSliderComponent",
+      "defaultConfig": {
+        "color": "contrast",
+        "dataTimeout": 5,
+        "displayName": "Slider Label",
+        "displayScale": {
+          "lower": 0,
+          "type": "linear",
+          "upper": 1
+        },
+        "enableTimeout": false,
+        "filterSelfPaths": true,
+        "paths": {
+          "gaugePath": {
+            "convertUnitTo": null,
+            "description": "PUT Supported Numeric Path. IMPORTANT: Format must be set to (base)",
+            "isPathConfigurable": true,
+            "path": null,
+            "pathSkUnitsFilter": null,
+            "pathType": "number",
+            "sampleTime": 500,
+            "showConvertUnitTo": false,
+            "showPathSkUnitsFilter": false,
+            "source": null,
+            "supportsPut": true
+          }
+        },
+        "supportAutomaticHistoricalSeries": false
+      },
+      "defaultHeight": 4,
+      "defaultWidth": 4,
+      "description": "A Digital Switching range slider that allows users to adjust values, such as controlling lighting intensity or audio volume from 0% to 100%.",
+      "icon": "sliderWidget",
+      "minHeight": 2,
+      "minWidth": 2,
+      "name": "Slider",
+      "pathSlots": [
+        {
+          "defaultConvertUnitTo": null,
+          "defaultPath": null,
+          "description": "PUT Supported Numeric Path. IMPORTANT: Format must be set to (base)",
+          "expectedSkUnit": null,
+          "isPathConfigurable": true,
+          "pathRequired": false,
+          "pathType": "number",
+          "sampleTime": 500,
+          "slot": "gaugePath",
+          "source": null
+        }
+      ],
+      "requiredPlugins": [],
+      "selector": "widget-slider"
+    },
+    {
+      "bindingKind": "none",
+      "category": "Gauge",
+      "componentClassName": "WidgetSolarChargerComponent",
+      "defaultConfig": {
+        "color": "contrast",
+        "ignoreZones": false,
+        "solarCharger": {
+          "optionsById": {},
+          "trackedDevices": []
+        }
+      },
+      "defaultHeight": 6,
+      "defaultWidth": 6,
+      "description": "Track solar generation and charging performance at a glance with live panel output, battery-side metrics, and clear charger and relay status indicators.",
+      "icon": "solar_charger",
+      "minHeight": 2,
+      "minWidth": 2,
+      "name": "Solar Charger",
+      "pathSlots": [],
+      "requiredPlugins": [],
+      "selector": "widget-solar-charger"
+    },
+    {
+      "bindingKind": "paths-record",
+      "category": "Core",
+      "componentClassName": "WidgetTextComponent",
+      "defaultConfig": {
+        "color": "contrast",
+        "dataTimeout": 5,
+        "displayName": "Gauge Label",
+        "enableTimeout": false,
+        "filterSelfPaths": true,
+        "paths": {
+          "stringPath": {
+            "description": "String Data",
+            "isPathConfigurable": true,
+            "path": null,
+            "pathType": "string",
+            "sampleTime": 500,
+            "source": null
+          }
+        }
+      },
+      "defaultHeight": 6,
+      "defaultWidth": 4,
+      "description": "Displays text data with a customizable color formatting option.",
+      "icon": "textWidget",
+      "minHeight": 2,
+      "minWidth": 1,
+      "name": "Text",
+      "pathSlots": [
+        {
+          "defaultConvertUnitTo": null,
+          "defaultPath": null,
+          "description": "String Data",
+          "expectedSkUnit": null,
+          "isPathConfigurable": true,
+          "pathRequired": false,
+          "pathType": "string",
+          "sampleTime": 500,
+          "slot": "stringPath",
+          "source": null
+        }
+      ],
+      "requiredPlugins": [],
+      "selector": "widget-text"
+    },
+    {
+      "bindingKind": "none",
+      "category": "Component",
+      "componentClassName": "WidgetTutorialComponent",
+      "defaultConfig": {
+        "filterSelfPaths": true
+      },
+      "defaultHeight": 6,
+      "defaultWidth": 4,
+      "description": "An instructional widget that guides new users through basic navigation, gestures, and dashboard editing steps.",
+      "icon": "helpWidget",
+      "minHeight": 4,
+      "minWidth": 4,
+      "name": "Tutorial",
+      "pathSlots": [],
+      "requiredPlugins": [],
+      "selector": "widget-tutorial"
+    },
+    {
+      "bindingKind": "paths-record",
+      "category": "Component",
+      "componentClassName": "WidgetWindComponent",
+      "defaultConfig": {
+        "awsEnable": true,
+        "compassModeEnabled": true,
+        "courseOverGroundEnable": true,
+        "dataTimeout": 5,
+        "driftEnable": true,
+        "enableTimeout": false,
+        "filterSelfPaths": true,
+        "laylineAngle": 40,
+        "laylineEnable": true,
+        "paths": {
+          "appWindAngle": {
+            "convertUnitTo": "deg",
+            "description": "Apparent Wind Angle",
+            "isPathConfigurable": true,
+            "path": "self.environment.wind.angleApparent",
+            "pathRequired": true,
+            "pathSkUnitsFilter": "rad",
+            "pathType": "number",
+            "sampleTime": 1000,
+            "showConvertUnitTo": false,
+            "showPathSkUnitsFilter": false,
+            "source": "default"
+          },
+          "appWindSpeed": {
+            "convertUnitTo": "knots",
+            "description": "Apparent Wind Speed",
+            "isPathConfigurable": true,
+            "path": "self.environment.wind.speedApparent",
+            "pathRequired": true,
+            "pathSkUnitsFilter": "m/s",
+            "pathType": "number",
+            "sampleTime": 1000,
+            "showPathSkUnitsFilter": false,
+            "source": "default"
+          },
+          "courseOverGround": {
+            "convertUnitTo": "deg",
+            "description": "True Course Over Ground",
+            "isPathConfigurable": true,
+            "path": "self.navigation.courseOverGroundTrue",
+            "pathRequired": false,
+            "pathSkUnitsFilter": "rad",
+            "pathType": "number",
+            "sampleTime": 1000,
+            "showConvertUnitTo": false,
+            "showPathSkUnitsFilter": false,
+            "source": "default"
+          },
+          "drift": {
+            "convertUnitTo": "knots",
+            "description": "Drift Speed Impact",
+            "isPathConfigurable": true,
+            "path": "self.environment.current.drift",
+            "pathRequired": false,
+            "pathSkUnitsFilter": "m/s",
+            "pathType": "number",
+            "sampleTime": 1000,
+            "showPathSkUnitsFilter": false,
+            "source": "default"
+          },
+          "headingPath": {
+            "convertUnitTo": "deg",
+            "description": "True Heading",
+            "isPathConfigurable": true,
+            "path": "self.navigation.headingTrue",
+            "pathRequired": true,
+            "pathSkUnitsFilter": "rad",
+            "pathType": "number",
+            "sampleTime": 1000,
+            "showConvertUnitTo": false,
+            "showPathSkUnitsFilter": false,
+            "source": "default"
+          },
+          "nextWaypointBearing": {
+            "convertUnitTo": "deg",
+            "description": "Next Waypoint True Bearing",
+            "isPathConfigurable": false,
+            "path": "self.navigation.course.calcValues.bearingTrue",
+            "pathRequired": false,
+            "pathSkUnitsFilter": "rad",
+            "pathType": "number",
+            "sampleTime": 1000,
+            "showConvertUnitTo": false,
+            "showPathSkUnitsFilter": false,
+            "source": "default"
+          },
+          "set": {
+            "convertUnitTo": "deg",
+            "description": "True Drift Set",
+            "isPathConfigurable": true,
+            "path": "self.environment.current.setTrue",
+            "pathRequired": false,
+            "pathSkUnitsFilter": "rad",
+            "pathType": "number",
+            "sampleTime": 1000,
+            "showConvertUnitTo": false,
+            "showPathSkUnitsFilter": false,
+            "source": "default"
+          },
+          "trueWindAngle": {
+            "convertUnitTo": "deg",
+            "description": "True Wind Angle",
+            "isPathConfigurable": true,
+            "path": "self.environment.wind.angleTrueWater",
+            "pathRequired": false,
+            "pathSkUnitsFilter": "rad",
+            "pathType": "number",
+            "sampleTime": 1000,
+            "showConvertUnitTo": false,
+            "showPathSkUnitsFilter": false,
+            "source": "default"
+          },
+          "trueWindSpeed": {
+            "convertUnitTo": "knots",
+            "description": "True Wind Speed",
+            "isPathConfigurable": true,
+            "path": "self.environment.wind.speedTrue",
+            "pathRequired": false,
+            "pathSkUnitsFilter": "m/s",
+            "pathType": "number",
+            "sampleTime": 1000,
+            "showPathSkUnitsFilter": false,
+            "source": "default"
+          }
+        },
+        "sailSetupEnable": false,
+        "supportAutomaticHistoricalSeries": false,
+        "twaEnable": true,
+        "twsEnable": true,
+        "waypointEnable": true,
+        "windSectorEnable": true,
+        "windSectorWindowSeconds": 5
+      },
+      "defaultHeight": 6,
+      "defaultWidth": 4,
+      "description": "A wind steering display that combines wind, wind sectors, heading, course over ground and next waypoint information.",
+      "icon": "windsteeringWidget",
+      "minHeight": 2,
+      "minWidth": 1,
+      "name": "Windsteer",
+      "pathSlots": [
+        {
+          "defaultConvertUnitTo": "deg",
+          "defaultPath": "self.navigation.headingTrue",
+          "description": "True Heading",
+          "expectedSkUnit": "rad",
+          "isPathConfigurable": true,
+          "pathRequired": true,
+          "pathType": "number",
+          "sampleTime": 1000,
+          "slot": "headingPath",
+          "source": "default"
+        },
+        {
+          "defaultConvertUnitTo": "deg",
+          "defaultPath": "self.environment.wind.angleApparent",
+          "description": "Apparent Wind Angle",
+          "expectedSkUnit": "rad",
+          "isPathConfigurable": true,
+          "pathRequired": true,
+          "pathType": "number",
+          "sampleTime": 1000,
+          "slot": "appWindAngle",
+          "source": "default"
+        },
+        {
+          "defaultConvertUnitTo": "knots",
+          "defaultPath": "self.environment.wind.speedApparent",
+          "description": "Apparent Wind Speed",
+          "expectedSkUnit": "m/s",
+          "isPathConfigurable": true,
+          "pathRequired": true,
+          "pathType": "number",
+          "sampleTime": 1000,
+          "slot": "appWindSpeed",
+          "source": "default"
+        },
+        {
+          "defaultConvertUnitTo": "deg",
+          "defaultPath": "self.environment.wind.angleTrueWater",
+          "description": "True Wind Angle",
+          "expectedSkUnit": "rad",
+          "isPathConfigurable": true,
+          "pathRequired": false,
+          "pathType": "number",
+          "sampleTime": 1000,
+          "slot": "trueWindAngle",
+          "source": "default"
+        },
+        {
+          "defaultConvertUnitTo": "knots",
+          "defaultPath": "self.environment.wind.speedTrue",
+          "description": "True Wind Speed",
+          "expectedSkUnit": "m/s",
+          "isPathConfigurable": true,
+          "pathRequired": false,
+          "pathType": "number",
+          "sampleTime": 1000,
+          "slot": "trueWindSpeed",
+          "source": "default"
+        },
+        {
+          "defaultConvertUnitTo": "deg",
+          "defaultPath": "self.navigation.courseOverGroundTrue",
+          "description": "True Course Over Ground",
+          "expectedSkUnit": "rad",
+          "isPathConfigurable": true,
+          "pathRequired": false,
+          "pathType": "number",
+          "sampleTime": 1000,
+          "slot": "courseOverGround",
+          "source": "default"
+        },
+        {
+          "defaultConvertUnitTo": "deg",
+          "defaultPath": "self.navigation.course.calcValues.bearingTrue",
+          "description": "Next Waypoint True Bearing",
+          "expectedSkUnit": "rad",
+          "isPathConfigurable": false,
+          "pathRequired": false,
+          "pathType": "number",
+          "sampleTime": 1000,
+          "slot": "nextWaypointBearing",
+          "source": "default"
+        },
+        {
+          "defaultConvertUnitTo": "deg",
+          "defaultPath": "self.environment.current.setTrue",
+          "description": "True Drift Set",
+          "expectedSkUnit": "rad",
+          "isPathConfigurable": true,
+          "pathRequired": false,
+          "pathType": "number",
+          "sampleTime": 1000,
+          "slot": "set",
+          "source": "default"
+        },
+        {
+          "defaultConvertUnitTo": "knots",
+          "defaultPath": "self.environment.current.drift",
+          "description": "Drift Speed Impact",
+          "expectedSkUnit": "m/s",
+          "isPathConfigurable": true,
+          "pathRequired": false,
+          "pathType": "number",
+          "sampleTime": 1000,
+          "slot": "drift",
+          "source": "default"
+        }
+      ],
+      "requiredPlugins": [],
+      "selector": "widget-wind-steer"
+    },
+    {
+      "bindingKind": "none",
+      "category": "Racing",
+      "componentClassName": "WidgetWindTrendsChartComponent",
+      "defaultConfig": {
+        "color": "contrast",
+        "filterSelfPaths": true,
+        "timeScale": "Last 30 Minutes"
+      },
+      "defaultHeight": 8,
+      "defaultWidth": 10,
+      "description": "A real-time wind trends graph with dual axes for direction and speed. Displays live values and simple moving averages over the current period’s average.",
+      "icon": "windtrendsWidget",
+      "minHeight": 6,
+      "minWidth": 8,
+      "name": "Wind Trends",
+      "pathSlots": [],
+      "requiredPlugins": [],
+      "selector": "widget-windtrends-chart"
+    },
+    {
+      "bindingKind": "paths-array",
+      "category": "Core",
+      "componentClassName": "WidgetZonesStatePanelComponent",
+      "defaultConfig": {
+        "color": "contrast",
+        "dataTimeout": 5,
+        "displayName": "Zones State Panel Label",
+        "enableTimeout": false,
+        "filterSelfPaths": true,
+        "multiChildCtrls": [],
+        "paths": [],
+        "putEnable": false,
+        "putMomentary": false,
+        "showLabel": true,
+        "zonesOnlyPaths": true
+      },
+      "defaultHeight": 6,
+      "defaultWidth": 4,
+      "description": "Displays the data state (severity and message) of the path's Zones (based on Signal K path metadata configuration).",
+      "icon": "zonesStatePanel",
+      "minHeight": 2,
+      "minWidth": 1,
+      "name": "Zones State Panel",
+      "pathSlots": [],
+      "requiredPlugins": [],
+      "selector": "widget-zones-state-panel"
+    }
+  ]
+}

--- a/src/assets/kip-dashboard-schema.json
+++ b/src/assets/kip-dashboard-schema.json
@@ -2,34 +2,42 @@
   "designSystem": {
     "colors": [
       {
+        "hex": "#FFFFFF",
         "label": "Contrast",
         "value": "contrast"
       },
       {
+        "hex": "#3298ff",
         "label": "Blue",
         "value": "blue"
       },
       {
+        "hex": "#00d000",
         "label": "Green",
         "value": "green"
       },
       {
+        "hex": "#ff9100",
         "label": "Orange",
         "value": "orange"
       },
       {
+        "hex": "#ffdf00",
         "label": "Yellow",
         "value": "yellow"
       },
       {
+        "hex": "#FC0FC0",
         "label": "Pink",
         "value": "pink"
       },
       {
+        "hex": "#A020F0",
         "label": "Purple",
         "value": "purple"
       },
       {
+        "hex": "#B5B5B5",
         "label": "Grey",
         "value": "grey"
       }

--- a/tools/gen-mcp-schema/ast.ts
+++ b/tools/gen-mcp-schema/ast.ts
@@ -108,6 +108,54 @@ export function findArrayLiteral(sourceFile: ts.SourceFile, propName: string): t
 }
 
 /**
+ * Returns the initializer expression of the first property/variable named
+ * `propName`, regardless of its kind (object, call, array, ...). Throws if not found.
+ */
+export function findPropertyInitializer(sourceFile: ts.SourceFile, propName: string): ts.Expression {
+  let result: ts.Expression | undefined;
+
+  const visit = (node: ts.Node): void => {
+    if (result) return;
+    if (
+      (ts.isPropertyDeclaration(node) ||
+        ts.isPropertyAssignment(node) ||
+        ts.isVariableDeclaration(node)) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === propName &&
+      node.initializer
+    ) {
+      result = node.initializer;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  if (!result) {
+    throw new Error(`Could not find an initializer named "${propName}" in ${sourceFile.fileName}`);
+  }
+  return result;
+}
+
+/**
+ * Maps an object literal's property assignments to name -> initializer. Skips
+ * spreads, shorthand and methods. Lets callers read only the literal keys they
+ * care about, tolerating non-literal siblings.
+ */
+export function getObjectProperties(node: ts.ObjectLiteralExpression): Map<string, ts.Expression> {
+  const props = new Map<string, ts.Expression>();
+  for (const member of node.properties) {
+    if (
+      ts.isPropertyAssignment(member) &&
+      (ts.isIdentifier(member.name) || ts.isStringLiteralLike(member.name))
+    ) {
+      props.set(member.name.text, member.initializer);
+    }
+  }
+  return props;
+}
+
+/**
  * Returns the module specifier a named import comes from, e.g. for
  * `import { WidgetNumericComponent } from '../../widgets/.../x.component'`
  * returns `../../widgets/.../x.component`. Throws if the import is not found.

--- a/tools/gen-mcp-schema/ast.ts
+++ b/tools/gen-mcp-schema/ast.ts
@@ -106,3 +106,74 @@ export function findArrayLiteral(sourceFile: ts.SourceFile, propName: string): t
   }
   return found;
 }
+
+/**
+ * Returns the module specifier a named import comes from, e.g. for
+ * `import { WidgetNumericComponent } from '../../widgets/.../x.component'`
+ * returns `../../widgets/.../x.component`. Throws if the import is not found.
+ */
+export function findImportModuleSpecifier(sourceFile: ts.SourceFile, importedName: string): string {
+  let specifier: string | undefined;
+
+  const visit = (node: ts.Node): void => {
+    if (specifier) return;
+    if (
+      ts.isImportDeclaration(node) &&
+      node.importClause?.namedBindings &&
+      ts.isNamedImports(node.importClause.namedBindings) &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      for (const element of node.importClause.namedBindings.elements) {
+        if (element.name.text === importedName) {
+          specifier = (node.moduleSpecifier as ts.StringLiteral).text;
+          return;
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  if (specifier === undefined) {
+    throw new Error(`Could not find an import for "${importedName}" in ${sourceFile.fileName}`);
+  }
+  return specifier;
+}
+
+/**
+ * Returns the initializer expression of a class's `static` property, e.g. a
+ * widget component's `static readonly DEFAULT_CONFIG = { ... }`. Throws if the
+ * class or the static property is not found.
+ */
+export function findStaticPropertyInitializer(
+  sourceFile: ts.SourceFile,
+  className: string,
+  propName: string,
+): ts.Expression {
+  let initializer: ts.Expression | undefined;
+
+  const visit = (node: ts.Node): void => {
+    if (initializer) return;
+    if (ts.isClassDeclaration(node) && node.name?.text === className) {
+      for (const member of node.members) {
+        if (
+          ts.isPropertyDeclaration(member) &&
+          ts.isIdentifier(member.name) &&
+          member.name.text === propName &&
+          member.modifiers?.some((m) => m.kind === ts.SyntaxKind.StaticKeyword) &&
+          member.initializer
+        ) {
+          initializer = member.initializer;
+          return;
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  if (!initializer) {
+    throw new Error(`Could not find static "${propName}" on class "${className}" in ${sourceFile.fileName}`);
+  }
+  return initializer;
+}

--- a/tools/gen-mcp-schema/ast.ts
+++ b/tools/gen-mcp-schema/ast.ts
@@ -1,0 +1,108 @@
+/**
+ * Small helpers for reading static literals out of KIP source with the
+ * TypeScript Compiler API.
+ *
+ * KIP already depends on `typescript`, so the generator uses the compiler API
+ * directly (no extra dependency). We only ever parse syntactically and read
+ * literal values — Angular components are never executed.
+ */
+import * as fs from 'node:fs';
+import * as ts from 'typescript';
+
+/** Parses a source file syntactically (no type-checking, no program). */
+export function parseSourceFile(filePath: string): ts.SourceFile {
+  const content = fs.readFileSync(filePath, 'utf8');
+  return ts.createSourceFile(filePath, content, ts.ScriptTarget.Latest, /* setParentNodes */ true);
+}
+
+/**
+ * Converts a literal expression node to a plain JS value.
+ *
+ * Supports strings, numbers (incl. unary minus), booleans, null, arrays and
+ * object literals. Anything else (an identifier, function call, spread, computed
+ * value, ...) throws — the generator fails loudly rather than emitting a wrong
+ * default.
+ */
+export function literalToValue(node: ts.Expression): unknown {
+  if (ts.isStringLiteralLike(node)) return node.text;
+  if (ts.isNumericLiteral(node)) return Number(node.text);
+
+  switch (node.kind) {
+    case ts.SyntaxKind.TrueKeyword:
+      return true;
+    case ts.SyntaxKind.FalseKeyword:
+      return false;
+    case ts.SyntaxKind.NullKeyword:
+      return null;
+  }
+
+  if (ts.isParenthesizedExpression(node)) {
+    return literalToValue(node.expression);
+  }
+
+  if (ts.isPrefixUnaryExpression(node) && node.operator === ts.SyntaxKind.MinusToken) {
+    const inner = literalToValue(node.operand);
+    if (typeof inner === 'number') return -inner;
+    throw unsupported(node);
+  }
+
+  if (ts.isArrayLiteralExpression(node)) {
+    return node.elements.map((element) => literalToValue(element));
+  }
+
+  if (ts.isObjectLiteralExpression(node)) {
+    const obj: Record<string, unknown> = {};
+    for (const member of node.properties) {
+      if (!ts.isPropertyAssignment(member)) throw unsupported(member);
+      obj[propertyName(member.name)] = literalToValue(member.initializer);
+    }
+    return obj;
+  }
+
+  throw unsupported(node);
+}
+
+function propertyName(name: ts.PropertyName): string {
+  if (ts.isIdentifier(name) || ts.isStringLiteralLike(name) || ts.isNumericLiteral(name)) {
+    return name.text;
+  }
+  throw new Error(`Unsupported property name kind: ${ts.SyntaxKind[name.kind]}`);
+}
+
+function unsupported(node: ts.Node): Error {
+  return new Error(
+    `Unsupported (non-literal) syntax: ${ts.SyntaxKind[node.kind]}. ` +
+      `The MCP schema generator only reads static literals.`,
+  );
+}
+
+/**
+ * Finds the first property/variable named `propName` whose initializer is an
+ * array literal, anywhere in the source file. Throws if not found.
+ */
+export function findArrayLiteral(sourceFile: ts.SourceFile, propName: string): ts.ArrayLiteralExpression {
+  let found: ts.ArrayLiteralExpression | undefined;
+
+  const visit = (node: ts.Node): void => {
+    if (found) return;
+    if (
+      (ts.isPropertyDeclaration(node) ||
+        ts.isPropertyAssignment(node) ||
+        ts.isVariableDeclaration(node)) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === propName &&
+      node.initializer &&
+      ts.isArrayLiteralExpression(node.initializer)
+    ) {
+      found = node.initializer;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  if (!found) {
+    throw new Error(`Could not find an array initializer named "${propName}" in ${sourceFile.fileName}`);
+  }
+  return found;
+}

--- a/tools/gen-mcp-schema/design-system.spec.ts
+++ b/tools/gen-mcp-schema/design-system.spec.ts
@@ -28,7 +28,10 @@ describe('extractDesignSystem', () => {
       'purple',
       'grey',
     ]);
-    expect(design.colors[0]).toEqual({ value: 'contrast', label: 'Contrast' });
+    expect(design.colors[0]).toEqual({ value: 'contrast', label: 'Contrast', hex: '#FFFFFF' });
+    for (const c of design.colors) {
+      expect(c.hex).toMatch(/^#[0-9a-fA-F]{3,8}$/);
+    }
   });
 
   it('lists the supported theme names', () => {

--- a/tools/gen-mcp-schema/design-system.spec.ts
+++ b/tools/gen-mcp-schema/design-system.spec.ts
@@ -1,0 +1,55 @@
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect } from 'vitest';
+import { extractDesignSystem } from './generate';
+
+const projectRoot = fileURLToPath(new URL('../../', import.meta.url));
+const design = extractDesignSystem({ projectRoot });
+
+describe('extractDesignSystem', () => {
+  it('reads the 24-column grid geometry', () => {
+    expect(design.grid).toMatchObject({
+      column: 24,
+      row: 24,
+      margin: 4,
+      float: true,
+      cellHeight: 'auto',
+    });
+  });
+
+  it('reads the colour tokens in palette order', () => {
+    const values = design.colors.map((c) => c.value);
+    expect(values).toEqual([
+      'contrast',
+      'blue',
+      'green',
+      'orange',
+      'yellow',
+      'pink',
+      'purple',
+      'grey',
+    ]);
+    expect(design.colors[0]).toEqual({ value: 'contrast', label: 'Contrast' });
+  });
+
+  it('lists the supported theme names', () => {
+    expect(design.themeNames).toEqual(expect.arrayContaining(['', 'light-theme', 'night-theme']));
+  });
+
+  it('lists the dashboard icons, sorted and de-duplicated', () => {
+    expect(design.icons.length).toBeGreaterThanOrEqual(40);
+    expect(design.icons).toContain('dashboard-anchored-boat');
+    expect(design.icons).toContain('dashboard-sailing');
+    const sorted = [...design.icons].sort((a, b) => a.localeCompare(b));
+    expect(design.icons).toEqual(sorted);
+    expect(new Set(design.icons).size).toBe(design.icons.length);
+  });
+
+  it('reads unit groups with their convertible measures', () => {
+    const speed = design.unitGroups.find((g) => g.group === 'Speed');
+    expect(speed?.measures.map((m) => m.measure)).toEqual(
+      expect.arrayContaining(['knots', 'kph', 'mph', 'm/s']),
+    );
+    const angle = design.unitGroups.find((g) => g.group === 'Angle');
+    expect(angle?.measures.map((m) => m.measure)).toEqual(expect.arrayContaining(['rad', 'deg']));
+  });
+});

--- a/tools/gen-mcp-schema/generate.spec.ts
+++ b/tools/gen-mcp-schema/generate.spec.ts
@@ -36,4 +36,10 @@ describe('extractWidgetCatalog', () => {
       expect.arrayContaining(['freeboard-sk', 'tracks', 'resources-provider', 'course-provider']),
     );
   });
+
+  it('returns widgets sorted by selector for stable, consistent diffs', () => {
+    const selectors = widgets.map((w) => w.selector);
+    const sorted = [...selectors].sort((a, b) => a.localeCompare(b));
+    expect(selectors).toEqual(sorted);
+  });
 });

--- a/tools/gen-mcp-schema/generate.spec.ts
+++ b/tools/gen-mcp-schema/generate.spec.ts
@@ -1,0 +1,39 @@
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect } from 'vitest';
+import { extractWidgetCatalog } from './generate';
+
+const projectRoot = fileURLToPath(new URL('../../', import.meta.url));
+
+describe('extractWidgetCatalog', () => {
+  const widgets = extractWidgetCatalog({ projectRoot });
+
+  it('extracts the full active widget catalog', () => {
+    // KIP ships ~32 active widgets; guard against an empty or truncated parse.
+    expect(widgets.length).toBeGreaterThanOrEqual(30);
+  });
+
+  it('includes widget-numeric as a Core widget with sizing and component class', () => {
+    const numeric = widgets.find((w) => w.selector === 'widget-numeric');
+    expect(numeric).toBeDefined();
+    expect(numeric?.name).toBe('Numeric');
+    expect(numeric?.category).toBe('Core');
+    expect(numeric?.componentClassName).toBe('WidgetNumericComponent');
+    expect(numeric?.defaultWidth).toBe(4);
+    expect(numeric?.defaultHeight).toBe(6);
+    expect(numeric?.requiredPlugins).toEqual([]);
+  });
+
+  it('excludes the commented-out widgets (alternator, inverter, ac)', () => {
+    const selectors = widgets.map((w) => w.selector);
+    expect(selectors).not.toContain('widget-alternator');
+    expect(selectors).not.toContain('widget-inverter');
+    expect(selectors).not.toContain('widget-ac');
+  });
+
+  it('captures the four required plugins for Freeboard-SK', () => {
+    const freeboard = widgets.find((w) => w.selector === 'widget-freeboardsk');
+    expect(freeboard?.requiredPlugins).toEqual(
+      expect.arrayContaining(['freeboard-sk', 'tracks', 'resources-provider', 'course-provider']),
+    );
+  });
+});

--- a/tools/gen-mcp-schema/generate.ts
+++ b/tools/gen-mcp-schema/generate.ts
@@ -4,12 +4,15 @@
  * Reads KIP source statically (never executes Angular components) and produces a
  * JSON description of the widget catalog and design system for the kip-mcp-server.
  */
+import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as ts from 'typescript';
 import {
   findArrayLiteral,
   findImportModuleSpecifier,
+  findPropertyInitializer,
   findStaticPropertyInitializer,
+  getObjectProperties,
   literalToValue,
   parseSourceFile,
 } from './ast';
@@ -30,6 +33,16 @@ const WIDGET_CATEGORIES: ReadonlySet<string> = new Set<WidgetCategory>([
   'Component',
   'Racing',
 ]);
+
+const APP_SERVICE = 'src/app/core/services/app-service.ts';
+const UNITS_SERVICE = 'src/app/core/services/units.service.ts';
+const DASHBOARD_COMPONENT = 'src/app/core/components/dashboard/dashboard.component.ts';
+const ICONS_SVG = 'src/assets/svg/icons.svg';
+
+// KIP applies themes as body CSS classes; the default (dark) theme is the empty
+// string. There is no single source literal to read, so these are listed here and
+// kept in step with src/styles.scss and src/themes/_m3{dark,light,night}.scss.
+const THEME_NAMES: readonly string[] = ['', 'light-theme', 'night-theme'];
 
 /**
  * Extracts KIP's widget catalog (`_widgetDefinition`) from widget.service.ts.
@@ -117,18 +130,86 @@ function asStringOrNull(value: unknown): string | null {
 
 /**
  * Extracts KIP's design system (grid, colour tokens, theme names, dashboard
- * icons and unit groups).
- *
- * STUB: implemented in the GREEN step.
+ * icons and unit groups) from KIP source.
  */
-export function extractDesignSystem(_opts: GenerateOptions): DesignSystem {
+export function extractDesignSystem(opts: GenerateOptions): DesignSystem {
   return {
-    grid: { column: 0, row: 0, margin: 0, float: false, cellHeight: '' },
-    colors: [],
-    themeNames: [],
-    icons: [],
-    unitGroups: [],
+    grid: extractGrid(opts.projectRoot),
+    colors: extractColors(opts.projectRoot),
+    themeNames: [...THEME_NAMES],
+    icons: extractIcons(opts.projectRoot),
+    unitGroups: extractUnitGroups(opts.projectRoot),
   };
+}
+
+function extractGrid(root: string): DesignSystem['grid'] {
+  const file = path.join(root, DASHBOARD_COMPONENT);
+  const initializer = findPropertyInitializer(parseSourceFile(file), 'gridOptions');
+
+  // gridOptions is `signal<NgGridStackOptions>({ ... })`; unwrap the call argument.
+  let objectLiteral: ts.ObjectLiteralExpression | undefined;
+  if (ts.isCallExpression(initializer) && ts.isObjectLiteralExpression(initializer.arguments[0])) {
+    objectLiteral = initializer.arguments[0];
+  } else if (ts.isObjectLiteralExpression(initializer)) {
+    objectLiteral = initializer;
+  }
+  if (!objectLiteral) {
+    throw new Error(`gridOptions is not signal({...}) or an object literal in ${file}`);
+  }
+
+  const props = getObjectProperties(objectLiteral);
+  return {
+    column: numberProp(props, 'column', file),
+    row: numberProp(props, 'row', file),
+    margin: numberProp(props, 'margin', file),
+    float: booleanProp(props, 'float', file),
+    // KIP computes the row height at runtime; it is not in the literal.
+    cellHeight: 'auto',
+  };
+}
+
+function extractColors(root: string): DesignSystem['colors'] {
+  const file = path.join(root, APP_SERVICE);
+  const raw = literalToValue(findArrayLiteral(parseSourceFile(file), 'configurableThemeColors'));
+  const list = raw as Array<{ value: unknown; label: unknown }>;
+  return list.map((c) => ({ value: String(c.value), label: String(c.label) }));
+}
+
+function extractUnitGroups(root: string): DesignSystem['unitGroups'] {
+  const file = path.join(root, UNITS_SERVICE);
+  const raw = literalToValue(findArrayLiteral(parseSourceFile(file), '_conversionList'));
+  const list = raw as Array<{ group: unknown; units: Array<{ measure: unknown; description: unknown }> }>;
+  return list.map((g) => ({
+    group: String(g.group),
+    measures: g.units.map((u) => ({ measure: String(u.measure), description: String(u.description) })),
+  }));
+}
+
+function extractIcons(root: string): string[] {
+  const svg = fs.readFileSync(path.join(root, ICONS_SVG), 'utf8');
+  const ids = new Set<string>();
+  const matcher = /id="(dashboard-[^"]*)"/g;
+  let match: RegExpExecArray | null;
+  while ((match = matcher.exec(svg)) !== null) {
+    ids.add(match[1]);
+  }
+  return [...ids].sort((a, b) => a.localeCompare(b));
+}
+
+function numberProp(props: Map<string, ts.Expression>, key: string, file: string): number {
+  const node = props.get(key);
+  if (!node) throw new Error(`Missing "${key}" in grid options in ${file}`);
+  const value = literalToValue(node);
+  if (typeof value !== 'number') throw new Error(`Expected number "${key}" in ${file}`);
+  return value;
+}
+
+function booleanProp(props: Map<string, ts.Expression>, key: string, file: string): boolean {
+  const node = props.get(key);
+  if (!node) throw new Error(`Missing "${key}" in grid options in ${file}`);
+  const value = literalToValue(node);
+  if (typeof value !== 'boolean') throw new Error(`Expected boolean "${key}" in ${file}`);
+  return value;
 }
 
 function toCatalogEntry(raw: Record<string, unknown>, file: string): WidgetCatalogEntry {

--- a/tools/gen-mcp-schema/generate.ts
+++ b/tools/gen-mcp-schema/generate.ts
@@ -7,7 +7,12 @@
 import * as path from 'node:path';
 import * as ts from 'typescript';
 import { findArrayLiteral, literalToValue, parseSourceFile } from './ast';
-import type { GenerateOptions, WidgetCatalogEntry, WidgetCategory } from './types';
+import type {
+  GenerateOptions,
+  WidgetCatalogEntry,
+  WidgetCategory,
+  WidgetSchemaEntry,
+} from './types';
 
 const WIDGET_SERVICE = 'src/app/core/services/widget.service.ts';
 const WIDGET_CATEGORIES: ReadonlySet<string> = new Set<WidgetCategory>([
@@ -37,6 +42,16 @@ export function extractWidgetCatalog(opts: GenerateOptions): WidgetCatalogEntry[
 
   entries.sort((a, b) => a.selector.localeCompare(b.selector));
   return entries;
+}
+
+/**
+ * Extracts the full widget schema for every catalog widget: the catalog entry
+ * plus its DEFAULT_CONFIG, structural binding kind, and path slots.
+ *
+ * STUB: implemented in the GREEN step.
+ */
+export function extractWidgetSchemas(_opts: GenerateOptions): WidgetSchemaEntry[] {
+  return [];
 }
 
 function toCatalogEntry(raw: Record<string, unknown>, file: string): WidgetCatalogEntry {

--- a/tools/gen-mcp-schema/generate.ts
+++ b/tools/gen-mcp-schema/generate.ts
@@ -6,9 +6,17 @@
  */
 import * as path from 'node:path';
 import * as ts from 'typescript';
-import { findArrayLiteral, literalToValue, parseSourceFile } from './ast';
+import {
+  findArrayLiteral,
+  findImportModuleSpecifier,
+  findStaticPropertyInitializer,
+  literalToValue,
+  parseSourceFile,
+} from './ast';
 import type {
+  BindingKind,
   GenerateOptions,
+  PathSlot,
   WidgetCatalogEntry,
   WidgetCategory,
   WidgetSchemaEntry,
@@ -30,28 +38,80 @@ const WIDGET_CATEGORIES: ReadonlySet<string> = new Set<WidgetCategory>([
  */
 export function extractWidgetCatalog(opts: GenerateOptions): WidgetCatalogEntry[] {
   const file = path.join(opts.projectRoot, WIDGET_SERVICE);
-  const sourceFile = parseSourceFile(file);
-  const array = findArrayLiteral(sourceFile, '_widgetDefinition');
+  return extractCatalogFromSource(parseSourceFile(file), file);
+}
 
+function extractCatalogFromSource(sourceFile: ts.SourceFile, file: string): WidgetCatalogEntry[] {
+  const array = findArrayLiteral(sourceFile, '_widgetDefinition');
   const entries = array.elements.map((element) => {
     if (!ts.isObjectLiteralExpression(element)) {
       throw new Error(`Expected a widget definition object literal in ${file}`);
     }
     return toCatalogEntry(literalToValue(element) as Record<string, unknown>, file);
   });
-
   entries.sort((a, b) => a.selector.localeCompare(b.selector));
   return entries;
 }
 
 /**
  * Extracts the full widget schema for every catalog widget: the catalog entry
- * plus its DEFAULT_CONFIG, structural binding kind, and path slots.
- *
- * STUB: implemented in the GREEN step.
+ * plus its DEFAULT_CONFIG (read verbatim), structural binding kind, and the path
+ * slots for record-bound widgets. Sorted by selector (inherited from the catalog).
  */
-export function extractWidgetSchemas(_opts: GenerateOptions): WidgetSchemaEntry[] {
-  return [];
+export function extractWidgetSchemas(opts: GenerateOptions): WidgetSchemaEntry[] {
+  const serviceFile = path.join(opts.projectRoot, WIDGET_SERVICE);
+  const serviceSource = parseSourceFile(serviceFile);
+  const serviceDir = path.dirname(serviceFile);
+  const catalog = extractCatalogFromSource(serviceSource, serviceFile);
+
+  return catalog.map((entry) => {
+    const moduleSpecifier = findImportModuleSpecifier(serviceSource, entry.componentClassName);
+    const componentFile = path.resolve(serviceDir, `${moduleSpecifier}.ts`);
+    const initializer = findStaticPropertyInitializer(
+      parseSourceFile(componentFile),
+      entry.componentClassName,
+      'DEFAULT_CONFIG',
+    );
+    if (!ts.isObjectLiteralExpression(initializer)) {
+      throw new Error(`DEFAULT_CONFIG of ${entry.componentClassName} is not an object literal`);
+    }
+    const defaultConfig = literalToValue(initializer) as Record<string, unknown>;
+    const bindingKind = deriveBindingKind(defaultConfig);
+    const pathSlots = bindingKind === 'paths-record' ? extractPathSlots(defaultConfig) : [];
+    return { ...entry, bindingKind, defaultConfig, pathSlots };
+  });
+}
+
+/** Derives how a widget binds Signal K data from its DEFAULT_CONFIG shape. */
+function deriveBindingKind(config: Record<string, unknown>): BindingKind {
+  const paths = config.paths;
+  if (Array.isArray(paths)) return 'paths-array';
+  if (paths !== null && typeof paths === 'object' && Object.keys(paths).length > 0) {
+    return 'paths-record';
+  }
+  if ('datachartPath' in config) return 'datachart';
+  return 'none';
+}
+
+/** Maps each entry of a record-form `config.paths` to a PathSlot, in source order. */
+function extractPathSlots(config: Record<string, unknown>): PathSlot[] {
+  const paths = config.paths as Record<string, Record<string, unknown>>;
+  return Object.entries(paths).map(([slot, raw]) => ({
+    slot,
+    description: asStringOrNull(raw.description),
+    defaultPath: asStringOrNull(raw.path),
+    source: asStringOrNull(raw.source),
+    pathType: asStringOrNull(raw.pathType),
+    isPathConfigurable: raw.isPathConfigurable === true,
+    pathRequired: raw.pathRequired === true,
+    defaultConvertUnitTo: asStringOrNull(raw.convertUnitTo),
+    expectedSkUnit: asStringOrNull(raw.pathSkUnitsFilter),
+    sampleTime: typeof raw.sampleTime === 'number' ? raw.sampleTime : null,
+  }));
+}
+
+function asStringOrNull(value: unknown): string | null {
+  return typeof value === 'string' ? value : null;
 }
 
 function toCatalogEntry(raw: Record<string, unknown>, file: string): WidgetCatalogEntry {

--- a/tools/gen-mcp-schema/generate.ts
+++ b/tools/gen-mcp-schema/generate.ts
@@ -39,6 +39,7 @@ const APP_SERVICE = 'src/app/core/services/app-service.ts';
 const UNITS_SERVICE = 'src/app/core/services/units.service.ts';
 const DASHBOARD_COMPONENT = 'src/app/core/components/dashboard/dashboard.component.ts';
 const ICONS_SVG = 'src/assets/svg/icons.svg';
+const M3_DARK = 'src/themes/_m3dark.scss';
 
 // KIP applies themes as body CSS classes; the default (dark) theme is the empty
 // string. There is no single source literal to read, so these are listed here and
@@ -175,11 +176,39 @@ function extractGrid(root: string): DesignSystem['grid'] {
   };
 }
 
+/**
+ * Reads the base (dark-theme) hex for each colour token from the
+ * `$kip-dark-color` SCSS map. Only `name: #hex` pairs are captured, so the
+ * `#{$...}` interpolations and `map.get(...)` aliases are skipped.
+ */
+function extractColorHex(root: string): Map<string, string> {
+  const scss = fs.readFileSync(path.join(root, M3_DARK), 'utf8');
+  const block = /\$kip-dark-color:\s*\(([\s\S]*?)\)\s*;/.exec(scss);
+  if (!block) {
+    throw new Error(`Could not find the $kip-dark-color map in ${M3_DARK}`);
+  }
+  const hexByToken = new Map<string, string>();
+  const pair = /([a-z][a-z0-9-]*)\s*:\s*(#[0-9a-fA-F]{3,8})\b/g;
+  let match: RegExpExecArray | null;
+  while ((match = pair.exec(block[1])) !== null) {
+    hexByToken.set(match[1], match[2]);
+  }
+  return hexByToken;
+}
+
 function extractColors(root: string): DesignSystem['colors'] {
   const file = path.join(root, APP_SERVICE);
   const raw = literalToValue(findArrayLiteral(parseSourceFile(file), 'configurableThemeColors'));
   const list = raw as Array<{ value: unknown; label: unknown }>;
-  return list.map((c) => ({ value: String(c.value), label: String(c.label) }));
+  const hexByToken = extractColorHex(root);
+  return list.map((c) => {
+    const value = String(c.value);
+    const hex = hexByToken.get(value);
+    if (!hex) {
+      throw new Error(`No dark-theme hex for colour token "${value}" in ${M3_DARK}`);
+    }
+    return { value, label: String(c.label), hex };
+  });
 }
 
 function extractUnitGroups(root: string): DesignSystem['unitGroups'] {

--- a/tools/gen-mcp-schema/generate.ts
+++ b/tools/gen-mcp-schema/generate.ts
@@ -15,6 +15,7 @@ import {
 } from './ast';
 import type {
   BindingKind,
+  DesignSystem,
   GenerateOptions,
   PathSlot,
   WidgetCatalogEntry,
@@ -112,6 +113,22 @@ function extractPathSlots(config: Record<string, unknown>): PathSlot[] {
 
 function asStringOrNull(value: unknown): string | null {
   return typeof value === 'string' ? value : null;
+}
+
+/**
+ * Extracts KIP's design system (grid, colour tokens, theme names, dashboard
+ * icons and unit groups).
+ *
+ * STUB: implemented in the GREEN step.
+ */
+export function extractDesignSystem(_opts: GenerateOptions): DesignSystem {
+  return {
+    grid: { column: 0, row: 0, margin: 0, float: false, cellHeight: '' },
+    colors: [],
+    themeNames: [],
+    icons: [],
+    unitGroups: [],
+  };
 }
 
 function toCatalogEntry(raw: Record<string, unknown>, file: string): WidgetCatalogEntry {

--- a/tools/gen-mcp-schema/generate.ts
+++ b/tools/gen-mcp-schema/generate.ts
@@ -45,6 +45,12 @@ const ICONS_SVG = 'src/assets/svg/icons.svg';
 // kept in step with src/styles.scss and src/themes/_m3{dark,light,night}.scss.
 const THEME_NAMES: readonly string[] = ['', 'light-theme', 'night-theme'];
 
+const SCHEMA_VERSION = 1;
+// Two distinct KIP version numbers (see storage.service.ts / config.demo.const.ts):
+// the applicationData file version in the URL, and app.configVersion in the body.
+const CONFIG_FILE_VERSION = 11;
+const CONFIG_VERSION = 12;
+
 /**
  * Extracts KIP's widget catalog (`_widgetDefinition`) from widget.service.ts.
  *
@@ -215,22 +221,30 @@ function booleanProp(props: Map<string, ts.Expression>, key: string, file: strin
 
 /**
  * Assembles the full schema artifact: version-stamped meta, the widget schemas,
- * and the design system.
- *
- * STUB: implemented in the GREEN step.
+ * and the design system. Deterministic — no timestamps — so the committed
+ * artifact only changes when KIP source changes.
  */
-export function buildSchema(_opts: GenerateOptions): KipDashboardSchema {
+export function buildSchema(opts: GenerateOptions): KipDashboardSchema {
   return {
-    meta: { schemaVersion: 0, kipVersion: '', configFileVersion: 0, configVersion: 0 },
-    widgets: [],
-    designSystem: {
-      grid: { column: 0, row: 0, margin: 0, float: false, cellHeight: '' },
-      colors: [],
-      themeNames: [],
-      icons: [],
-      unitGroups: [],
+    meta: {
+      schemaVersion: SCHEMA_VERSION,
+      kipVersion: readKipVersion(opts.projectRoot),
+      configFileVersion: CONFIG_FILE_VERSION,
+      configVersion: CONFIG_VERSION,
     },
+    widgets: extractWidgetSchemas(opts),
+    designSystem: extractDesignSystem(opts),
   };
+}
+
+function readKipVersion(root: string): string {
+  const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8')) as {
+    version?: string;
+  };
+  if (!pkg.version) {
+    throw new Error('KIP package.json has no "version"');
+  }
+  return pkg.version;
 }
 
 function toCatalogEntry(raw: Record<string, unknown>, file: string): WidgetCatalogEntry {

--- a/tools/gen-mcp-schema/generate.ts
+++ b/tools/gen-mcp-schema/generate.ts
@@ -3,19 +3,95 @@
  *
  * Reads KIP source statically (never executes Angular components) and produces a
  * JSON description of the widget catalog and design system for the kip-mcp-server.
- *
- * STUB: the extraction is implemented in the next (GREEN) step. For now the
- * functions return empty results so the failing tests describe the intended
- * behavior.
  */
-import type { GenerateOptions, WidgetCatalogEntry } from './types';
+import * as path from 'node:path';
+import * as ts from 'typescript';
+import { findArrayLiteral, literalToValue, parseSourceFile } from './ast';
+import type { GenerateOptions, WidgetCatalogEntry, WidgetCategory } from './types';
+
+const WIDGET_SERVICE = 'src/app/core/services/widget.service.ts';
+const WIDGET_CATEGORIES: ReadonlySet<string> = new Set<WidgetCategory>([
+  'Core',
+  'Gauge',
+  'Component',
+  'Racing',
+]);
 
 /**
  * Extracts KIP's widget catalog (`_widgetDefinition`) from widget.service.ts.
  *
- * Only the active (non-commented-out) widget definitions are returned.
+ * Only the active (non-commented-out) widget definitions are returned, sorted by
+ * selector so the generated artifact diffs stay localized when widgets change.
  */
-export function extractWidgetCatalog(_opts: GenerateOptions): WidgetCatalogEntry[] {
-  // TODO(GREEN): parse src/app/core/services/widget.service.ts with ts-morph.
-  return [];
+export function extractWidgetCatalog(opts: GenerateOptions): WidgetCatalogEntry[] {
+  const file = path.join(opts.projectRoot, WIDGET_SERVICE);
+  const sourceFile = parseSourceFile(file);
+  const array = findArrayLiteral(sourceFile, '_widgetDefinition');
+
+  const entries = array.elements.map((element) => {
+    if (!ts.isObjectLiteralExpression(element)) {
+      throw new Error(`Expected a widget definition object literal in ${file}`);
+    }
+    return toCatalogEntry(literalToValue(element) as Record<string, unknown>, file);
+  });
+
+  entries.sort((a, b) => a.selector.localeCompare(b.selector));
+  return entries;
+}
+
+function toCatalogEntry(raw: Record<string, unknown>, file: string): WidgetCatalogEntry {
+  const category = requireString(raw, 'category', file);
+  if (!WIDGET_CATEGORIES.has(category)) {
+    throw new Error(`Unknown widget category "${category}" in ${file}`);
+  }
+
+  const entry: WidgetCatalogEntry = {
+    name: requireString(raw, 'name', file),
+    selector: requireString(raw, 'selector', file),
+    componentClassName: requireString(raw, 'componentClassName', file),
+    category: category as WidgetCategory,
+    description: requireString(raw, 'description', file),
+    icon: requireString(raw, 'icon', file),
+    minWidth: requireNumber(raw, 'minWidth', file),
+    minHeight: requireNumber(raw, 'minHeight', file),
+    defaultWidth: requireNumber(raw, 'defaultWidth', file),
+    defaultHeight: requireNumber(raw, 'defaultHeight', file),
+    // Plugin lists are sets: sort them for stable diffs.
+    requiredPlugins: requireStringArray(raw, 'requiredPlugins', file).slice().sort(),
+  };
+
+  if (raw.anyOfPlugins !== undefined) {
+    entry.anyOfPlugins = requireStringArray(raw, 'anyOfPlugins', file).slice().sort();
+  }
+  return entry;
+}
+
+function requireString(raw: Record<string, unknown>, key: string, file: string): string {
+  const value = raw[key];
+  if (typeof value !== 'string') {
+    throw new Error(`Expected string "${key}" in a widget definition in ${file}, got ${describe(value)}`);
+  }
+  return value;
+}
+
+function requireNumber(raw: Record<string, unknown>, key: string, file: string): number {
+  const value = raw[key];
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    throw new Error(`Expected number "${key}" in a widget definition in ${file}, got ${describe(value)}`);
+  }
+  return value;
+}
+
+function requireStringArray(raw: Record<string, unknown>, key: string, file: string): string[] {
+  const value = raw[key];
+  if (!Array.isArray(value) || !value.every((item) => typeof item === 'string')) {
+    throw new Error(`Expected string[] "${key}" in a widget definition in ${file}, got ${describe(value)}`);
+  }
+  return value as string[];
+}
+
+function describe(value: unknown): string {
+  if (value === null) return 'null';
+  if (Array.isArray(value)) return 'array';
+  return typeof value;
 }

--- a/tools/gen-mcp-schema/generate.ts
+++ b/tools/gen-mcp-schema/generate.ts
@@ -20,6 +20,7 @@ import type {
   BindingKind,
   DesignSystem,
   GenerateOptions,
+  KipDashboardSchema,
   PathSlot,
   WidgetCatalogEntry,
   WidgetCategory,
@@ -210,6 +211,26 @@ function booleanProp(props: Map<string, ts.Expression>, key: string, file: strin
   const value = literalToValue(node);
   if (typeof value !== 'boolean') throw new Error(`Expected boolean "${key}" in ${file}`);
   return value;
+}
+
+/**
+ * Assembles the full schema artifact: version-stamped meta, the widget schemas,
+ * and the design system.
+ *
+ * STUB: implemented in the GREEN step.
+ */
+export function buildSchema(_opts: GenerateOptions): KipDashboardSchema {
+  return {
+    meta: { schemaVersion: 0, kipVersion: '', configFileVersion: 0, configVersion: 0 },
+    widgets: [],
+    designSystem: {
+      grid: { column: 0, row: 0, margin: 0, float: false, cellHeight: '' },
+      colors: [],
+      themeNames: [],
+      icons: [],
+      unitGroups: [],
+    },
+  };
 }
 
 function toCatalogEntry(raw: Record<string, unknown>, file: string): WidgetCatalogEntry {

--- a/tools/gen-mcp-schema/generate.ts
+++ b/tools/gen-mcp-schema/generate.ts
@@ -1,0 +1,21 @@
+/**
+ * Generator for the KIP dashboard schema artifact.
+ *
+ * Reads KIP source statically (never executes Angular components) and produces a
+ * JSON description of the widget catalog and design system for the kip-mcp-server.
+ *
+ * STUB: the extraction is implemented in the next (GREEN) step. For now the
+ * functions return empty results so the failing tests describe the intended
+ * behavior.
+ */
+import type { GenerateOptions, WidgetCatalogEntry } from './types';
+
+/**
+ * Extracts KIP's widget catalog (`_widgetDefinition`) from widget.service.ts.
+ *
+ * Only the active (non-commented-out) widget definitions are returned.
+ */
+export function extractWidgetCatalog(_opts: GenerateOptions): WidgetCatalogEntry[] {
+  // TODO(GREEN): parse src/app/core/services/widget.service.ts with ts-morph.
+  return [];
+}

--- a/tools/gen-mcp-schema/schema-artifact.spec.ts
+++ b/tools/gen-mcp-schema/schema-artifact.spec.ts
@@ -1,0 +1,23 @@
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect } from 'vitest';
+import { buildSchema } from './generate';
+import { toCanonicalJson } from './serialize';
+
+const projectRoot = fileURLToPath(new URL('../../', import.meta.url));
+const assetPath = join(projectRoot, 'src/assets/kip-dashboard-schema.json');
+const expected = toCanonicalJson(buildSchema({ projectRoot }));
+
+// `npm run gen:mcp-schema` sets UPDATE_SCHEMA to (re)write the committed artifact.
+if (process.env.UPDATE_SCHEMA) {
+  mkdirSync(dirname(assetPath), { recursive: true });
+  writeFileSync(assetPath, expected);
+}
+
+describe('generated schema artifact', () => {
+  it('is up to date — run `npm run gen:mcp-schema` after changing widgets or the design system', () => {
+    const actual = readFileSync(assetPath, 'utf8');
+    expect(actual).toBe(expected);
+  });
+});

--- a/tools/gen-mcp-schema/schema.spec.ts
+++ b/tools/gen-mcp-schema/schema.spec.ts
@@ -1,0 +1,24 @@
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect } from 'vitest';
+import { buildSchema } from './generate';
+
+const projectRoot = fileURLToPath(new URL('../../', import.meta.url));
+const schema = buildSchema({ projectRoot });
+
+describe('buildSchema', () => {
+  it('stamps meta with the KIP version and config versions', () => {
+    expect(schema.meta).toMatchObject({
+      schemaVersion: 1,
+      configFileVersion: 11,
+      configVersion: 12,
+    });
+    expect(schema.meta.kipVersion).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it('includes the widget schemas and the design system', () => {
+    expect(schema.widgets.length).toBeGreaterThanOrEqual(30);
+    expect(schema.widgets.some((w) => w.selector === 'widget-numeric')).toBe(true);
+    expect(schema.designSystem.grid.column).toBe(24);
+    expect(schema.designSystem.colors).toHaveLength(8);
+  });
+});

--- a/tools/gen-mcp-schema/serialize.spec.ts
+++ b/tools/gen-mcp-schema/serialize.spec.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { canonicalize, toCanonicalJson } from './serialize';
+
+describe('canonicalize', () => {
+  it('sorts object keys recursively', () => {
+    const input = { b: 1, a: { d: 2, c: 3 } };
+    expect(JSON.stringify(canonicalize(input))).toBe(JSON.stringify({ a: { c: 3, d: 2 }, b: 1 }));
+  });
+
+  it('preserves array order', () => {
+    expect(canonicalize([3, 1, 2])).toEqual([3, 1, 2]);
+  });
+
+  it('leaves primitives and null untouched', () => {
+    expect(canonicalize('x')).toBe('x');
+    expect(canonicalize(42)).toBe(42);
+    expect(canonicalize(null)).toBeNull();
+  });
+});
+
+describe('toCanonicalJson', () => {
+  it('produces identical output regardless of input key order', () => {
+    expect(toCanonicalJson({ x: 1, y: 2 })).toBe(toCanonicalJson({ y: 2, x: 1 }));
+  });
+
+  it('ends with a trailing newline', () => {
+    expect(toCanonicalJson({})).toBe('{}\n');
+  });
+});

--- a/tools/gen-mcp-schema/serialize.ts
+++ b/tools/gen-mcp-schema/serialize.ts
@@ -1,0 +1,35 @@
+/**
+ * Canonical serialization for the generated schema artifact.
+ *
+ * The artifact is committed to the repo and checked by a CI drift gate, so its
+ * output must be byte-stable: the same source always produces the same file,
+ * regardless of the order keys happen to appear in the source.
+ *
+ * Strategy:
+ *  - Object keys are sorted recursively (key order is never meaningful in JSON).
+ *  - Array order is left untouched. Callers decide array order explicitly: sets
+ *    such as widget lists and plugin lists are sorted for stable diffs, while
+ *    semantically ordered lists (the colour palette, unit groups) keep their
+ *    authored order.
+ */
+
+/** Returns a deep copy of `value` with every object's keys sorted. */
+export function canonicalize<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map((item) => canonicalize(item)) as unknown as T;
+  }
+  if (value !== null && typeof value === 'object') {
+    const source = value as Record<string, unknown>;
+    const sorted: Record<string, unknown> = {};
+    for (const key of Object.keys(source).sort()) {
+      sorted[key] = canonicalize(source[key]);
+    }
+    return sorted as unknown as T;
+  }
+  return value;
+}
+
+/** Serializes `value` to canonical, pretty-printed JSON with a trailing newline. */
+export function toCanonicalJson(value: unknown): string {
+  return `${JSON.stringify(canonicalize(value), null, 2)}\n`;
+}

--- a/tools/gen-mcp-schema/types.ts
+++ b/tools/gen-mcp-schema/types.ts
@@ -136,6 +136,28 @@ export interface DesignSystem {
   unitGroups: UnitGroup[];
 }
 
+/** Provenance and version stamps for the generated artifact. */
+export interface SchemaMeta {
+  /** Version of this artifact's own shape. */
+  schemaVersion: number;
+  /** KIP package version the artifact was generated from. */
+  kipVersion: string;
+  /** applicationData file version used in the storage URL (`.../kip/{N}/...`). */
+  configFileVersion: number;
+  /** `app.configVersion` value KIP expects in a saved config body. */
+  configVersion: number;
+}
+
+/**
+ * The complete generated artifact: everything the kip-mcp-server needs to design
+ * valid KIP dashboards, read from KIP source and written canonically.
+ */
+export interface KipDashboardSchema {
+  meta: SchemaMeta;
+  widgets: WidgetSchemaEntry[];
+  designSystem: DesignSystem;
+}
+
 export interface GenerateOptions {
   /** Absolute path to the KIP repository root. */
   projectRoot: string;

--- a/tools/gen-mcp-schema/types.ts
+++ b/tools/gen-mcp-schema/types.ts
@@ -1,0 +1,47 @@
+/**
+ * Types for the generated KIP dashboard schema artifact.
+ *
+ * This artifact is produced by reading KIP's own source (the widget catalog,
+ * each widget's DEFAULT_CONFIG, and the design-system constants) and is consumed
+ * by the external kip-mcp-server so an AI can design valid KIP dashboards.
+ *
+ * Keep this in sync with KIP's interfaces. The generator fails loudly when the
+ * source no longer matches these expectations.
+ */
+
+export type WidgetCategory = 'Core' | 'Gauge' | 'Component' | 'Racing';
+
+/**
+ * One entry of KIP's widget catalog (`_widgetDefinition` in widget.service.ts).
+ */
+export interface WidgetCatalogEntry {
+  /** Human-readable name shown in the widget picker. */
+  name: string;
+  /** Widget type id, e.g. `widget-numeric`. Goes into `widgetProperties.type`. */
+  selector: string;
+  /** Angular component class that implements the widget. */
+  componentClassName: string;
+  /** Picker grouping. */
+  category: WidgetCategory;
+  /** Short description of what the widget does. */
+  description: string;
+  /** Icon key in KIP's SVG sprite. */
+  icon: string;
+  /** Minimum grid width in columns (of 24). */
+  minWidth: number;
+  /** Minimum grid height in rows. */
+  minHeight: number;
+  /** Default grid width in columns (of 24) when first added. */
+  defaultWidth: number;
+  /** Default grid height in rows when first added. */
+  defaultHeight: number;
+  /** Plugins that must ALL be enabled for the widget to work. */
+  requiredPlugins: string[];
+  /** Plugins where at least one must be enabled, if present. */
+  anyOfPlugins?: string[];
+}
+
+export interface GenerateOptions {
+  /** Absolute path to the KIP repository root. */
+  projectRoot: string;
+}

--- a/tools/gen-mcp-schema/types.ts
+++ b/tools/gen-mcp-schema/types.ts
@@ -97,6 +97,8 @@ export interface WidgetSchemaEntry extends WidgetCatalogEntry {
 export interface ColorToken {
   value: string;
   label: string;
+  /** Base (dark-theme) hex for the token, e.g. `#3298ff`, for previews. */
+  hex: string;
 }
 
 /** One convertible unit within a unit group. */

--- a/tools/gen-mcp-schema/types.ts
+++ b/tools/gen-mcp-schema/types.ts
@@ -93,6 +93,49 @@ export interface WidgetSchemaEntry extends WidgetCatalogEntry {
   pathSlots: PathSlot[];
 }
 
+/** A named widget colour token (KIP's `configurableThemeColors`). */
+export interface ColorToken {
+  value: string;
+  label: string;
+}
+
+/** One convertible unit within a unit group. */
+export interface UnitMeasure {
+  measure: string;
+  description: string;
+}
+
+/** A group of related units (KIP's unit conversion list). */
+export interface UnitGroup {
+  group: string;
+  measures: UnitMeasure[];
+}
+
+/** The dashboard grid geometry (GridStack options). */
+export interface GridGeometry {
+  column: number;
+  row: number;
+  margin: number;
+  float: boolean;
+  /** Row height; KIP computes this at runtime, hence `'auto'`. */
+  cellHeight: string;
+}
+
+/**
+ * KIP's design system: everything a dashboard designer needs beyond the widgets
+ * themselves — the grid, colour tokens, theme names, dashboard icons and units.
+ *
+ * Colour tokens and unit groups keep their authored order (the palette and the
+ * base-unit-first convention are meaningful); icons are sorted (a plain set).
+ */
+export interface DesignSystem {
+  grid: GridGeometry;
+  colors: ColorToken[];
+  themeNames: string[];
+  icons: string[];
+  unitGroups: UnitGroup[];
+}
+
 export interface GenerateOptions {
   /** Absolute path to the KIP repository root. */
   projectRoot: string;

--- a/tools/gen-mcp-schema/types.ts
+++ b/tools/gen-mcp-schema/types.ts
@@ -41,6 +41,58 @@ export interface WidgetCatalogEntry {
   anyOfPlugins?: string[];
 }
 
+/**
+ * How a widget binds Signal K data, derived structurally from its DEFAULT_CONFIG.
+ *
+ *  - `paths-record`  config.paths is a keyed object of slots (most widgets).
+ *  - `paths-array`   config.paths is an array (switch / zones panels).
+ *  - `datachart`     no paths; a single top-level datachartPath (history chart).
+ *  - `none`          no path binding (static widgets, or ones configured through a
+ *                    special config object such as bms/ais/charger).
+ *
+ * Plugin/capability gating is described separately (catalog plugin fields), not here.
+ */
+export type BindingKind = 'paths-record' | 'paths-array' | 'datachart' | 'none';
+
+/**
+ * A single data slot of a `paths-record` widget, derived from one entry of
+ * DEFAULT_CONFIG.paths. Fields mirror KIP's IWidgetPath.
+ */
+export interface PathSlot {
+  /** The key under config.paths, e.g. `numericPath` or `headingPath`. */
+  slot: string;
+  /** Slot label shown in KIP's options UI. */
+  description: string | null;
+  /** The default Signal K path baked into DEFAULT_CONFIG (often null). */
+  defaultPath: string | null;
+  /** Default source, or null for the server default. */
+  source: string | null;
+  /** `number` | `string` | `boolean` | `Date` | `multiple` | null. */
+  pathType: string | null;
+  /** Whether the user (or MCP) may set this slot's path. */
+  isPathConfigurable: boolean;
+  /** Whether the widget needs this slot bound to work. */
+  pathRequired: boolean;
+  /** Default unit conversion (convertUnitTo), or null. */
+  defaultConvertUnitTo: string | null;
+  /** Expected Signal K base unit filter (pathSkUnitsFilter), or null. */
+  expectedSkUnit: string | null;
+  /** Default subscription throttle in milliseconds, or null. */
+  sampleTime: number | null;
+}
+
+/**
+ * A catalog entry enriched with its DEFAULT_CONFIG, binding kind and path slots —
+ * everything the MCP needs to build a valid widget instance.
+ */
+export interface WidgetSchemaEntry extends WidgetCatalogEntry {
+  bindingKind: BindingKind;
+  /** The widget's DEFAULT_CONFIG, read verbatim from source. */
+  defaultConfig: Record<string, unknown>;
+  /** Data slots for `paths-record` widgets; empty for every other binding kind. */
+  pathSlots: PathSlot[];
+}
+
 export interface GenerateOptions {
   /** Absolute path to the KIP repository root. */
   projectRoot: string;

--- a/tools/gen-mcp-schema/vitest.config.ts
+++ b/tools/gen-mcp-schema/vitest.config.ts
@@ -1,0 +1,18 @@
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+/**
+ * Isolated Vitest config for the MCP schema generator.
+ *
+ * The generator is a plain Node tool (it reads files with ts-morph), so it runs
+ * in the `node` environment with no Angular/jsdom setup. Kept separate from the
+ * app's vitest.config.ts so `ng test` and `test:mcp-schema` never interfere.
+ */
+export default defineConfig({
+  root: fileURLToPath(new URL('../../', import.meta.url)),
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['tools/gen-mcp-schema/**/*.spec.ts'],
+  },
+});

--- a/tools/gen-mcp-schema/widget-schema.spec.ts
+++ b/tools/gen-mcp-schema/widget-schema.spec.ts
@@ -1,0 +1,64 @@
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect } from 'vitest';
+import { extractWidgetSchemas } from './generate';
+import type { WidgetSchemaEntry } from './types';
+
+const projectRoot = fileURLToPath(new URL('../../', import.meta.url));
+const schemas = extractWidgetSchemas({ projectRoot });
+const bySelector = (selector: string): WidgetSchemaEntry | undefined =>
+  schemas.find((w) => w.selector === selector);
+
+describe('extractWidgetSchemas', () => {
+  it('extracts a DEFAULT_CONFIG object for every catalog widget', () => {
+    expect(schemas.length).toBeGreaterThanOrEqual(30);
+    for (const widget of schemas) {
+      expect(widget.defaultConfig, widget.selector).toBeTypeOf('object');
+      expect(widget.defaultConfig, widget.selector).not.toBeNull();
+    }
+  });
+
+  it('classifies bindingKind structurally from DEFAULT_CONFIG', () => {
+    expect(bySelector('widget-numeric')?.bindingKind).toBe('paths-record');
+    expect(bySelector('widget-wind-steer')?.bindingKind).toBe('paths-record');
+    expect(bySelector('widget-boolean-switch')?.bindingKind).toBe('paths-array');
+    expect(bySelector('widget-zones-state-panel')?.bindingKind).toBe('paths-array');
+    expect(bySelector('widget-data-chart')?.bindingKind).toBe('datachart');
+    expect(bySelector('widget-windtrends-chart')?.bindingKind).toBe('none');
+    expect(bySelector('widget-bms')?.bindingKind).toBe('none');
+  });
+
+  it('extracts path slots for a record-bound widget (numeric)', () => {
+    const numericPath = bySelector('widget-numeric')?.pathSlots.find((s) => s.slot === 'numericPath');
+    expect(numericPath).toMatchObject({
+      slot: 'numericPath',
+      defaultPath: null,
+      pathType: 'number',
+      isPathConfigurable: true,
+      pathRequired: false,
+      defaultConvertUnitTo: 'unitless',
+      expectedSkUnit: null,
+      sampleTime: 500,
+    });
+  });
+
+  it('captures default-bound, required slots (wind-steer heading)', () => {
+    const heading = bySelector('widget-wind-steer')?.pathSlots.find((s) => s.slot === 'headingPath');
+    expect(heading).toMatchObject({
+      defaultPath: 'self.navigation.headingTrue',
+      pathRequired: true,
+      expectedSkUnit: 'rad',
+      defaultConvertUnitTo: 'deg',
+    });
+  });
+
+  it('gives non-record widgets no path slots', () => {
+    expect(bySelector('widget-data-chart')?.pathSlots).toEqual([]);
+    expect(bySelector('widget-boolean-switch')?.pathSlots).toEqual([]);
+    expect(bySelector('widget-bms')?.pathSlots).toEqual([]);
+  });
+
+  it('keeps a widget special config object verbatim (bms)', () => {
+    const config = bySelector('widget-bms')?.defaultConfig as { bms?: unknown };
+    expect(config.bms).toMatchObject({ trackedDevices: [], groups: [], banks: [] });
+  });
+});


### PR DESCRIPTION
## What this adds

A build-time generator that extracts KIP's design vocabulary into a single,
versioned JSON artifact for the external **[kip-mcp-server](https://github.com/dillan/kip-mcp-server)** to consume, so an AI
assistant can design valid KIP dashboards.

- `tools/gen-mcp-schema/` reads KIP source statically with the **TypeScript Compiler
  API** (already a KIP dependency — no new packages) and emits
  `src/assets/kip-dashboard-schema.json`: the widget catalog, each widget's
  `DEFAULT_CONFIG`, its binding kind and path slots, plus the design system (24-column
  grid, colour tokens, theme names, dashboard icons, unit groups).
- It reads **static literals only** and never executes Angular components. It **fails
  loudly** if a widget's `DEFAULT_CONFIG` is ever not a pure literal (so the artifact
  can't go silently wrong).
- Output is **canonical and deterministic** (recursively sorted keys, sorted sets, no
  timestamps), so the committed artifact diffs cleanly between versions.
- `npm run gen:mcp-schema` regenerates it; a drift-gate test fails if it's out of date.

## Scope and safety

- Changes are limited to `tools/gen-mcp-schema/` and the generated
  `src/assets/kip-dashboard-schema.json`. **No app code changes.**
- Built **test-first** (Vitest) in an isolated `node` config, so it does not touch the
  app's `ng test` or the production build.
- KIP's static host already serves `src/assets`, so the artifact is reachable at
  `/@mxtommy/kip/assets/kip-dashboard-schema.json` with no new server code.
