### PR TITLE
Lazy-load widget components and the history chart dialog

### DIFF
--- a/src/app/core/components/widget-embedded/widget-embedded.component.spec.ts
+++ b/src/app/core/components/widget-embedded/widget-embedded.component.spec.ts
@@ -1,5 +1,80 @@
+import { Component, Type, input } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { of } from 'rxjs';
+import { WidgetEmbeddedComponent } from './widget-embedded.component';
+import { WidgetService } from '../../services/widget.service';
+import { AppService } from '../../services/app-service';
+import { DataService } from '../../services/data.service';
+import { UnitsService } from '../../services/units.service';
+import type { IWidget } from '../../interfaces/widgets-interface';
+
+// A trivial stand-in widget the embedded host will lazy-load and render.
+@Component({
+  selector: 'test-lazy-widget',
+  standalone: true,
+  template: '<span class="test-lazy-widget">loaded</span>'
+})
+class TestLazyWidgetComponent {
+  public id = input<string>();
+  public type = input<string>();
+  public theme = input<unknown>();
+  public static readonly DEFAULT_CONFIG = { displayName: 'Test' };
+}
+
 describe('WidgetEmbeddedComponent', () => {
-	it('placeholder', () => {
-		expect(true).toBe(true);
-	});
+  let fixture: ComponentFixture<WidgetEmbeddedComponent>;
+  const getComponentType = vi.fn();
+
+  const setup = async () => {
+    await TestBed.configureTestingModule({
+      imports: [WidgetEmbeddedComponent],
+      providers: [
+        { provide: WidgetService, useValue: { getComponentType, getDefaultConfig: vi.fn().mockReturnValue(undefined) } },
+        { provide: AppService, useValue: { cssThemeColorRoles$: of({ contrast: '#fff' }) } },
+        // Mocked so the streams/metadata host directives don't construct the real DataService chain.
+        { provide: DataService, useValue: {} },
+        { provide: UnitsService, useValue: { convertToUnit: (_u: string, v: unknown) => v } }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(WidgetEmbeddedComponent);
+    fixture.componentRef.setInput('widgetProperties', {
+      uuid: 'embedded-1',
+      type: 'test-lazy-widget',
+      config: {}
+    } as IWidget);
+  };
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    TestBed.resetTestingModule();
+  });
+
+  it('lazily resolves the widget component and renders it once the chunk loads', async () => {
+    getComponentType.mockResolvedValue(TestLazyWidgetComponent as Type<unknown>);
+    await setup();
+
+    fixture.detectChanges(); // ngOnInit kicks off the async load
+    // Not rendered synchronously: resolution is async (the import has not resolved yet).
+    expect(fixture.nativeElement.querySelector('.test-lazy-widget')).toBeNull();
+
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    // After the (mocked) import resolves, the child widget is created and rendered.
+    expect(getComponentType).toHaveBeenCalledWith('test-lazy-widget');
+    expect(fixture.nativeElement.querySelector('.test-lazy-widget')?.textContent).toContain('loaded');
+  });
+
+  it('does not create a child when the component type fails to resolve', async () => {
+    getComponentType.mockResolvedValue(undefined);
+    await setup();
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.test-lazy-widget')).toBeNull();
+  });
 });

--- a/src/app/core/components/widget-embedded/widget-embedded.component.ts
+++ b/src/app/core/components/widget-embedded/widget-embedded.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, Type, ViewChild, ViewContainerRef, Input, effect, ComponentRef, OnInit } from '@angular/core';
+import { Component, inject, Type, ViewChild, ViewContainerRef, Input, effect, ComponentRef, OnInit, OnDestroy } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { MatCardModule } from '@angular/material/card';
 import { IWidget, IWidgetSvcConfig } from '../../interfaces/widgets-interface';
@@ -74,7 +74,7 @@ interface WidgetViewComponentBase { defaultConfig?: IWidgetSvcConfig }
  * In the parent component template use:
  *   <widget-embedded [widgetProperties]="xteWidgetProps"></widget-embedded>
  */
-export class WidgetEmbeddedComponent implements OnInit {
+export class WidgetEmbeddedComponent implements OnInit, OnDestroy {
   @Input({ required: true }) protected widgetProperties!: IWidget;
   // Mark static:true so the outlet is available during ngOnInit allowing
   // runtime initialization + child creation before the first stability check.
@@ -87,6 +87,7 @@ export class WidgetEmbeddedComponent implements OnInit {
   protected theme = toSignal(this._app.cssThemeColorRoles$, { requireSync: true });
   private childRef: ComponentRef<WidgetViewComponentBase>;
   private compType: Type<WidgetViewComponentBase>
+  private _destroyed = false;
 
   constructor() {
     effect(() => {
@@ -100,7 +101,17 @@ export class WidgetEmbeddedComponent implements OnInit {
   ngOnInit(): void {
     const type = this.widgetProperties.type;
     if (!type) return;
-    this.compType = this._widgetService.getComponentType(type) as Type<WidgetViewComponentBase> | undefined;
+    // Widget components are lazy-loaded, so resolution is async.
+    void this.loadAndCreateChild(type);
+  }
+
+  ngOnDestroy(): void {
+    this._destroyed = true;
+  }
+
+  private async loadAndCreateChild(type: string): Promise<void> {
+    this.compType = await this._widgetService.getComponentType(type) as Type<WidgetViewComponentBase> | undefined;
+    if (this._destroyed) return; // host torn down while the chunk loaded
 
     // Initialize runtime
     this._runtime?.initialize?.(undefined, this.widgetProperties.config);
@@ -110,13 +121,14 @@ export class WidgetEmbeddedComponent implements OnInit {
     this._streams?.applyStreamsConfigDiff?.(merged);
     this._meta?.applyMetaConfigDiff?.(merged);
 
-    // Create the child component BEFORE first change detection completes so its
     if (this.outlet && this.compType) {
       this.childRef = this.outlet.createComponent(this.compType);
       this.childRef.setInput('id', this.widgetProperties.uuid);
       this.childRef.setInput('type', this.widgetProperties.type);
       // Pass current theme value; ongoing updates handled by effect in ctor.
       this.childRef.setInput('theme', this.theme());
+      // Created after the import resolved (outside the initial CD pass), so render it now.
+      this.childRef.changeDetectorRef.detectChanges();
     }
   }
 }

--- a/src/app/core/components/widget-host2/widget-host2.component.ts
+++ b/src/app/core/components/widget-host2/widget-host2.component.ts
@@ -80,6 +80,7 @@ export class WidgetHost2Component extends BaseWidget implements OnInit, OnDestro
   private childRef: ComponentRef<WidgetViewComponentBase> | null = null;
   private compType: Type<WidgetViewComponentBase>
   private _hasInitialized = false;
+  private _destroyed = false;
   private readonly openOverlays = new Set<TOverlayGate>();
   // Debug helper gated by the same localStorage flag used by gestures directive
   private isDebugEnabled(): boolean {
@@ -122,7 +123,19 @@ export class WidgetHost2Component extends BaseWidget implements OnInit, OnDestro
     if (shouldAutoOpenOptions) {
       delete this.widgetProperties.autoOpenOptionsOnCreate;
     }
-    this.compType = this.widgetService.getComponentType(type) as Type<WidgetViewComponentBase> | undefined;
+    // Widget components are lazy-loaded, so resolution is async. Kick it off; the child is created
+    // once its chunk resolves (instant for an already-loaded type, a fetch on first use).
+    void this.loadAndCreateChild(type, shouldAutoOpenOptions);
+  }
+
+  /**
+   * Resolve (lazy-import) the widget component, initialize the runtime/streams from its default +
+   * saved config, and create the child view. Awaiting the import means this runs after the initial
+   * render, so it guards against the host being destroyed mid-load and explicitly renders the child.
+   */
+  private async loadAndCreateChild(type: string, shouldAutoOpenOptions: boolean): Promise<void> {
+    this.compType = await this.widgetService.getComponentType(type) as Type<WidgetViewComponentBase> | undefined;
+    if (this._destroyed) return; // host was torn down while the chunk loaded
 
     // Resolve default configuration for this component type using helper
     const defaultCfg = this.getDefaultConfig();
@@ -135,7 +148,6 @@ export class WidgetHost2Component extends BaseWidget implements OnInit, OnDestro
     this.streams?.applyStreamsConfigDiff?.(merged);
     this.meta?.applyMetaConfigDiff?.(merged);
 
-    // Create the child component BEFORE first change detection completes so its
     if (this.outlet && this.compType) {
       this.childRef = this.outlet.createComponent(this.compType, {
         bindings: [
@@ -144,6 +156,8 @@ export class WidgetHost2Component extends BaseWidget implements OnInit, OnDestro
           inputBinding('theme', this.theme)
         ]
       });
+      // Created outside the initial CD pass (after the import resolved), so render it now.
+      this.childRef.changeDetectorRef.detectChanges();
     }
     this._hasInitialized = true;
 
@@ -153,6 +167,7 @@ export class WidgetHost2Component extends BaseWidget implements OnInit, OnDestro
   }
 
   ngOnDestroy(): void {
+    this._destroyed = true;
     this.childRef?.destroy();
     this.childRef = null;
     this.openOverlays.clear();
@@ -407,11 +422,12 @@ export class WidgetHost2Component extends BaseWidget implements OnInit, OnDestro
         || familyDescriptor?.displayTitle
         || 'Widget Data History';
 
-      this.dialog.openWidgetHistoryDialog({
+      const dialogRef = await this.dialog.openWidgetHistoryDialog({
         title,
         widget: this.widgetProperties,
         seriesDefinitions
-      }).afterClosed().subscribe(() => {
+      });
+      dialogRef.afterClosed().subscribe(() => {
         this.releaseOverlay('history');
       });
     } catch (error) {

--- a/src/app/core/services/dashboard-history-series-sync.service.spec.ts
+++ b/src/app/core/services/dashboard-history-series-sync.service.spec.ts
@@ -172,6 +172,7 @@ describe('DashboardHistorySeriesSyncService', () => {
     };
     let widgetServiceMock: {
         getComponentType: Mock;
+        getDefaultConfig: Mock;
     };
     let reconcileSpy: Mock;
 
@@ -192,7 +193,8 @@ describe('DashboardHistorySeriesSyncService', () => {
         });
 
         widgetServiceMock = {
-            getComponentType: vi.fn().mockReturnValue(undefined)
+            getComponentType: vi.fn().mockResolvedValue(undefined),
+            getDefaultConfig: vi.fn().mockReturnValue(undefined)
         };
 
         TestBed.configureTestingModule({
@@ -893,33 +895,31 @@ describe('DashboardHistorySeriesSyncService', () => {
     });
 
     it('resolves numeric paths from widget DEFAULT_CONFIG when saved config is partial', () => {
-        widgetServiceMock.getComponentType.mockImplementation((selector: string) => {
+        widgetServiceMock.getDefaultConfig.mockImplementation((selector: string) => {
             if (selector !== 'widget-horizon') {
                 return undefined;
             }
 
             return {
-                DEFAULT_CONFIG: {
-                    supportAutomaticHistoricalSeries: true,
-                    timeScale: 'minute',
-                    period: 30,
-                    paths: {
-                        gaugePitchPath: {
-                            description: 'Pitch',
-                            path: 'self.navigation.attitude.pitch',
-                            source: 'default',
-                            pathType: 'number',
-                            isPathConfigurable: true,
-                            sampleTime: 1000
-                        },
-                        gaugeRollPath: {
-                            description: 'Roll',
-                            path: 'self.navigation.attitude.roll',
-                            source: 'default',
-                            pathType: 'number',
-                            isPathConfigurable: true,
-                            sampleTime: 1000
-                        }
+                supportAutomaticHistoricalSeries: true,
+                timeScale: 'minute',
+                period: 30,
+                paths: {
+                    gaugePitchPath: {
+                        description: 'Pitch',
+                        path: 'self.navigation.attitude.pitch',
+                        source: 'default',
+                        pathType: 'number',
+                        isPathConfigurable: true,
+                        sampleTime: 1000
+                    },
+                    gaugeRollPath: {
+                        description: 'Roll',
+                        path: 'self.navigation.attitude.roll',
+                        source: 'default',
+                        pathType: 'number',
+                        isPathConfigurable: true,
+                        sampleTime: 1000
                     }
                 }
             };

--- a/src/app/core/services/dashboard-history-series-sync.service.ts
+++ b/src/app/core/services/dashboard-history-series-sync.service.ts
@@ -208,12 +208,11 @@ export class DashboardHistorySeriesSyncService {
   }
 
   private getDefaultConfigForType(widgetType: string): IWidgetSvcConfig | undefined {
-    try {
-      const comp = this.widgetService.getComponentType(widgetType) as { DEFAULT_CONFIG?: IWidgetSvcConfig } | undefined;
-      return comp?.DEFAULT_CONFIG;
-    } catch {
-      return undefined;
-    }
+    // Reads the widget's static DEFAULT_CONFIG from WidgetService's cache, which is populated when
+    // the widget component is lazy-loaded (i.e. rendered). Returns undefined for widgets whose chunk
+    // has not been fetched yet; the saved config alone is then used, and a later reconcile picks up
+    // the defaults once the widget has loaded.
+    return this.widgetService.getDefaultConfig(widgetType);
   }
 
   private collectSeriesFromNodes(nodes: IGridWidgetNode[], sink: IKipSeriesDefinition[]): void {

--- a/src/app/core/services/dialog.service.ts
+++ b/src/app/core/services/dialog.service.ts
@@ -10,7 +10,7 @@ import { WidgetsListComponent } from '../components/widgets-list/widgets-list.co
 import { UpgradeConfigComponent } from '../components/upgrade-config/upgrade-config.component';
 import { DialogDashboardPageEditorComponent } from '../components/dialog-dashboard-page-editor/dialog-dashboard-page-editor.component';
 import { DialogAisTargetComponent } from '../../widgets/widget-ais-radar/dialog-ais-target/dialog-ais-target.component';
-import { IWidgetHistoryChartDialogData, WidgetHistoryChartDialogComponent } from '../components/widget-history-chart-dialog/widget-history-chart-dialog.component';
+import type { IWidgetHistoryChartDialogData, WidgetHistoryChartDialogComponent } from '../components/widget-history-chart-dialog/widget-history-chart-dialog.component';
 
 @Injectable({
   providedIn: 'root'
@@ -104,12 +104,16 @@ export class DialogService {
    * Opens a history-only chart dialog for a widget.
    *
    * @param {IWidgetHistoryChartDialogData} data Widget history dialog payload.
-   * @returns {MatDialogRef<WidgetHistoryChartDialogComponent>} Dialog reference.
+   * @returns {Promise<MatDialogRef<WidgetHistoryChartDialogComponent>>} Dialog reference.
+   *
+   * @remarks The history chart dialog (and its chart.js dependency) is lazy-loaded so it stays out
+   * of the initial bundle and is only fetched the first time a user opens widget history.
    *
    * @example
-   * const ref = dialogService.openWidgetHistoryDialog({ title: 'History', widget, seriesDefinitions });
+   * const ref = await dialogService.openWidgetHistoryDialog({ title: 'History', widget, seriesDefinitions });
    */
-  public openWidgetHistoryDialog(data: IWidgetHistoryChartDialogData): MatDialogRef<WidgetHistoryChartDialogComponent> {
+  public async openWidgetHistoryDialog(data: IWidgetHistoryChartDialogData): Promise<MatDialogRef<WidgetHistoryChartDialogComponent>> {
+    const { WidgetHistoryChartDialogComponent } = await import('../components/widget-history-chart-dialog/widget-history-chart-dialog.component');
     return this.dialog.open(WidgetHistoryChartDialogComponent,
       {
         data,

--- a/src/app/core/services/widget.service.spec.ts
+++ b/src/app/core/services/widget.service.spec.ts
@@ -22,4 +22,28 @@ describe('WidgetService', () => {
     expect(selectors).toContain('widget-alternator');
     expect(selectors).toContain('widget-ac');
   });
+
+  it('lazily resolves a component type as a promise and dedupes concurrent lookups', async () => {
+    const p1 = service.getComponentType('widget-text');
+    const p2 = service.getComponentType('widget-text');
+    expect(p1).toBeInstanceOf(Promise);
+    expect(p1).toBe(p2); // same in-flight promise reused (single import())
+
+    const type = await p1;
+    expect(type).toBeTruthy();
+  });
+
+  it('resolves undefined for an unknown selector without attempting an import', async () => {
+    await expect(service.getComponentType('widget-does-not-exist')).resolves.toBeUndefined();
+  });
+
+  it('exposes DEFAULT_CONFIG only after the component has been loaded', async () => {
+    // Not fetched yet: config-only consumers get undefined and fall back to saved config.
+    expect(service.getDefaultConfig('widget-text')).toBeUndefined();
+
+    await service.getComponentType('widget-text');
+
+    // Once the chunk has loaded, the static DEFAULT_CONFIG is cached for synchronous reads.
+    expect(service.getDefaultConfig('widget-text')).toBeDefined();
+  });
 });

--- a/src/app/core/services/widget.service.ts
+++ b/src/app/core/services/widget.service.ts
@@ -1,41 +1,11 @@
 import { inject, Injectable } from '@angular/core';
 import { Type } from '@angular/core';
 import { PluginConfigClientService } from './plugin-config-client.service';
-import { WidgetNumericComponent } from '../../widgets/widget-numeric/widget-numeric.component';
-import { WidgetTextComponent } from '../../widgets/widget-text/widget-text.component';
-import { WidgetWindTrendsChartComponent } from '../../widgets/widget-windtrends-chart/widget-windtrends-chart.component';
-import { WidgetWindComponent } from '../../widgets/widget-windsteer/widget-windsteer.component';
-import { WidgetTutorialComponent } from '../../widgets/widget-tutorial/widget-tutorial.component';
-import { WidgetSliderComponent } from '../../widgets/widget-slider/widget-slider.component';
-import { WidgetSimpleLinearComponent } from '../../widgets/widget-simple-linear/widget-simple-linear.component';
-import { WidgetRacesteerComponent } from '../../widgets/widget-racesteer/widget-racesteer.component';
-import { WidgetRacerTimerComponent } from '../../widgets/widget-racer-timer/widget-racer-timer.component';
-import { WidgetRacerLineComponent } from '../../widgets/widget-racer-line/widget-racer-line.component';
-import { WidgetRaceTimerComponent } from '../../widgets/widget-race-timer/widget-race-timer.component';
-import { WidgetPositionComponent } from '../../widgets/widget-position/widget-position.component';
-import { WidgetAisRadarComponent } from '../../widgets/widget-ais-radar/widget-ais-radar.component';
-import { WidgetLabelComponent } from '../../widgets/widget-label/widget-label.component';
-import { WidgetIframeComponent } from '../../widgets/widget-iframe/widget-iframe.component';
-import { WidgetHorizonComponent } from '../../widgets/widget-horizon/widget-horizon.component';
-import { WidgetHeelGaugeComponent } from '../../widgets/widget-heel-gauge/widget-heel-gauge.component';
-import { WidgetSteelGaugeComponent } from '../../widgets/widget-gauge-steel/widget-gauge-steel.component';
-import { WidgetGaugeNgRadialComponent } from '../../widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component';
-import { WidgetGaugeNgLinearComponent } from '../../widgets/widget-gauge-ng-linear/widget-gauge-ng-linear.component';
-import { WidgetGaugeNgCompassComponent } from '../../widgets/widget-gauge-ng-compass/widget-gauge-ng-compass.component';
-import { WidgetFreeboardskComponent } from '../../widgets/widget-freeboardsk/widget-freeboardsk.component';
-import { WidgetAnchorAlarmComponent } from '../../widgets/widget-anchor-alarm/widget-anchor-alarm.component';
-import { WidgetDatetimeComponent } from '../../widgets/widget-datetime/widget-datetime.component';
-import { WidgetDataChartComponent } from '../../widgets/widget-data-chart/widget-data-chart.component';
-import { WidgetBooleanSwitchComponent } from '../../widgets/widget-boolean-switch/widget-boolean-switch.component';
-import { WidgetMultiStateSwitchComponent } from '../../widgets/widget-multi-state-switch/widget-multi-state-switch.component';
-import { WidgetZonesStatePanelComponent } from '../../widgets/widget-zones-state-panel/widget-zones-state-panel.component';
-import { WidgetAutopilotComponent } from '../../widgets/widget-autopilot/widget-autopilot.component';
-import { WidgetBmsComponent } from '../../widgets/widget-bms/widget-bms.component';
-import { WidgetSolarChargerComponent } from '../../widgets/widget-solar-charger/widget-solar-charger.component';
-import { WidgetChargerComponent } from '../../widgets/widget-charger/widget-charger.component';
-import { WidgetInverterComponent } from '../../widgets/widget-inverter/widget-inverter.component';
-import { WidgetAlternatorComponent } from '../../widgets/widget-alternator/widget-alternator.component';
-import { WidgetAcComponent } from '../../widgets/widget-ac/widget-ac.component';
+import type { IWidgetSvcConfig } from '../interfaces/widgets-interface';
+// Widget view components are NOT imported statically. They are loaded on demand through the lazy
+// loader map below so each widget's code (and its heavy vendor deps: chart.js, d3, canvas-gauges,
+// etc.) ships in its own chunk and is only downloaded when that widget type is actually placed on a
+// dashboard. See `_componentTypeMap` and `getComponentType()`.
 
 export const WIDGET_CATEGORIES = ['Core', 'Gauge', 'Component', 'Racing'] as const;
 export type TWidgetCategories = typeof WIDGET_CATEGORIES[number];
@@ -138,45 +108,49 @@ export class WidgetService {
   private readonly _pluginConfig = inject(PluginConfigClientService);
   private readonly _widgetCategories = [...WIDGET_CATEGORIES];
   // Cache for selector -> component Type resolutions to avoid repeated definition scans
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private readonly _componentTypeCache = new Map<string, Type<any> | undefined>();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private readonly _componentTypeMap: Record<string, Type<any>> = {
-    WidgetNumericComponent: WidgetNumericComponent,
-    WidgetTextComponent: WidgetTextComponent,
-    WidgetWindTrendsChartComponent: WidgetWindTrendsChartComponent,
-    WidgetWindComponent: WidgetWindComponent,
-    WidgetTutorialComponent: WidgetTutorialComponent,
-    WidgetSliderComponent: WidgetSliderComponent,
-    WidgetSimpleLinearComponent: WidgetSimpleLinearComponent,
-    WidgetRacesteerComponent: WidgetRacesteerComponent,
-    WidgetRacerTimerComponent: WidgetRacerTimerComponent,
-    WidgetRacerLineComponent: WidgetRacerLineComponent,
-    WidgetRaceTimerComponent: WidgetRaceTimerComponent,
-    WidgetPositionComponent: WidgetPositionComponent,
-    WidgetAisRadarComponent: WidgetAisRadarComponent,
-    WidgetLabelComponent: WidgetLabelComponent,
-    WidgetIframeComponent: WidgetIframeComponent,
-    WidgetHorizonComponent: WidgetHorizonComponent,
-    WidgetHeelGaugeComponent: WidgetHeelGaugeComponent,
-    WidgetSteelGaugeComponent: WidgetSteelGaugeComponent,
-    WidgetGaugeNgRadialComponent: WidgetGaugeNgRadialComponent,
-    WidgetGaugeNgLinearComponent: WidgetGaugeNgLinearComponent,
-    WidgetGaugeNgCompassComponent: WidgetGaugeNgCompassComponent,
-    WidgetFreeboardskComponent: WidgetFreeboardskComponent,
-    WidgetAnchorAlarmComponent: WidgetAnchorAlarmComponent,
-    WidgetDatetimeComponent: WidgetDatetimeComponent,
-    WidgetDataChartComponent: WidgetDataChartComponent,
-    WidgetBooleanSwitchComponent: WidgetBooleanSwitchComponent,
-    WidgetMultiStateSwitchComponent: WidgetMultiStateSwitchComponent,
-    WidgetZonesStatePanelComponent: WidgetZonesStatePanelComponent,
-    WidgetAutopilotComponent: WidgetAutopilotComponent,
-    WidgetBmsComponent: WidgetBmsComponent,
-    WidgetSolarChargerComponent: WidgetSolarChargerComponent,
-    WidgetChargerComponent: WidgetChargerComponent,
-    WidgetInverterComponent: WidgetInverterComponent,
-    WidgetAlternatorComponent: WidgetAlternatorComponent,
-    WidgetAcComponent: WidgetAcComponent
+  // Resolved component-type promises, deduped per selector so repeat/concurrent lookups reuse one import().
+  private readonly _componentTypePromise = new Map<string, Promise<Type<unknown> | undefined>>();
+  // Static DEFAULT_CONFIG captured when a widget loads, so config-only consumers (historical-series
+  // reconciliation) can read it synchronously without forcing a chunk download.
+  private readonly _defaultConfigCache = new Map<string, IWidgetSvcConfig | undefined>();
+  // Lazy loaders: each value dynamically imports its widget component on first use, so the widget's
+  // code + vendor deps live in a separate chunk fetched only when that widget type is instantiated.
+  private readonly _componentTypeMap: Record<string, () => Promise<Type<unknown>>> = {
+    WidgetNumericComponent: () => import('../../widgets/widget-numeric/widget-numeric.component').then(m => m.WidgetNumericComponent),
+    WidgetTextComponent: () => import('../../widgets/widget-text/widget-text.component').then(m => m.WidgetTextComponent),
+    WidgetWindTrendsChartComponent: () => import('../../widgets/widget-windtrends-chart/widget-windtrends-chart.component').then(m => m.WidgetWindTrendsChartComponent),
+    WidgetWindComponent: () => import('../../widgets/widget-windsteer/widget-windsteer.component').then(m => m.WidgetWindComponent),
+    WidgetTutorialComponent: () => import('../../widgets/widget-tutorial/widget-tutorial.component').then(m => m.WidgetTutorialComponent),
+    WidgetSliderComponent: () => import('../../widgets/widget-slider/widget-slider.component').then(m => m.WidgetSliderComponent),
+    WidgetSimpleLinearComponent: () => import('../../widgets/widget-simple-linear/widget-simple-linear.component').then(m => m.WidgetSimpleLinearComponent),
+    WidgetRacesteerComponent: () => import('../../widgets/widget-racesteer/widget-racesteer.component').then(m => m.WidgetRacesteerComponent),
+    WidgetRacerTimerComponent: () => import('../../widgets/widget-racer-timer/widget-racer-timer.component').then(m => m.WidgetRacerTimerComponent),
+    WidgetRacerLineComponent: () => import('../../widgets/widget-racer-line/widget-racer-line.component').then(m => m.WidgetRacerLineComponent),
+    WidgetRaceTimerComponent: () => import('../../widgets/widget-race-timer/widget-race-timer.component').then(m => m.WidgetRaceTimerComponent),
+    WidgetPositionComponent: () => import('../../widgets/widget-position/widget-position.component').then(m => m.WidgetPositionComponent),
+    WidgetAisRadarComponent: () => import('../../widgets/widget-ais-radar/widget-ais-radar.component').then(m => m.WidgetAisRadarComponent),
+    WidgetLabelComponent: () => import('../../widgets/widget-label/widget-label.component').then(m => m.WidgetLabelComponent),
+    WidgetIframeComponent: () => import('../../widgets/widget-iframe/widget-iframe.component').then(m => m.WidgetIframeComponent),
+    WidgetHorizonComponent: () => import('../../widgets/widget-horizon/widget-horizon.component').then(m => m.WidgetHorizonComponent),
+    WidgetHeelGaugeComponent: () => import('../../widgets/widget-heel-gauge/widget-heel-gauge.component').then(m => m.WidgetHeelGaugeComponent),
+    WidgetSteelGaugeComponent: () => import('../../widgets/widget-gauge-steel/widget-gauge-steel.component').then(m => m.WidgetSteelGaugeComponent),
+    WidgetGaugeNgRadialComponent: () => import('../../widgets/widget-gauge-ng-radial/widget-gauge-ng-radial.component').then(m => m.WidgetGaugeNgRadialComponent),
+    WidgetGaugeNgLinearComponent: () => import('../../widgets/widget-gauge-ng-linear/widget-gauge-ng-linear.component').then(m => m.WidgetGaugeNgLinearComponent),
+    WidgetGaugeNgCompassComponent: () => import('../../widgets/widget-gauge-ng-compass/widget-gauge-ng-compass.component').then(m => m.WidgetGaugeNgCompassComponent),
+    WidgetFreeboardskComponent: () => import('../../widgets/widget-freeboardsk/widget-freeboardsk.component').then(m => m.WidgetFreeboardskComponent),
+    WidgetAnchorAlarmComponent: () => import('../../widgets/widget-anchor-alarm/widget-anchor-alarm.component').then(m => m.WidgetAnchorAlarmComponent),
+    WidgetDatetimeComponent: () => import('../../widgets/widget-datetime/widget-datetime.component').then(m => m.WidgetDatetimeComponent),
+    WidgetDataChartComponent: () => import('../../widgets/widget-data-chart/widget-data-chart.component').then(m => m.WidgetDataChartComponent),
+    WidgetBooleanSwitchComponent: () => import('../../widgets/widget-boolean-switch/widget-boolean-switch.component').then(m => m.WidgetBooleanSwitchComponent),
+    WidgetMultiStateSwitchComponent: () => import('../../widgets/widget-multi-state-switch/widget-multi-state-switch.component').then(m => m.WidgetMultiStateSwitchComponent),
+    WidgetZonesStatePanelComponent: () => import('../../widgets/widget-zones-state-panel/widget-zones-state-panel.component').then(m => m.WidgetZonesStatePanelComponent),
+    WidgetAutopilotComponent: () => import('../../widgets/widget-autopilot/widget-autopilot.component').then(m => m.WidgetAutopilotComponent),
+    WidgetBmsComponent: () => import('../../widgets/widget-bms/widget-bms.component').then(m => m.WidgetBmsComponent),
+    WidgetSolarChargerComponent: () => import('../../widgets/widget-solar-charger/widget-solar-charger.component').then(m => m.WidgetSolarChargerComponent),
+    WidgetChargerComponent: () => import('../../widgets/widget-charger/widget-charger.component').then(m => m.WidgetChargerComponent),
+    WidgetInverterComponent: () => import('../../widgets/widget-inverter/widget-inverter.component').then(m => m.WidgetInverterComponent),
+    WidgetAlternatorComponent: () => import('../../widgets/widget-alternator/widget-alternator.component').then(m => m.WidgetAlternatorComponent),
+    WidgetAcComponent: () => import('../../widgets/widget-ac/widget-ac.component').then(m => m.WidgetAcComponent)
 };
   private readonly _widgetDefinition: readonly WidgetDescription[] = [
     {
@@ -647,41 +621,67 @@ export class WidgetService {
   }
 
   /**
-   * Resolves a widget's runtime component Type from its selector.
+   * Resolves a widget's runtime component Type from its selector by dynamically importing the
+   * widget's chunk on demand.
    *
    * Flow:
    *  1. Locate the widget definition whose `selector` matches the provided string.
-   *  2. Look up the definition's `componentClassName` inside `_componentTypeMap`.
-   *  3. Return the component Type if the widget has been migrated; otherwise `undefined`.
+   *  2. Look up the definition's lazy loader inside `_componentTypeMap` and `import()` it.
+   *  3. Resolve with the component Type (and cache its DEFAULT_CONFIG), or `undefined` if unknown.
    *
-   * Host2 will fall back to a safe default (currently Numeric) when `undefined` is returned.
-   * This allows incremental migration without breaking existing dashboard configs.
-   *
-   * NOTE: We intentionally keep this lightweight instead of using dynamic `import()` to
-   * preserve tree‑shaking.
+   * The returned promise is cached per selector so repeat/concurrent lookups reuse a single import.
+   * Host2 (and widget-embedded) await this before creating the child; they fall back to a safe
+   * default when it resolves `undefined`.
    *
    * @param selector Dashboard widget type / selector (e.g. `widget-numeric`).
-   * @returns Angular component Type or undefined if not yet migrated.
+   * @returns Promise resolving to the Angular component Type, or undefined if unknown / failed to load.
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public getComponentType(selector: string): Type<any> | undefined {
-    // Only return cached value if it's a defined component Type; avoid sticky undefined caching
-    const cached = this._componentTypeCache.get(selector);
-    if (cached) return cached;
+  public getComponentType(selector: string): Promise<Type<unknown> | undefined> {
+    const existing = this._componentTypePromise.get(selector);
+    if (existing) return existing;
 
     const def = this._widgetDefinition.find(w => w.selector === selector);
-    if (!def) return undefined;
+    if (!def) return Promise.resolve(undefined);
 
-    const resolved = this._componentTypeMap[def.componentClassName];
-    if (!resolved) {
-      // Do NOT cache undefined so that adding a new mapping later in dev picks it up without reload
+    const loader = this._componentTypeMap[def.componentClassName];
+    if (!loader) {
       if (typeof ngDevMode !== 'undefined' && ngDevMode) {
         console.warn('[WidgetService] No component mapping for', def.componentClassName);
       }
-      return undefined;
+      return Promise.resolve(undefined);
     }
-    this._componentTypeCache.set(selector, resolved);
-    return resolved;
+
+    const promise = loader()
+      .then(componentType => {
+        // Capture the static DEFAULT_CONFIG so config-only consumers can read it without re-loading.
+        this._defaultConfigCache.set(
+          selector,
+          (componentType as { DEFAULT_CONFIG?: IWidgetSvcConfig }).DEFAULT_CONFIG
+        );
+        return componentType;
+      })
+      .catch((error: unknown) => {
+        // Drop the cached promise so a later attempt can retry the import after a transient failure.
+        this._componentTypePromise.delete(selector);
+        console.error('[WidgetService] Failed to load component for', def.componentClassName, error);
+        return undefined;
+      });
+
+    this._componentTypePromise.set(selector, promise);
+    return promise;
+  }
+
+  /**
+   * Synchronously returns a widget type's static DEFAULT_CONFIG IF its component has already been
+   * loaded (e.g. it is rendered on a dashboard). Returns `undefined` for widgets whose chunk has not
+   * been fetched yet — config-only callers should treat that as "not yet known" and fall back to the
+   * saved config rather than force a chunk download.
+   *
+   * @param selector Dashboard widget type / selector (e.g. `widget-numeric`).
+   * @returns The cached DEFAULT_CONFIG, or undefined if the component has not been loaded.
+   */
+  public getDefaultConfig(selector: string): IWidgetSvcConfig | undefined {
+    return this._defaultConfigCache.get(selector);
   }
 
   /**


### PR DESCRIPTION
Stop bundling every widget's code (and its heavy libraries) into the initial download. Each widget now loads on demand the first time that widget type appears on a dashboard, so a simple dashboard no longer pays for the AIS radar, the charts, the gauges, the electrical widgets, the autopilot and so on.

### Changes
- **`WidgetService` holds dynamic `import()` loaders** instead of static component references, and `getComponentType()` returns a promise (deduped per widget type). It caches each widget's `DEFAULT_CONFIG` when the widget loads so the history-series reconciler can still read it synchronously via the new `getDefaultConfig()`, falling back to the saved config for widgets that have not loaded yet.
- **`widget-host2` and `widget-embedded` await the widget chunk**, then create and render the child, guarding against being destroyed mid-load.
- **The history chart dialog (which uses chart.js) is opened with a dynamic import**, so it stays out of the initial download until a user opens widget history.

### Measured (production build)
| Metric | master | this PR |
|--------|-------:|--------:|
| Initial transfer | 618.84 kB | **434.38 kB (−29.8%)** |
| Initial raw | 2.90 MB | 1.87 MB |

chart.js core (~266 KB raw / ~73 KB transfer) and all heavy widget code move into lazy chunks (verified chart.js is no longer referenced by `index.html`).

**Follow-up:** the numeric widget imports the optional background `MinichartComponent`, which uses chart.js — so chart.js still loads alongside the numeric widget (just not in the initial download). Decoupling the minichart (load it only when the background-chart option is on) would keep chart.js off the numeric path entirely.

### Verification
Build + lint pass. New tests cover the async resolver + config cache (`WidgetService`) and **the async load-and-render path** (`widget-embedded`: child not rendered synchronously, then rendered after the chunk resolves — the same pattern Host2 uses). The `widget-host2` spec is blocked by the pre-existing `master` `localStorage` test-setup issue (verified identical on `master`), so the host integration is best smoke-tested by loading the app.
---

### Part of a performance series

These five PRs are independent (each branches off `master`, touches disjoint files, and can merge in any order):

- Trim startup bundle and unblock first paint (bundle/startup)
- Cut per-delta work on the data hot path (data pipeline)
- Fix resize, data-inspector and race-timer hot spots (correctness/UX)
- Cut per-widget render and change-detection overhead (widgets)
- Lazy-load widget components and the history chart dialog (bundle)

Together they cut the initial transfer size from ~619 KB to ~414 KB (about 33% smaller) and remove a lot of per-delta CPU/allocation work on low-power devices.

The client test suite on `master` currently has ~54 pre-existing `localStorage`/`SettingsService` spec failures (fixed separately in #1083). Any such failures noted below are pre-existing and unrelated to these changes — verified by reproducing them on `master`.
