### PR TITLE
Await server writes before reload/refresh (fix misused-promise bugs)

### DIFF
--- a/src/app/core/components/options/configuration/config.component.spec.ts
+++ b/src/app/core/components/options/configuration/config.component.spec.ts
@@ -28,6 +28,18 @@ describe('SettingsConfigComponent', () => {
   let toastMock: {
     show: ReturnType<typeof vi.fn>;
   };
+  let settingsMock: {
+    useSharedConfig: boolean;
+    getAppConfig: ReturnType<typeof vi.fn>;
+    getDashboardConfig: ReturnType<typeof vi.fn>;
+    getThemeConfig: ReturnType<typeof vi.fn>;
+    loadConfigFromLocalStorage: ReturnType<typeof vi.fn>;
+    replaceConfig: ReturnType<typeof vi.fn>;
+    reloadApp: ReturnType<typeof vi.fn>;
+    resetSettings: ReturnType<typeof vi.fn>;
+    resetConnection: ReturnType<typeof vi.fn>;
+    loadDemoConfig: ReturnType<typeof vi.fn>;
+  };
 
   beforeEach(async () => {
     authTokenSubject = new BehaviorSubject<IAuthorizationToken | null>(null);
@@ -38,12 +50,24 @@ describe('SettingsConfigComponent', () => {
         { scope: 'user', name: 'default' },
         { scope: 'user', name: 'race-config' }
       ]),
-      removeItem: vi.fn(),
+      removeItem: vi.fn().mockResolvedValue(undefined),
       getConfig: vi.fn().mockResolvedValue({ app: {}, dashboards: [], theme: {} }),
-      setConfig: vi.fn().mockReturnValue(true)
+      setConfig: vi.fn().mockResolvedValue(null)
     };
     toastMock = {
       show: vi.fn()
+    };
+    settingsMock = {
+      useSharedConfig: false,
+      getAppConfig: vi.fn(),
+      getDashboardConfig: vi.fn(),
+      getThemeConfig: vi.fn(),
+      loadConfigFromLocalStorage: vi.fn(),
+      replaceConfig: vi.fn(),
+      reloadApp: vi.fn(),
+      resetSettings: vi.fn(),
+      resetConnection: vi.fn(),
+      loadDemoConfig: vi.fn()
     };
 
     await TestBed.configureTestingModule({
@@ -57,21 +81,7 @@ describe('SettingsConfigComponent', () => {
         },
         { provide: StorageService, useValue: storageMock },
         { provide: ToastService, useValue: toastMock },
-        {
-          provide: SettingsService,
-          useValue: {
-            useSharedConfig: false,
-            getAppConfig: vi.fn(),
-            getDashboardConfig: vi.fn(),
-            getThemeConfig: vi.fn(),
-            loadConfigFromLocalStorage: vi.fn(),
-            replaceConfig: vi.fn(),
-            reloadApp: vi.fn(),
-            resetSettings: vi.fn(),
-            resetConnection: vi.fn(),
-            loadDemoConfig: vi.fn()
-          }
-        }
+        { provide: SettingsService, useValue: settingsMock }
       ]
     })
       .compileComponents();
@@ -116,5 +126,233 @@ describe('SettingsConfigComponent', () => {
 
     expect(toastMock.show).toHaveBeenCalledWith('Please select a valid configuration to delete.', 0, false, 'error');
     expect(storageMock.removeItem).not.toHaveBeenCalled();
+  });
+
+  it('restoring a configuration reloads only after the save resolves', async () => {
+    let resolveSave: (value: unknown) => void;
+    storageMock.setConfig.mockReturnValueOnce(new Promise((resolve) => { resolveSave = resolve; }));
+    component.copyConfigForm.setValue({ sourceTarget: 'global::multi-test2' });
+
+    const done = component.copyConfig();
+    // Let getConfig resolve and saveConfig kick off the (still pending) setConfig.
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(storageMock.setConfig).toHaveBeenCalledWith('user', 'default', expect.anything());
+    // Reload must wait for the server write to complete, not race it.
+    expect(settingsMock.reloadApp).not.toHaveBeenCalled();
+
+    resolveSave(null);
+    await done;
+
+    expect(settingsMock.reloadApp).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not reload when restoring a configuration fails to save', async () => {
+    storageMock.setConfig.mockRejectedValueOnce(new Error('network down'));
+    component.copyConfigForm.setValue({ sourceTarget: 'global::multi-test2' });
+
+    await component.copyConfig();
+
+    expect(settingsMock.reloadApp).not.toHaveBeenCalled();
+    expect(toastMock.show).toHaveBeenCalledWith('Configuration not saved to server', 0, false, 'error');
+  });
+
+  it('uploading a configuration reloads only after the save resolves', async () => {
+    authTokenSubject.next(createToken({ isDeviceAccessToken: true }));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    let resolveSave: (value: unknown) => void;
+    storageMock.setConfig.mockReturnValueOnce(new Promise((resolve) => { resolveSave = resolve; }));
+
+    const file = new File(
+      [JSON.stringify({ app: {}, dashboards: [], theme: {} })],
+      'KipConfig.json',
+      { type: 'application/json' }
+    );
+    const event = { target: { files: [file] } } as unknown as Event;
+
+    component.uploadJsonConfig(event);
+
+    // Wait for FileReader.onload to parse and call setConfig.
+    await vi.waitFor(() => expect(storageMock.setConfig).toHaveBeenCalledWith('user', 'default', expect.anything()));
+    // Reload must not fire while the upload write is still in flight.
+    expect(settingsMock.reloadApp).not.toHaveBeenCalled();
+
+    resolveSave(null);
+    await vi.waitFor(() => expect(settingsMock.reloadApp).toHaveBeenCalledTimes(1));
+  });
+
+  it('does not reload when an uploaded configuration fails to save', async () => {
+    authTokenSubject.next(createToken({ isDeviceAccessToken: true }));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    storageMock.setConfig.mockRejectedValueOnce(new Error('network down'));
+
+    const file = new File(
+      [JSON.stringify({ app: {}, dashboards: [], theme: {} })],
+      'KipConfig.json',
+      { type: 'application/json' }
+    );
+    const event = { target: { files: [file] } } as unknown as Event;
+
+    component.uploadJsonConfig(event);
+
+    await vi.waitFor(() => expect(toastMock.show).toHaveBeenCalledWith('Configuration not saved to server', 0, false, 'error'));
+    expect(settingsMock.reloadApp).not.toHaveBeenCalled();
+  });
+
+  it('refreshes the configuration list only after a delete completes', async () => {
+    storageMock.listConfigs.mockClear();
+    let resolveDelete: () => void;
+    storageMock.removeItem.mockReturnValueOnce(new Promise<void>((resolve) => { resolveDelete = resolve; }));
+
+    const done = component.deleteConfig('global', 'multi-test2');
+    await Promise.resolve();
+
+    // The list must not refresh until the server has actually removed the entry.
+    expect(storageMock.listConfigs).not.toHaveBeenCalled();
+
+    resolveDelete();
+    await done;
+
+    expect(storageMock.listConfigs).toHaveBeenCalled();
+    expect(toastMock.show).toHaveBeenCalledWith('Configuration [multi-test2] deleted from [global] storage scope', 1000, false, 'success');
+  });
+
+  it('reports an error and skips the refresh when a delete fails', async () => {
+    storageMock.listConfigs.mockClear();
+    storageMock.removeItem.mockRejectedValueOnce(new Error('network down'));
+
+    await component.deleteConfig('global', 'multi-test2');
+
+    expect(toastMock.show).toHaveBeenCalledWith('Configuration [multi-test2] could not be deleted from [global] storage scope', 0, false, 'error');
+    expect(storageMock.listConfigs).not.toHaveBeenCalled();
+  });
+
+  it('rejects an uploaded file that is not valid JSON', async () => {
+    authTokenSubject.next(createToken({ isDeviceAccessToken: true }));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const file = new File(['{ not valid json'], 'KipConfig.json', { type: 'application/json' });
+    const event = { target: { files: [file] } } as unknown as Event;
+
+    component.uploadJsonConfig(event);
+
+    await vi.waitFor(() => expect(toastMock.show).toHaveBeenCalledWith('File does not contain valid JSON.', 0, false, 'error'));
+    expect(storageMock.setConfig).not.toHaveBeenCalled();
+    expect(settingsMock.reloadApp).not.toHaveBeenCalled();
+  });
+
+  it('rejects an uploaded file that is not a JSON file', () => {
+    const file = new File(['hello'], 'notes.txt', { type: 'text/plain' });
+    const event = { target: { files: [file] } } as unknown as Event;
+
+    component.uploadJsonConfig(event);
+
+    expect(toastMock.show).toHaveBeenCalledWith('Please select a valid JSON file', 0, false, 'error');
+    expect(storageMock.setConfig).not.toHaveBeenCalled();
+    expect(settingsMock.reloadApp).not.toHaveBeenCalled();
+  });
+
+  it('uploads to local storage and reloads when there is no auth token', async () => {
+    // No token emitted -> hasToken is false -> localStorage path.
+    const config = { app: { a: 1 }, dashboards: [{ d: 1 }], theme: { t: 1 } };
+    const file = new File([JSON.stringify(config)], 'KipConfig.json', { type: 'application/json' });
+    const event = { target: { files: [file] } } as unknown as Event;
+
+    component.uploadJsonConfig(event);
+
+    await vi.waitFor(() => expect(settingsMock.reloadApp).toHaveBeenCalledTimes(1));
+    expect(storageMock.setConfig).not.toHaveBeenCalled();
+    expect(settingsMock.replaceConfig).toHaveBeenCalledWith('appConfig', config.app, false);
+    expect(settingsMock.replaceConfig).toHaveBeenCalledWith('dashboardsConfig', config.dashboards, false);
+    expect(settingsMock.replaceConfig).toHaveBeenCalledWith('themeConfig', config.theme, false);
+  });
+
+  it('surfaces an error and does not reload when the local storage upload write fails', async () => {
+    // No token -> localStorage path. A localStorage.setItem throw (quota exceeded /
+    // private mode) must be contained, not escape the async onload handler.
+    settingsMock.replaceConfig.mockImplementation(() => { throw new DOMException('Quota', 'QuotaExceededError'); });
+    const file = new File([JSON.stringify({ app: {}, dashboards: [], theme: {} })], 'KipConfig.json', { type: 'application/json' });
+    const event = { target: { files: [file] } } as unknown as Event;
+
+    component.uploadJsonConfig(event);
+
+    await vi.waitFor(() => expect(toastMock.show).toHaveBeenCalledWith('Configuration not saved', 0, false, 'error'));
+    expect(settingsMock.reloadApp).not.toHaveBeenCalled();
+  });
+
+  it('refreshes the configuration list after a successful save with refresh enabled', async () => {
+    storageMock.listConfigs.mockClear();
+
+    const saved = await component.saveConfig({ app: {}, dashboards: [], theme: {} } as never, 'global', 'my-backup');
+
+    expect(saved).toBe(true);
+    expect(storageMock.setConfig).toHaveBeenCalledWith('global', 'my-backup', expect.anything());
+    expect(storageMock.listConfigs).toHaveBeenCalled();
+  });
+
+  it('refuses to save to the reserved user/default scope without forceSave', async () => {
+    const saved = await component.saveConfig({ app: {}, dashboards: [], theme: {} } as never, 'user', 'default');
+
+    expect(saved).toBe(false);
+    expect(storageMock.setConfig).not.toHaveBeenCalled();
+    expect(toastMock.show).toHaveBeenCalledWith("Saving configuration with scope 'user' and name 'default' is not allowed.", 0, false, 'error');
+  });
+
+  it('shows an error and does not restore when no configuration is selected', async () => {
+    component.copyConfigForm.setValue({ sourceTarget: '' });
+
+    await component.copyConfig();
+
+    expect(toastMock.show).toHaveBeenCalledWith('Please select a valid configuration to restore.', 0, false, 'error');
+    expect(storageMock.getConfig).not.toHaveBeenCalled();
+    expect(settingsMock.reloadApp).not.toHaveBeenCalled();
+  });
+
+  it('shows an error and does not reload when the source config cannot be retrieved', async () => {
+    storageMock.getConfig.mockRejectedValueOnce({ statusText: 'Not Found' });
+    component.copyConfigForm.setValue({ sourceTarget: 'global::multi-test2' });
+
+    await component.copyConfig();
+
+    expect(toastMock.show).toHaveBeenCalledWith('Cannot retrieve server configuration: Not Found', 0, false, 'error');
+    expect(storageMock.setConfig).not.toHaveBeenCalled();
+    expect(settingsMock.reloadApp).not.toHaveBeenCalled();
+  });
+
+  it('surfaces the storage-requirements message on a 401 when listing configs', async () => {
+    storageMock.listConfigs.mockRejectedValueOnce({ status: 401, statusText: 'Unauthorized' });
+
+    component.getServerConfigList();
+
+    await vi.waitFor(() => expect(toastMock.show).toHaveBeenCalledWith(
+      expect.stringContaining('Storage Service: Unauthorized'), 0, false, 'error'));
+  });
+
+  it('reads the active config from memory when shared config is enabled', () => {
+    settingsMock.useSharedConfig = true;
+    settingsMock.getAppConfig.mockReturnValue({ a: 1 });
+    settingsMock.getDashboardConfig.mockReturnValue([{ d: 1 }]);
+    settingsMock.getThemeConfig.mockReturnValue({ t: 1 });
+
+    expect(component.getActiveConfig()).toEqual({ app: { a: 1 }, dashboards: [{ d: 1 }], theme: { t: 1 } });
+    expect(settingsMock.loadConfigFromLocalStorage).not.toHaveBeenCalled();
+  });
+
+  it('reads the active config from local storage when shared config is disabled', () => {
+    settingsMock.useSharedConfig = false;
+    settingsMock.loadConfigFromLocalStorage.mockImplementation((key: string) => ({ from: key }));
+
+    expect(component.getActiveConfig()).toEqual({
+      app: { from: 'appConfig' },
+      dashboards: { from: 'dashboardsConfig' },
+      theme: { from: 'themeConfig' }
+    });
   });
 });

--- a/src/app/core/components/options/configuration/config.component.ts
+++ b/src/app/core/components/options/configuration/config.component.ts
@@ -113,23 +113,33 @@ export class SettingsConfigComponent {
     }
   }
 
-  public saveConfig(conf: IConfig, scope: string, name: string, dontRefreshConfigList?: boolean, forceSave?: boolean) {
-    if (this.supportApplicationData) {
-      // Prevent saving with scope 'user' and name 'default'
-      if ((scope === 'user' && name === 'default') && !forceSave) {
-        this.toast.show("Saving configuration with scope 'user' and name 'default' is not allowed.", 0, false, 'error');
-        return;
-      }
-
-      if (this.storageSvc.setConfig(scope, name, conf)) {
-        this.toast.show(`Configuration [${name}] saved to [${scope}] storage scope`, 1000, true, 'success');
-        if (!dontRefreshConfigList || undefined) {
-          this.getServerConfigList();
-        }
-      } else {
-        this.toast.show("Configuration not saved to server", 0, false, 'error');
-      }
+  public async saveConfig(conf: IConfig, scope: string, name: string, dontRefreshConfigList?: boolean, forceSave?: boolean): Promise<boolean> {
+    if (!this.supportApplicationData) {
+      return false;
     }
+
+    // Prevent saving with scope 'user' and name 'default'
+    if ((scope === 'user' && name === 'default') && !forceSave) {
+      this.toast.show("Saving configuration with scope 'user' and name 'default' is not allowed.", 0, false, 'error');
+      return false;
+    }
+
+    // setConfig posts to the server asynchronously. We must await it so callers
+    // (upload, restore, save) only reload/refresh once the write has landed —
+    // otherwise reloadApp() navigates away and aborts the in-flight request,
+    // silently dropping the new configuration.
+    try {
+      await this.storageSvc.setConfig(scope, name, conf);
+    } catch {
+      this.toast.show("Configuration not saved to server", 0, false, 'error');
+      return false;
+    }
+
+    this.toast.show(`Configuration [${name}] saved to [${scope}] storage scope`, 1000, true, 'success');
+    if (!dontRefreshConfigList) {
+      this.getServerConfigList();
+    }
+    return true;
   }
 
   /**
@@ -159,8 +169,10 @@ export class SettingsConfigComponent {
       return;
     }
 
-    this.saveConfig(conf, 'user', 'default', false, true);
-    this.settings.reloadApp();
+    const saved = await this.saveConfig(conf, 'user', 'default', false, true);
+    if (saved) {
+      this.settings.reloadApp();
+    }
   }
 
   public deleteConfigByKey(configKey: string) {
@@ -173,8 +185,17 @@ export class SettingsConfigComponent {
     this.deleteConfig(config.scope, config.name);
   }
 
-  public deleteConfig (scope: string, name: string, forceConfigFileVersion?: number, dontRefreshConfigList?: boolean) {
-    this.storageSvc.removeItem(scope, name, forceConfigFileVersion);
+  public async deleteConfig (scope: string, name: string, forceConfigFileVersion?: number, dontRefreshConfigList?: boolean) {
+    // Await the delete so we only report success and refresh the list once the
+    // server has actually removed the entry; otherwise the dropdown can still
+    // show the just-deleted configuration and a failed delete looks successful.
+    try {
+      await this.storageSvc.removeItem(scope, name, forceConfigFileVersion);
+    } catch {
+      this.toast.show(`Configuration [${name}] could not be deleted from [${scope}] storage scope`, 0, false, 'error');
+      return;
+    }
+
     this.toast.show(`Configuration [${name}] deleted from [${scope}] storage scope`, 1000, false, 'success');
     if (!dontRefreshConfigList) {
       this.getServerConfigList();
@@ -258,19 +279,35 @@ export class SettingsConfigComponent {
     const file = input.files?.[0];
     if (file && file.type === "application/json") {
       const reader = new FileReader();
-      reader.onload = (e) => {
+      reader.onload = async (e) => {
         try {
           this.jsonData = JSON.parse(e.target?.result as string); // Parse JSON
-          if (this.hasToken) {
-            this.saveConfig(this.jsonData, 'user', 'default', false, true);
-          } else {
-            this.saveToLocalstorage(this.jsonData);
-          }
-          this.settings.reloadApp();
         } catch (error) {
           this.toast.show("File does not contain valid JSON.", 0, false, 'error');
           console.error("Invalid JSON file format:", error);
+          return;
         }
+
+        if (this.hasToken) {
+          // Wait for the server write to complete before reloading; reloading
+          // mid-request aborts the upload and leaves the old config in place.
+          const saved = await this.saveConfig(this.jsonData, 'user', 'default', false, true);
+          if (!saved) {
+            return;
+          }
+        } else {
+          // localStorage.setItem can throw (quota exceeded, private mode). Contain
+          // it here so it surfaces an error instead of escaping this async handler
+          // as an unhandled rejection and silently skipping the reload.
+          try {
+            this.saveToLocalstorage(this.jsonData);
+          } catch (error) {
+            this.toast.show("Configuration not saved", 0, false, 'error');
+            console.error("Failed to save configuration to local storage:", error);
+            return;
+          }
+        }
+        this.settings.reloadApp();
       };
       reader.readAsText(file); // Read the file as text
     } else {

--- a/src/app/core/components/options/display/display.component.spec.ts
+++ b/src/app/core/components/options/display/display.component.spec.ts
@@ -41,8 +41,6 @@ class SettingsServiceMock {
     public getSplitShellSide() { return 'left' as const; }
     public getSplitShellSwipeDisabled() { return false; }
     public getWidgetHistoryDisabled() { return false; }
-    public getBrowserTabTitle() { return 'KIP'; }
-    public getDisablePathValidation() { return false; }
     public setAutoNightMode(): void { }
     public setRedNightMode(): void { }
     public setNightModeBrightness(): void { }
@@ -53,8 +51,6 @@ class SettingsServiceMock {
     public setSplitShellSide(): void { }
     public setSplitShellSwipeDisabled(): void { }
     public setWidgetHistoryDisabled(): void { }
-    public setBrowserTabTitle(): void { }
-    public setDisablePathValidation(): void { }
 }
 
 class PluginConfigClientServiceMock {
@@ -144,29 +140,6 @@ describe('SettingsNotificationsComponent', () => {
         await flushPromises();
 
         expect(toast.show).toHaveBeenCalledWith("To enable Automatic Night Mode, the Derived Data plugin must be enabled. Do you wish to enable the plugin?", 0, false, 'warn', 'Ok');
-    });
-
-    it('shows an error and not a success toast when the KIP plugin config save fails', async () => {
-        const pluginService = TestBed.inject(PluginConfigClientService) as unknown as PluginConfigClientServiceMock;
-        pluginService.savePluginConfig.mockResolvedValue({ ok: false, error: { message: 'server rejected' } });
-
-        // Auto night mode is off -> straight to applyAndSaveSettings (the server save path).
-        component['saveAllSettings']();
-        await flushPromises();
-        await flushPromises();
-
-        expect(toast.show).toHaveBeenCalledWith('Failed to save KIP plugin configuration on server.', 0, false, 'error');
-        expect(toast.show).not.toHaveBeenCalledWith('Configuration saved', 1000, true, 'message');
-    });
-
-    it('shows the success toast when the KIP plugin config save succeeds', async () => {
-        // Default savePluginConfig mock resolves { ok: true }.
-        component['saveAllSettings']();
-        await flushPromises();
-        await flushPromises();
-
-        expect(toast.show).toHaveBeenCalledWith('Configuration saved', 1000, true, 'message');
-        expect(toast.show).not.toHaveBeenCalledWith('Failed to save KIP plugin configuration on server.', 0, false, 'error');
     });
 
     it('shows prompt for configuring sun flag only when plugin is enabled but sun flag is false', async () => {

--- a/src/app/core/components/options/display/display.component.spec.ts
+++ b/src/app/core/components/options/display/display.component.spec.ts
@@ -41,6 +41,8 @@ class SettingsServiceMock {
     public getSplitShellSide() { return 'left' as const; }
     public getSplitShellSwipeDisabled() { return false; }
     public getWidgetHistoryDisabled() { return false; }
+    public getBrowserTabTitle() { return 'KIP'; }
+    public getDisablePathValidation() { return false; }
     public setAutoNightMode(): void { }
     public setRedNightMode(): void { }
     public setNightModeBrightness(): void { }
@@ -51,6 +53,8 @@ class SettingsServiceMock {
     public setSplitShellSide(): void { }
     public setSplitShellSwipeDisabled(): void { }
     public setWidgetHistoryDisabled(): void { }
+    public setBrowserTabTitle(): void { }
+    public setDisablePathValidation(): void { }
 }
 
 class PluginConfigClientServiceMock {
@@ -140,6 +144,29 @@ describe('SettingsNotificationsComponent', () => {
         await flushPromises();
 
         expect(toast.show).toHaveBeenCalledWith("To enable Automatic Night Mode, the Derived Data plugin must be enabled. Do you wish to enable the plugin?", 0, false, 'warn', 'Ok');
+    });
+
+    it('shows an error and not a success toast when the KIP plugin config save fails', async () => {
+        const pluginService = TestBed.inject(PluginConfigClientService) as unknown as PluginConfigClientServiceMock;
+        pluginService.savePluginConfig.mockResolvedValue({ ok: false, error: { message: 'server rejected' } });
+
+        // Auto night mode is off -> straight to applyAndSaveSettings (the server save path).
+        component['saveAllSettings']();
+        await flushPromises();
+        await flushPromises();
+
+        expect(toast.show).toHaveBeenCalledWith('Failed to save KIP plugin configuration on server.', 0, false, 'error');
+        expect(toast.show).not.toHaveBeenCalledWith('Configuration saved', 1000, true, 'message');
+    });
+
+    it('shows the success toast when the KIP plugin config save succeeds', async () => {
+        // Default savePluginConfig mock resolves { ok: true }.
+        component['saveAllSettings']();
+        await flushPromises();
+        await flushPromises();
+
+        expect(toast.show).toHaveBeenCalledWith('Configuration saved', 1000, true, 'message');
+        expect(toast.show).not.toHaveBeenCalledWith('Failed to save KIP plugin configuration on server.', 0, false, 'error');
     });
 
     it('shows prompt for configuring sun flag only when plugin is enabled but sun flag is false', async () => {

--- a/src/app/core/components/options/display/display.component.ts
+++ b/src/app/core/components/options/display/display.component.ts
@@ -100,10 +100,10 @@ export class SettingsDisplayComponent implements OnInit {
       return;
     }
 
-    this.applyAndSaveSettings();
+    void this.applyAndSaveSettings();
   }
 
-  private applyAndSaveSettings(): void {
+  private async applyAndSaveSettings(): Promise<void> {
     this.settings.setAutoNightMode(this.autoNightMode());
     this.settings.setRedNightMode(this.isRedNightMode());
     this.settings.setNightModeBrightness(this.nightBrightness());
@@ -128,10 +128,15 @@ export class SettingsDisplayComponent implements OnInit {
     this.settings.setSplitShellSwipeDisabled(this.splitShellSwipeDisabled());
     this.settings.setWidgetHistoryDisabled(this.widgetHistoryDisabled());
     this.settings.setDisablePathValidation(this.isPathValidationDisabled());
-    if (!this.setKipPluginConfig()) {
-      this.toast.show('Failed to save KIP plugin configuration on server.', 0, false, 'error');
-    }
+    // Await the server write; setKipPluginConfig() returns a Promise, so the old
+    // `if (!this.setKipPluginConfig())` was always false (a Promise is truthy) —
+    // the error branch was dead and "Configuration saved" lied on failure.
+    const ok = await this.setKipPluginConfig();
     this.displayForm()?.form.markAsPristine();
+    if (!ok) {
+      this.toast.show('Failed to save KIP plugin configuration on server.', 0, false, 'error');
+      return;
+    }
     this.toast.show("Configuration saved", 1000, true, 'message');
   }
 
@@ -140,7 +145,7 @@ export class SettingsDisplayComponent implements OnInit {
     if (seq !== this._pluginCheckSeq) return;
 
     if (isValid) {
-      this.applyAndSaveSettings();
+      await this.applyAndSaveSettings();
     } else {
       // Reset toggle and abort save
       this.autoNightMode.set(false);

--- a/src/app/core/services/configuration-upgrade.service.spec.ts
+++ b/src/app/core/services/configuration-upgrade.service.spec.ts
@@ -50,4 +50,25 @@ describe('ConfigurationUpgradeService', () => {
         expect(mockStorage.listConfigs).toHaveBeenCalledWith(9);
         expect(service.error()).toBeNull();
     });
+
+    it('startFresh retires BOTH global and user legacy configs via an awaited write before resetting', async () => {
+        mockStorage.initConfig = null; // remote (Signal K) path
+        mockStorage.listConfigs.mockResolvedValueOnce([
+            { scope: 'global', name: 'gconf' },
+            { scope: 'user', name: 'uconf' }
+        ]);
+        mockStorage.getConfig.mockImplementation(async () => ({ app: { configVersion: 10 } }));
+
+        service.startFresh();
+
+        // The reset (which reloads the page) must run only after retiring completes.
+        await vi.waitFor(() => expect(mockAppSettings.resetSettings).toHaveBeenCalled());
+
+        // Global must be retired via an awaited setConfig (not a deferred fire-and-forget),
+        // to legacy file version 9 with configVersion 0 — same as the user scope.
+        expect(mockStorage.setConfig).toHaveBeenCalledWith(
+            'global', 'gconf', expect.objectContaining({ app: expect.objectContaining({ configVersion: 0 }) }), 9);
+        expect(mockStorage.setConfig).toHaveBeenCalledWith(
+            'user', 'uconf', expect.objectContaining({ app: expect.objectContaining({ configVersion: 0 }) }), 9);
+    });
 });

--- a/src/app/core/services/configuration-upgrade.service.ts
+++ b/src/app/core/services/configuration-upgrade.service.ts
@@ -206,22 +206,16 @@ export class ConfigurationUpgradeService {
           for (const rootConfig of rootConfigs) {
             const oldConfiguration = await this._storage.getConfig(rootConfig.scope, rootConfig.name, this.legacyFileVersion) as unknown as IConfig;
             oldConfiguration.app.configVersion = 0; // retire
-            if (rootConfig.scope === 'global') {
-              try {
-                setTimeout(() => {
-                  this._storage.patchGlobal(rootConfig.name, rootConfig.scope, oldConfiguration, 'replace', this.legacyFileVersion);
-                  this.pushMsg(`[Retired] Configuration ${rootConfig.scope}/${rootConfig.name} patched to version 0.`);
-                }, 750);
-              } catch {
-                this.pushError(`[Upgrade] Error saving configuration for ${rootConfig.name}.`);
-              }
-            } else {
-              try {
-                await this._storage.setConfig(rootConfig.scope, rootConfig.name, oldConfiguration, this.legacyFileVersion);
-                this.pushMsg(`[Retired] Configuration ${rootConfig.scope}/${rootConfig.name} patched to version 0.`);
-              } catch {
-                this.pushError(`[Upgrade] Error saving configuration for ${rootConfig.name}.`);
-              }
+            try {
+              // Await the retire write for BOTH scopes so it completes before the
+              // finally() block runs resetSettings() and reloads the page. The old
+              // 'global' branch scheduled a deferred, un-awaited patchGlobal (via
+              // setTimeout) that the reload aborted, leaving the legacy global config
+              // un-retired. Mirror the awaited setConfig pattern used by runUpgrade().
+              await this._storage.setConfig(rootConfig.scope, rootConfig.name, oldConfiguration, this.legacyFileVersion);
+              this.pushMsg(`[Retired] Configuration ${rootConfig.scope}/${rootConfig.name} patched to version 0.`);
+            } catch {
+              this.pushError(`[Upgrade] Error saving configuration for ${rootConfig.name}.`);
             }
           }
         })

--- a/src/app/core/services/dashboard-history-series-sync.service.spec.ts
+++ b/src/app/core/services/dashboard-history-series-sync.service.spec.ts
@@ -339,6 +339,49 @@ describe('DashboardHistorySeriesSyncService', () => {
         expect(windSpeed?.path).toBe('self.environment.wind.speedTrue');
     });
 
+    it('retries on the next cycle when a reconcile fails (resolves null instead of throwing)', async () => {
+        vi.useFakeTimers();
+        TestBed.inject(DashboardHistorySeriesSyncService);
+        connectionStub.serverServiceEndpoint$.next({
+            operation: 2,
+            message: 'Connected',
+            serverDescription: 'Signal K',
+            httpServiceUrl: 'http://localhost:3000/signalk/v1/api/',
+            WsServiceUrl: 'ws://localhost:3000/signalk/v1/stream'
+        });
+
+        // First reconcile attempt "fails": reconcileSeries returns null (it does not throw).
+        reconcileSpy.mockResolvedValueOnce(null);
+
+        dashboardStub.dashboards.set([
+            {
+                id: 'dash-1',
+                name: 'Dashboard 1',
+                icon: 'dashboard-dashboard',
+                configuration: [
+                    createAutomaticNode('widget-numeric-1', 'widget-numeric', { source: 'default', period: 10 })
+                ]
+            }
+        ]);
+        await vi.advanceTimersByTimeAsync(800);
+        expect(reconcileSpy).toHaveBeenCalledTimes(1);
+
+        // Re-emit the SAME series content (new array reference). Because the prior attempt
+        // failed, the signature must NOT have been marked submitted, so this retries.
+        dashboardStub.dashboards.set([
+            {
+                id: 'dash-1',
+                name: 'Dashboard 1',
+                icon: 'dashboard-dashboard',
+                configuration: [
+                    createAutomaticNode('widget-numeric-1', 'widget-numeric', { source: 'default', period: 10 })
+                ]
+            }
+        ]);
+        await vi.advanceTimersByTimeAsync(800);
+        expect(reconcileSpy).toHaveBeenCalledTimes(2);
+    });
+
     it('should skip reconcile when history series service mode is disabled', async () => {
         vi.useFakeTimers();
         TestBed.inject(DashboardHistorySeriesSyncService);

--- a/src/app/core/services/dashboard-history-series-sync.service.ts
+++ b/src/app/core/services/dashboard-history-series-sync.service.ts
@@ -127,8 +127,15 @@ export class DashboardHistorySeriesSyncService {
     }
 
     try {
-      await this.kipSeries.reconcileSeries(nextSeries);
-      this.lastSubmittedSignature = nextSignature;
+      // reconcileSeries resolves to null on failure (it swallows errors and does
+      // NOT throw), so we must inspect the result. Only mark the signature as
+      // submitted on a real success; otherwise leave it unset so the next cycle retries.
+      const result = await this.kipSeries.reconcileSeries(nextSeries);
+      if (result) {
+        this.lastSubmittedSignature = nextSignature;
+      } else {
+        console.warn('[DashboardHistorySeriesSyncService] Reconcile did not complete; will retry on next cycle');
+      }
     } catch (error) {
       console.error('[DashboardHistorySeriesSyncService] Reconcile failed:', error);
       // Don't update lastSubmittedSignature so next cycle will retry

--- a/src/app/core/services/settings.service.spec.ts
+++ b/src/app/core/services/settings.service.spec.ts
@@ -1,16 +1,90 @@
 import { TestBed } from '@angular/core/testing';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { BehaviorSubject } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MatSnackBar } from '@angular/material/snack-bar';
 import { SettingsService } from './settings.service';
+import { StorageService } from './storage.service';
 
 describe('SettingsService', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [SettingsService]
-    });
-  });
-
   it('should be created', () => {
+    TestBed.configureTestingModule({ providers: [SettingsService] });
     const service = TestBed.inject(SettingsService);
     expect(service).toBeTruthy();
+  });
+
+  describe('loadDemoConfig (shared/server config)', () => {
+    let storageMock: {
+      activeConfigFileVersion: number;
+      storageServiceReady$: BehaviorSubject<boolean>;
+      isRemoteContextBootstrapped: () => boolean;
+      initConfig: unknown;
+      setConfig: ReturnType<typeof vi.fn>;
+    };
+    let snackMock: { open: ReturnType<typeof vi.fn> };
+    let service: SettingsService;
+
+    beforeEach(() => {
+      storageMock = {
+        activeConfigFileVersion: 0,
+        storageServiceReady$: new BehaviorSubject<boolean>(true),
+        isRemoteContextBootstrapped: () => false,
+        initConfig: null,
+        setConfig: vi.fn().mockResolvedValue(null)
+      };
+      snackMock = { open: vi.fn() };
+
+      TestBed.configureTestingModule({
+        providers: [
+          SettingsService,
+          { provide: StorageService, useValue: storageMock },
+          { provide: MatSnackBar, useValue: snackMock }
+        ]
+      });
+
+      service = TestBed.inject(SettingsService);
+      service.useSharedConfig = true;
+      vi.spyOn(service, 'reloadApp').mockImplementation(() => undefined);
+    });
+
+    it('reloads only after the demo config save resolves', async () => {
+      let resolveSave: (value: unknown) => void;
+      storageMock.setConfig.mockReturnValueOnce(new Promise((resolve) => { resolveSave = resolve; }));
+
+      service.loadDemoConfig();
+      await Promise.resolve();
+
+      expect(storageMock.setConfig).toHaveBeenCalledWith('user', 'default', expect.anything());
+      // Reload must wait for the write, not race it.
+      expect(service.reloadApp).not.toHaveBeenCalled();
+
+      resolveSave(null);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(service.reloadApp).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not reload and surfaces an error when the demo config save fails', async () => {
+      storageMock.setConfig.mockRejectedValueOnce(new Error('network down'));
+
+      service.loadDemoConfig();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // The save must actually be attempted (not skipped) before we assert no reload.
+      expect(storageMock.setConfig).toHaveBeenCalledWith('user', 'default', expect.anything());
+      expect(service.reloadApp).not.toHaveBeenCalled();
+      expect(snackMock.open).toHaveBeenCalled();
+    });
+
+    it('does nothing when storage is not ready', async () => {
+      storageMock.storageServiceReady$.next(false);
+
+      service.loadDemoConfig();
+      await Promise.resolve();
+
+      expect(storageMock.setConfig).not.toHaveBeenCalled();
+      expect(service.reloadApp).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/app/core/services/settings.service.ts
+++ b/src/app/core/services/settings.service.ts
@@ -644,8 +644,25 @@ export class SettingsService {
         theme: DemoThemeConfig
       };
       console.log("[AppSettings Service] Loading Demo configuration settings as remote config: " + this.useSharedConfig + " and reloading app.");
-      this.storage.setConfig('user', this.sharedConfigName, demoConfig);
-      this.reloadApp();
+      // Wait for the server write to land before reloading; reloading mid-request
+      // aborts the POST and leaves the previous configuration in place.
+      if (this.storage.storageServiceReady$.getValue()) {
+        this.storage.setConfig('user', this.sharedConfigName, demoConfig)
+          .then(() => {
+            this.reloadApp();
+          })
+          .catch(error => {
+            console.error("[AppSettings Service] Error saving demo configuration to the server", error);
+            this.snackBar.open(
+              'Problem saving configuration to the server. Resolve this issue before KIP can be used reliably.',
+              'Close',
+              {
+                duration: 0,
+                verticalPosition: 'top'
+              }
+            );
+          });
+      }
     } else {
       console.log("[AppSettings Service] Loading Demo configuration settings to LocalStorage");
       this.replaceConfig("appConfig", DemoAppConfig);

--- a/src/app/core/services/storage.service.spec.ts
+++ b/src/app/core/services/storage.service.spec.ts
@@ -1,16 +1,68 @@
 import { TestBed } from '@angular/core/testing';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { BehaviorSubject, Subject, of, throwError } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { HttpClient } from '@angular/common/http';
 import { StorageService } from './storage.service';
+import { SignalKConnectionService } from './signalk-connection.service';
+import { AuthenticationService } from './authentication.service';
 
 describe('StorageService', () => {
   let service: StorageService;
+  let httpMock: { post: ReturnType<typeof vi.fn>; get: ReturnType<typeof vi.fn> };
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    httpMock = { post: vi.fn(), get: vi.fn() };
+    TestBed.configureTestingModule({
+      providers: [
+        StorageService,
+        { provide: HttpClient, useValue: httpMock },
+        {
+          provide: SignalKConnectionService,
+          useValue: {
+            serverServiceEndpoint$: new BehaviorSubject({ operation: 0 }),
+            serverVersion$: new BehaviorSubject('2.0.0')
+          }
+        },
+        { provide: AuthenticationService, useValue: { isLoggedIn$: new BehaviorSubject(false) } }
+      ]
+    });
     service = TestBed.inject(StorageService);
+    // Force the service ready so removeItem's ensureReady() guard passes.
+    service.storageServiceReady$.next(true);
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('removeItem resolves only after the queued delete request completes', async () => {
+    const post$ = new Subject<unknown>();
+    httpMock.post.mockReturnValue(post$);
+
+    let resolved = false;
+    const done = service.removeItem('user', 'race-config').then(() => { resolved = true; });
+
+    // The request is dispatched synchronously through the patch queue...
+    expect(httpMock.post).toHaveBeenCalledTimes(1);
+    // ...but the promise must not resolve until the server responds.
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    post$.next(null);
+    post$.complete();
+    await done;
+
+    expect(resolved).toBe(true);
+  });
+
+  it('removeItem rejects on failure yet the patch queue keeps processing', async () => {
+    httpMock.post
+      .mockReturnValueOnce(throwError(() => ({ status: 500, message: 'boom' })))
+      .mockReturnValueOnce(of(null));
+
+    await expect(service.removeItem('user', 'first')).rejects.toBeTruthy();
+    // A failed delete must not kill the sequential queue for later operations.
+    await expect(service.removeItem('user', 'second')).resolves.toBeUndefined();
+    expect(httpMock.post).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/app/core/services/storage.service.ts
+++ b/src/app/core/services/storage.service.ts
@@ -6,7 +6,7 @@ import { IConfig } from "../interfaces/app-settings.interfaces";
 import { compare } from 'compare-versions';
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { Subject } from 'rxjs/internal/Subject';
-import { tap, concatMap, catchError, lastValueFrom, BehaviorSubject } from 'rxjs';
+import { tap, concatMap, catchError, lastValueFrom, BehaviorSubject, of } from 'rxjs';
 import { AuthenticationService } from './authentication.service';
 
 export interface Config {
@@ -23,7 +23,10 @@ export interface IStorageRemoteBootstrapContext {
 interface IPatchAction {
   url: string,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  document: any
+  document: any,
+  // Optional deferred handlers so callers can await a queued patch's completion.
+  resolve?: () => void,
+  reject?: (error: unknown) => void
 }
 
 @Injectable({
@@ -52,8 +55,20 @@ export class StorageService {
     //console.log(`[Storage Service] Send patch request:\n${JSON.stringify(arg.document)}`);
     return this.http.post(arg.url, arg.document)
       .pipe(
-        tap(() => console.log("[Storage Service] Remote config patch request completed successfully")),
-        catchError((error) => this.handleError(error))
+        tap({
+          next: () => console.log("[Storage Service] Remote config patch request completed successfully"),
+          // Settle on completion (not on the value emission) so the deferred
+          // promise resolves whenever the request terminates successfully, even
+          // if the response body is empty.
+          complete: () => arg.resolve?.()
+        }),
+        catchError((error) => {
+          this.logError(error);
+          arg.reject?.(error);
+          // Swallow the error so the sequential patch queue keeps processing
+          // subsequent requests instead of terminating on the first failure.
+          return of(null);
+        })
       );
   }
 
@@ -462,7 +477,7 @@ export class StorageService {
    *
    * @memberof StorageService
    */
-  public removeItem(scope: string, name: string, forceConfigFileVersion?: number) {
+  public removeItem(scope: string, name: string, forceConfigFileVersion?: number): Promise<void> {
     this.ensureReady();
     let url = this.serverEndpoint + scope + "/kip/" + this.configFileVersion;
     if (forceConfigFileVersion) {
@@ -475,8 +490,12 @@ export class StorageService {
           "path": `/${name}`
         }
       ]
-    const patch: IPatchAction = { url, document };
-    this.patchQueue$.next(patch);
+    // Resolve only once the queued delete patch has actually run on the server,
+    // so callers can refresh their config list against the post-delete state.
+    return new Promise<void>((resolve, reject) => {
+      const patch: IPatchAction = { url, document, resolve, reject };
+      this.patchQueue$.next(patch);
+    });
   }
 
   /**
@@ -533,7 +552,7 @@ export class StorageService {
     return this._isRemoteContextBootstrapped;
   }
 
-  private handleError(error: HttpErrorResponse) {
+  private logError(error: HttpErrorResponse) {
     if (error.status === 0) {
       // A client-side or network error occurred. Handle it accordingly.
       console.error('[Storage Service] An error occurred:', error.error);
@@ -542,7 +561,11 @@ export class StorageService {
       // The response body may contain clues as to what went wrong.
       console.error(`[Storage Service] Backend returned error: `, error.message);
     }
-    // Return an observable with a user-facing error message.
+  }
+
+  private handleError(error: HttpErrorResponse) {
+    this.logError(error);
+    // Rethrow so awaiting callers (get/set/list) observe the failure.
     throw error;
   }
 


### PR DESCRIPTION
## What

Fixes a class of "misused promise" bugs where an async server write is not awaited before a dependent action (a page reload, a list refresh, or a success message). The action races or aborts the write, so the result is silently wrong. Each fix has tests that fail without it.

### Fixes

1. **Config upload / restore / delete** (`config.component.ts`, `storage.service.ts`) — uploading or restoring a configuration fired the server write but reloaded the page before it finished, which aborted the request and dropped the new config. Delete refreshed the list before the delete landed and reported success even when the write failed. `saveConfig` now awaits the write and only reloads on success; `removeItem` returns a promise that resolves when the queued delete actually completes; the patch queue keeps processing after a failed request; and a failed local-storage upload now shows an error instead of silently doing nothing.

2. **Demo config** (`settings.service.ts`) — loading the demo configuration reloaded the page before the write finished. It now awaits the write and only reloads on success, matching `resetSettings`.

3. **History-series reconcile** (`dashboard-history-series-sync.service.ts`) — `reconcileSeries` returns `null` on failure instead of throwing, so a failed reconcile was recorded as submitted and never retried. It now checks the result and retries on the next cycle.

4. **Start-fresh upgrade** (`configuration-upgrade.service.ts`) — the global-scope legacy config was retired with a delayed, fire-and-forget write that the follow-up reset and reload aborted, leaving the legacy config behind. It now awaits the write for both scopes, the same way `runUpgrade` does.

5. **Display settings save** (`display.component.ts`) — the KIP plugin save check tested an un-awaited promise, which is always truthy, so the error path was dead code and "Configuration saved" showed even when the server rejected the write. It now awaits the result and reports success or the error accordingly.

## Tests

Adds focused tests for each fix. The last commit ("Add display settings save tests") also adds two `SettingsService` mock methods that PR #1083 adds as well; that commit is kept separate so it can be dropped or rebased to reconcile with #1083 when merging.

## Verification

- Full local test suite: no new failures versus `master`, +26 passing tests, and 2 spec files that were failing on `master` now pass.
- Lint and the production build pass.
