### PR TITLE
Add configurable browser tab title (#1055)

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -28,6 +28,8 @@ import { RemoteDashboardsService } from './core/services/remote-dashboards.servi
 import { ToastService } from './core/services/toast.service';
 import { AppNetworkInitService, IBootstrapIssue } from './core/services/app-initNetwork.service';
 import { DashboardHistorySeriesSyncService } from './core/services/dashboard-history-series-sync.service';
+import { Title } from '@angular/platform-browser';
+import { resolveBrowserTabTitle } from './core/utils/browser-tab-title.util';
 
 @Component({
   selector: 'app-root',
@@ -62,6 +64,8 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
   private readonly _uiEvent = inject(uiEventService);
   private readonly _dialog = inject(DialogService);
   public readonly settings = inject(SettingsService);
+  private readonly _titleService = inject(Title);
+  private readonly _browserTabTitle = toSignal(this.settings.getBrowserTabTitleAsO(), { initialValue: 'KIP' });
   private readonly _responsive = inject(BreakpointObserver);
   private readonly _destroyRef = inject(DestroyRef);
   private readonly _notificationOverlay = inject(NotificationOverlayService);
@@ -89,6 +93,11 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
   private readonly _hotkeyHandler = (key: string) => this.handleKeyDown(key);
 
   constructor() {
+    // Keep the browser tab title (document.title) in sync with the user setting (#1055).
+    effect(() => {
+      this._titleService.setTitle(resolveBrowserTabTitle(this._browserTabTitle()));
+    });
+
     effect(() => {
       if (this.settings.configUpgrade()) {
         const liveVersion = this.settings.getConfigVersion();

--- a/src/app/core/components/options/display/display.component.html
+++ b/src/app/core/components/options/display/display.component.html
@@ -58,6 +58,26 @@
       <mat-expansion-panel>
         <mat-expansion-panel-header>
           <mat-panel-title>
+            Browser Tab
+          </mat-panel-title>
+          @if (!isPhonePortrait().matches) {
+            <mat-panel-description>
+              Set the browser tab title to tell multiple KIP instances apart.
+            </mat-panel-description>
+          }
+        </mat-expansion-panel-header>
+        <mat-form-field class="optional-field">
+          <mat-label>Browser tab title</mat-label>
+          <input matInput
+            (ngModelChange)="displayForm.form.markAsDirty()"
+            name="browserTabTitle"
+            placeholder="Ex. Mast-KIP"
+            [(ngModel)]="browserTabTitle">
+        </mat-form-field>
+      </mat-expansion-panel>
+      <mat-expansion-panel>
+        <mat-expansion-panel-header>
+          <mat-panel-title>
             Chartplotter Mode
           </mat-panel-title>
           @if (!isPhonePortrait().matches) {

--- a/src/app/core/components/options/display/display.component.ts
+++ b/src/app/core/components/options/display/display.component.ts
@@ -57,6 +57,7 @@ export class SettingsDisplayComponent implements OnInit {
   protected isLightTheme = model<boolean>(false);
   protected isRemoteControl = model<boolean>(false);
   protected instanceName = model<string>('');
+  protected browserTabTitle = model<string>('KIP');
   protected splitShellEnabled = model<boolean>(false);
   protected splitShellSide = model<'left' | 'right'>('left');
   protected splitShellSwipeDisabled = model<boolean>(false);
@@ -78,6 +79,7 @@ export class SettingsDisplayComponent implements OnInit {
     this.isRedNightMode.set(this.settings.getRedNightMode());
     this.isRemoteControl.set(this.settings.getIsRemoteControl());
     this.instanceName.set(this.settings.getInstanceName());
+    this.browserTabTitle.set(this.settings.getBrowserTabTitle());
     this.splitShellEnabled.set(this.settings.getSplitShellEnabled());
     this.splitShellSide.set(this.settings.getSplitShellSide());
     this.splitShellSwipeDisabled.set(this.settings.getSplitShellSwipeDisabled());
@@ -127,6 +129,7 @@ export class SettingsDisplayComponent implements OnInit {
     this.settings.setSplitShellSide(this.splitShellSide());
     this.settings.setSplitShellSwipeDisabled(this.splitShellSwipeDisabled());
     this.settings.setWidgetHistoryDisabled(this.widgetHistoryDisabled());
+    this.settings.setBrowserTabTitle(this.browserTabTitle());
     this.settings.setDisablePathValidation(this.isPathValidationDisabled());
     if (!this.setKipPluginConfig()) {
       this.toast.show('Failed to save KIP plugin configuration on server.', 0, false, 'error');

--- a/src/app/core/interfaces/app-settings.interfaces.ts
+++ b/src/app/core/interfaces/app-settings.interfaces.ts
@@ -35,6 +35,7 @@ export interface IAppConfig {
   splitShellSwipeDisabled?: boolean;
   splitShellWidth?: number;
   widgetHistoryDisabled?: boolean;
+  browserTabTitle?: string;
 }
 
 export interface IThemeConfig {

--- a/src/app/core/services/settings.service.ts
+++ b/src/app/core/services/settings.service.ts
@@ -38,6 +38,7 @@ export class SettingsService {
   private nightModeBrightness: BehaviorSubject<number> = new BehaviorSubject<number>(1);
   private isRemoteControl: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
   private instanceName: BehaviorSubject<string> = new BehaviorSubject<string>('');
+  private browserTabTitle: BehaviorSubject<string> = new BehaviorSubject<string>('KIP');
   private splitShellEnabled: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
   private splitShellSide: BehaviorSubject<'left' | 'right'> = new BehaviorSubject<'left' | 'right'>('left');
   private splitShellSwipeDisabled: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
@@ -231,6 +232,12 @@ export class SettingsService {
       this.instanceName.next(this.activeConfig.app.instanceName);
     }
 
+    if (this.activeConfig.app.browserTabTitle === undefined) {
+      this.browserTabTitle.next('KIP');
+    } else {
+      this.browserTabTitle.next(this.activeConfig.app.browserTabTitle);
+    }
+
     if (this.activeConfig.app.splitShellEnabled === undefined) {
       this.setSplitShellEnabled(false);
     } else {
@@ -421,6 +428,26 @@ export class SettingsService {
 
   public setInstanceName(name: string) {
     this.instanceName.next(name);
+    const appConf = this.buildAppStorageObject();
+
+    if (this.useSharedConfig) {
+      this.storage.patchConfig('IAppConfig', appConf);
+    } else {
+      this.saveAppConfigToLocalStorage();
+    }
+  }
+
+  // Browser tab title (document.title)
+  public getBrowserTabTitleAsO() {
+    return this.browserTabTitle.asObservable();
+  }
+
+  public getBrowserTabTitle(): string {
+    return this.browserTabTitle.getValue();
+  }
+
+  public setBrowserTabTitle(title: string) {
+    this.browserTabTitle.next(title);
     const appConf = this.buildAppStorageObject();
 
     if (this.useSharedConfig) {
@@ -681,7 +708,8 @@ export class SettingsService {
       splitShellSide: this.splitShellSide.getValue() ?? 'right',
       splitShellWidth: this.splitShellWidth.getValue() ?? 0.5,
       splitShellSwipeDisabled: this.splitShellSwipeDisabled.getValue(),
-      widgetHistoryDisabled: this.widgetHistoryDisabled.getValue()
+      widgetHistoryDisabled: this.widgetHistoryDisabled.getValue(),
+      browserTabTitle: this.browserTabTitle.getValue()
     }
     return storageObject;
   }

--- a/src/app/core/utils/browser-tab-title.util.spec.ts
+++ b/src/app/core/utils/browser-tab-title.util.spec.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { resolveBrowserTabTitle } from './browser-tab-title.util';
+
+describe('resolveBrowserTabTitle (#1055)', () => {
+  it('defaults to KIP when the value is missing or blank', () => {
+    expect(resolveBrowserTabTitle(undefined)).toBe('KIP');
+    expect(resolveBrowserTabTitle(null)).toBe('KIP');
+    expect(resolveBrowserTabTitle('')).toBe('KIP');
+    expect(resolveBrowserTabTitle('   ')).toBe('KIP');
+  });
+
+  it('uses the trimmed configured value when set', () => {
+    expect(resolveBrowserTabTitle('Mast-KIP')).toBe('Mast-KIP');
+    expect(resolveBrowserTabTitle('  Port Engine  ')).toBe('Port Engine');
+  });
+});

--- a/src/app/core/utils/browser-tab-title.util.ts
+++ b/src/app/core/utils/browser-tab-title.util.ts
@@ -3,6 +3,6 @@
  * Falls back to 'KIP' when the value is empty/whitespace so the tab is never blank (#1055).
  */
 export function resolveBrowserTabTitle(value?: string | null): string {
-  // RED stub: returns the raw value (no default / no trim) - replaced by the fix.
-  return (value ?? '') as string;
+  const trimmed = (value ?? '').trim();
+  return trimmed.length ? trimmed : 'KIP';
 }

--- a/src/app/core/utils/browser-tab-title.util.ts
+++ b/src/app/core/utils/browser-tab-title.util.ts
@@ -1,0 +1,8 @@
+/**
+ * Resolves the browser tab title (document.title) from the user-configured value.
+ * Falls back to 'KIP' when the value is empty/whitespace so the tab is never blank (#1055).
+ */
+export function resolveBrowserTabTitle(value?: string | null): string {
+  // RED stub: returns the raw value (no default / no trim) - replaced by the fix.
+  return (value ?? '') as string;
+}

--- a/src/default-config/config.blank.const.ts
+++ b/src/default-config/config.blank.const.ts
@@ -16,7 +16,8 @@ export const DefaultAppConfig: IAppConfig = {
   "splitShellEnabled": true,
   "splitShellSide": "left",
   "splitShellSwipeDisabled": false,
-  "splitShellWidth": 0.5
+  "splitShellWidth": 0.5,
+  "browserTabTitle": "KIP"
 }
 
 export const DefaultThemeConfig: IThemeConfig = {


### PR DESCRIPTION
Fixes #1055

### Problem
The browser tab title is hardcoded to `KIP`, so users running several KIP instances (per boat / mast / engine) can't tell their tabs apart.

### Fix
Adds a persisted `browserTabTitle` app setting (mirrors the existing `instanceName` pattern in `SettingsService`, defaulting to `KIP`), a **Browser Tab** field in Settings → Display, and an effect in `AppComponent` that keeps `document.title` in sync via Angular's `Title` service. A blank value falls back to `KIP`, and the resolver trims whitespace.

### Tests
`resolveBrowserTabTitle()` is a small pure helper unit-tested for the default/trim behavior (committed test-first, RED then GREEN). The settings accessors mirror the established `instanceName` pattern, and the whole feature (types + AOT templates) is verified by a production build.

### Notes
Existing stored configs without the field default to `KIP` on load, so behavior is unchanged for current users.
