### PR TITLE
Fix pre-existing client test-suite failures (54 → 0)

### DIFF
--- a/src/app/core/components/options/display/display.component.spec.ts
+++ b/src/app/core/components/options/display/display.component.spec.ts
@@ -31,6 +31,7 @@ class ToastServiceMock {
 }
 
 class SettingsServiceMock {
+    public getDisablePathValidation() { return false; }
     public getNightModeBrightness() { return 0.27; }
     public getAutoNightMode() { return false; }
     public getThemeName() { return ''; }

--- a/src/app/core/services/settings.service.ts
+++ b/src/app/core/services/settings.service.ts
@@ -145,7 +145,9 @@ export class SettingsService {
    * @memberof SettingsService
    */
   public loadConfigFromLocalStorage(type: string) {
-    let config = JSON.parse(localStorage.getItem(type) ?? '');
+    // A missing key returns null; JSON.parse('') would throw, so fall back to the string 'null'
+    // which parses to null and triggers the default-loading branch below (the intended behavior).
+    let config = JSON.parse(localStorage.getItem(type) ?? 'null');
 
     if (config === null) {
       console.log(`[AppSettings Service] Error loading ${type} config. Force loading ${type} defaults`);

--- a/src/app/core/services/widget.service.spec.ts
+++ b/src/app/core/services/widget.service.spec.ts
@@ -18,8 +18,11 @@ describe('WidgetService', () => {
     const selectors = service.kipWidgets.map(widget => widget.selector);
 
     expect(selectors).toContain('widget-charger');
-    expect(selectors).toContain('widget-inverter');
-    expect(selectors).toContain('widget-alternator');
-    expect(selectors).toContain('widget-ac');
+    // The Alternator, Inverter and AC Monitor widget definitions are currently commented out in
+    // widget.service.ts (see the /* ... */ block around the electrical family entries), so they are
+    // not registered yet. Re-enable these assertions when those definitions are uncommented.
+    // expect(selectors).toContain('widget-inverter');
+    // expect(selectors).toContain('widget-alternator');
+    // expect(selectors).toContain('widget-ac');
   });
 });

--- a/src/app/widget-config/path-control-config/path-control-config.component.spec.ts
+++ b/src/app/widget-config/path-control-config/path-control-config.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { UntypedFormControl, UntypedFormGroup } from '@angular/forms';
+import { BehaviorSubject } from 'rxjs';
 import { IDynamicControl } from '../../core/interfaces/widgets-interface';
 
 import { PathControlConfigComponent } from './path-control-config.component';
@@ -16,7 +17,18 @@ describe('PathControlConfigComponent', () => {
     await TestBed.configureTestingModule({
       imports: [PathControlConfigComponent],
       providers: [
-        { provide: SignalKConnectionService, useValue: { skServerVersion: '2.14.0' } },
+        {
+          // Real AuthenticationService/StorageService get pulled in via the DI HTTP interceptor and
+          // subscribe to these streams, so mirror the global connection stub (plus skServerVersion).
+          provide: SignalKConnectionService,
+          useValue: {
+            skServerVersion: '2.14.0',
+            serverServiceEndpoint$: new BehaviorSubject({ operation: 0, httpServiceUrl: '', WsServiceUrl: '', subscribeAll: false }),
+            serverVersion$: new BehaviorSubject(null),
+            signalKURL: { url: 'http://localhost' },
+            getServiceEndpointStatusAsO(): unknown { return this.serverServiceEndpoint$.asObservable(); }
+          }
+        },
         {
           provide: DataService,
           useValue: {

--- a/src/test.ts
+++ b/src/test.ts
@@ -4,6 +4,29 @@ import { cwd } from 'node:process';
 // Mark global test flag before anything else so app code can detect test context
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (window as any).__KIP_TEST__ = true;
+
+// jsdom in this unit-test runner ships WITHOUT Web Storage, so `localStorage`/`sessionStorage`
+// are undefined. Any service that reads localStorage in its constructor (AuthenticationService,
+// SettingsService, StorageService, …) throws "Cannot read properties of undefined (reading
+// 'getItem')" and every spec that builds that real service fails. Provide an in-memory polyfill.
+if (typeof globalThis.localStorage === 'undefined') {
+  class MemoryStorage implements Storage {
+    private store = new Map<string, string>();
+    get length(): number { return this.store.size; }
+    clear(): void { this.store.clear(); }
+    getItem(key: string): string | null { return this.store.has(key) ? this.store.get(key)! : null; }
+    key(index: number): string | null { return Array.from(this.store.keys())[index] ?? null; }
+    removeItem(key: string): void { this.store.delete(key); }
+    setItem(key: string, value: string): void { this.store.set(key, String(value)); }
+  }
+  for (const name of ['localStorage', 'sessionStorage']) {
+    const value = new MemoryStorage();
+    Object.defineProperty(globalThis, name, { configurable: true, value });
+    if (typeof window !== 'undefined') {
+      Object.defineProperty(window, name, { configurable: true, value });
+    }
+  }
+}
 // Neutralize hard navigation that break Karma connection
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const loc: any = window.location;
@@ -438,6 +461,8 @@ class SettingsServiceStub {
   public getNightModeBrightness(): number { return this.nightModeBrightnessSubject.value; }
   public getNotificationServiceConfigAsO(): Observable<import('./app/core/interfaces/app-settings.interfaces').INotificationConfig> { return this._notificationConfig.asObservable(); }
   public getNotificationConfig(): import('./app/core/interfaces/app-settings.interfaces').INotificationConfig { return this._notificationConfig.value; }
+  // Used by SettingsDisplayComponent at field init (model<boolean>(this.settings.getDisablePathValidation())).
+  public getDisablePathValidation(): boolean { return false; }
 }
 
 // Lightweight runtime directive stub so components can inject it in tests


### PR DESCRIPTION
## Fix the pre-existing client test-suite failures (54 → 0)

`ng test` on `master` currently reports **54 failed / 308 passed**. This PR triages all of them and brings the client suite to **362 passed / 0 failed**, with one small genuine app-code robustness fix and the rest being test-infra/mock corrections. The plugin suite (`node:test`) is unaffected.

The failures were layered (one root cause masks the next), so each fix was verified with a full-suite run:

| After | Failures |
|------|---------:|
| baseline | 54 |
| localStorage polyfill | 36 |
| safe `JSON.parse` in SettingsService | 6 |
| local-mock fixes | 1 |
| stale-test fix | **0** |

### Root causes & fixes

**1. `localStorage` is undefined in the jsdom test environment.** The jsdom used by `@angular/build:unit-test` ships without Web Storage (a probe confirms `typeof localStorage === 'undefined'`). Four services read `localStorage` in their constructor, so every spec that builds one of those *real* services threw `Cannot read properties of undefined (reading 'getItem')`. → added an in-memory `localStorage`/`sessionStorage` polyfill to `src/test.ts` (test-only).

**2. Unsafe `JSON.parse` in `SettingsService.loadConfigFromLocalStorage` — the one app-code fix.** The line was `JSON.parse(localStorage.getItem(type) ?? '')`; a missing key returns `null` → `?? ''` → `JSON.parse('')` → `SyntaxError: Unexpected end of JSON input`. The very next line already handles `config === null` by loading defaults, so the author *intended* `null` for a missing key. Changed `?? ''` → `?? 'null'` (parses to `null`, hits the existing defaults branch). This is also a latent production robustness bug — worth landing on its own even aside from the tests. The other four `JSON.parse(localStorage.getItem(...))` sites are already safe.

**3. Local service-mocks in specs drifted from the real API.**
- `display.component.spec.ts` — local `SettingsServiceMock` was missing `getDisablePathValidation()` (the component calls it at field init). Added it.
- `path-control-config.component.spec.ts` — its bare `{ skServerVersion }` `SignalKConnectionService` mock caused the real `AuthenticationService`/`StorageService` (pulled in via the DI HTTP-interceptor chain) to throw on `serverServiceEndpoint$`/`serverVersion$`. Mirrored the global connection stub (plus the `skServerVersion` the component uses).

**4. Stale test asserting disabled widgets.** `widget.service.spec.ts` asserted `widget-inverter`/`widget-alternator`/`widget-ac`, but those three definitions are commented out in `widget.service.ts` (only `widget-charger` is active). Commented out those three assertions (kept, not deleted) with a note to re-enable them when the widget definitions are uncommented.

### Notes for review
- Only one change touches app code (`settings.service.ts`, 1 line); everything else is test infrastructure/specs.
- A broader follow-up worth considering: prefer the shared global stubs in `src/test.ts` over ad-hoc per-spec mocks (or a typed mock factory) so mocks can't silently drift from the real interfaces — that's the underlying cause of the category-3 failures.

### Verification
`ng test --watch=false` → **Test Files 98 passed (98) · Tests 362 passed (362)**. `ng lint` clean.
