### PR TITLE
Fix Help images 404 when KIP is served under a base href (#1056)

### DIFF
--- a/src/app/core/components/app-help/help-docs-image-paths.spec.ts
+++ b/src/app/core/components/app-help/help-docs-image-paths.spec.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { cwd } from 'node:process';
+
+/**
+ * Guard for #1056.
+ *
+ * Help markdown is rendered inside KIP while the app is served under a base href
+ * (e.g. /@mxtommy/kip/). Image references must resolve against that base, so local image
+ * paths have to be base-relative (e.g. `assets/help-docs/img/x.png`). A parent-relative
+ * path (`../../assets/...`) climbs above the base href and 404s on a real Signal K server;
+ * a root-absolute path (`/assets/...`) drops the base href entirely. Both are forbidden.
+ * Absolute http(s) and data: URLs are fine.
+ */
+const HELP_DOCS_DIR = join(cwd(), 'src/assets/help-docs');
+
+function listMarkdownFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...listMarkdownFiles(full));
+    } else if (entry.isFile() && entry.name.endsWith('.md')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function extractImageSrcs(markdown: string): string[] {
+  const htmlImg = [...markdown.matchAll(/<img[^>]*\ssrc=["']([^"']+)["']/gi)].map(m => m[1]);
+  const mdImg = [...markdown.matchAll(/!\[[^\]]*\]\(([^)\s]+)/g)].map(m => m[1]);
+  return [...htmlImg, ...mdImg];
+}
+
+function isLocal(src: string): boolean {
+  return !/^(https?:)?\/\//i.test(src) && !src.startsWith('data:');
+}
+
+describe('help-docs image paths (#1056)', () => {
+  it('uses only base-relative local image paths (no ../ or leading /)', () => {
+    const offenders: string[] = [];
+
+    for (const file of listMarkdownFiles(HELP_DOCS_DIR)) {
+      const content = readFileSync(file, 'utf-8');
+      for (const src of extractImageSrcs(content)) {
+        if (isLocal(src) && (src.startsWith('../') || src.startsWith('/'))) {
+          offenders.push(`${file.replace(cwd() + '/', '')} -> ${src}`);
+        }
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/src/assets/help-docs/chartplotter.md
+++ b/src/assets/help-docs/chartplotter.md
@@ -39,7 +39,7 @@ The transition is automatic; no manual toggle is required. The per‑dashboard c
 2. Drag the split divider and release.
 3. Press **Save** (check icon) to persist globally, or **Cancel** (X) to revert to the previous ratio.
 
-<img src="../../assets/help-docs/img/splitdeviderhandle.png" alt="Resize the split" title="Split handle" width="100%">
+<img src="assets/help-docs/img/splitdeviderhandle.png" alt="Resize the split" title="Split handle" width="100%">
 
 >**Notes:**
 >- Width changes are only committed on Save (prevents accidental layout shifts).

--- a/src/assets/help-docs/welcome.md
+++ b/src/assets/help-docs/welcome.md
@@ -13,7 +13,7 @@ KIP supports multiple input modes for seamless navigation across devices.
 > Note that the words Touch and Tap are synonymous with mouse click.
 
 ## General Layout
-<img src="../../assets/help-docs/img/general-layout.png" alt="Sidebar Menus" title="Sidebar Menus" width="100%">
+<img src="assets/help-docs/img/general-layout.png" alt="Sidebar Menus" title="Sidebar Menus" width="100%">
 
 1. Actions menu
 2. *Fullscreen toggle button


### PR DESCRIPTION
Fixes #1056

### Problem
Help page images returned 404 on a real Signal K server (confirmed broken in the public demo): the browser requested `/assets/help-docs/img/...` instead of `/@mxtommy/kip/assets/help-docs/img/...`.

### Root cause
`welcome.md` and `chartplotter.md` referenced images as `../../assets/help-docs/img/...`. The `../../` climbs above the `/@mxtommy/kip/` base href, so the path resolves to the server root. (`ng serve` serves at root, which is why it worked locally.) `index.html` already uses base-relative `assets/...` for its own assets.

### Fix
Changed the two image references to base-relative `assets/help-docs/img/...`, which resolves correctly both in local dev and under the deployed base href.

### Tests
New guard spec scans every `help-docs` markdown file and fails if any local image path escapes the base href (`../` or leading `/`), preventing regressions. Committed test-first (RED then GREEN).
