### PR TITLE
Render advancedwind wind shift as a signed angle in real-time charts (#1070)

### DIFF
--- a/src/app/core/services/dataset-stream.service.spec.ts
+++ b/src/app/core/services/dataset-stream.service.spec.ts
@@ -381,4 +381,16 @@ describe('DatasetStreamService', () => {
         expect(final.lastMinimum).toBeCloseTo(6.1959188446, 6); // 355°
         expect(final.lastMaximum).toBeCloseTo(0.0872664626, 6); // 5°
     }));
+
+    it('treats the advancedwind wind-shift path as a signed angle, while its fast/slow trend siblings stay compass directions (#1070)', inject([DatasetStreamService], (service: DatasetStreamService) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const resolve = (path: string, unit: string) => (service as any).resolveAngleDomain(path, unit);
+
+        // advancedwind publishes the wind SHIFT (fast−slow delta) in −π..π; it must keep its sign
+        // instead of wrapping into the 0..2π compass domain (the #1070 discontinuity).
+        expect(resolve('self.environment.wind.directionTrue.trend.shift', 'rad')).toBe('signed');
+        // The .fast/.slow trend averages are absolute compass directions and must NOT be signed.
+        expect(resolve('self.environment.wind.directionTrue.trend.fast', 'rad')).toBe('direction');
+        expect(resolve('self.environment.wind.directionTrue.trend.slow', 'rad')).toBe('direction');
+    }));
 });

--- a/src/app/core/services/dataset-stream.service.ts
+++ b/src/app/core/services/dataset-stream.service.ts
@@ -80,8 +80,6 @@ export class DatasetStreamService implements OnDestroy {
     "self.environment.wind.angleTrueGround",
     "self.environment.wind.angleTrueWater",
     "self.steering.rudderAngle",
-    // advancedwind wind shift is a fast−slow direction delta in (−π, π]; it is named
-    // "directionTrue.*" but is signed, unlike its .fast/.slow siblings (0..2π). (#1070)
     "self.environment.wind.directionTrue.trend.shift"
   ]);
 

--- a/src/app/core/services/dataset-stream.service.ts
+++ b/src/app/core/services/dataset-stream.service.ts
@@ -79,7 +79,10 @@ export class DatasetStreamService implements OnDestroy {
     "self.environment.wind.angleApparent",
     "self.environment.wind.angleTrueGround",
     "self.environment.wind.angleTrueWater",
-    "self.steering.rudderAngle"
+    "self.steering.rudderAngle",
+    // advancedwind wind shift is a fast−slow direction delta in (−π, π]; it is named
+    // "directionTrue.*" but is signed, unlike its .fast/.slow siblings (0..2π). (#1070)
+    "self.environment.wind.directionTrue.trend.shift"
   ]);
 
   constructor() {


### PR DESCRIPTION
Fixes #1070

### Problem
The real-time Data Chart wrapped the advancedwind plugin's **wind shift** (`environment.wind.directionTrue.trend.shift`, published in −π…π) into the 0–360° compass domain, so a series like `3, 2, 1, 0, -1, -2, -3` displayed as `3, 2, 1, 0, 359, 358, 357` — the discontinuity in #1070.

### Fix
Add the wind-shift path to the existing `signedAnglePaths` allowlist in `DatasetStreamService`. Zero-config: the chart renders it in its native −180…180° range for everyone, no UI and no per-chart setting.

Verified against the [advancedwind docs](https://github.com/Asw1n/advancedwind): only `.trend.shift` is a signed delta (it's `fast − slow`). Its `.trend.fast` / `.trend.slow` siblings are absolute compass directions (0–360°), so they are intentionally **left as `direction`** — the fix classifies exactly one path, and a regression assertion pins that the siblings stay compass.

Note: the path is named `directionTrue.trend.shift` but is signed, which is why it needs to be listed explicitly (the "name has *direction* → 0–360" heuristic doesn't hold for a delta).

### Tests
Test-first (RED → GREEN): `resolveAngleDomain` returns `signed` for the wind-shift path and `direction` for its fast/slow siblings. Lint + production build clean.

_(Replaces the earlier per-chart "Angle display range" override — adding the path directly is the smaller-footprint fix suggested in review.)_
