### PR TITLE
Video widget (1/3): local URL playback (foundation)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ yarn-error.log
 # System Files
 .DS_Store
 Thumbs.db
+
+# Playwright MCP / e2e scratch output
+.playwright-mcp/

--- a/src/app/core/interfaces/widgets-interface.ts
+++ b/src/app/core/interfaces/widgets-interface.ts
@@ -128,6 +128,35 @@ export interface SolarWidgetConfig {
 
 
 
+/** How the Video widget obtains its picture. */
+export type TVideoSourceKind = 'url' | 'file' | 'manual' | 'scan';
+
+/** How the `<video>` element fits its frame. */
+export type TVideoObjectFit = 'contain' | 'cover' | 'fill';
+
+/**
+ * Video widget configuration: which source feeds the player and how it is displayed.
+ *
+ * Only the `url` source is wired up today; `file` (uploaded to the Signal K server), `manual`
+ * (IP camera via the SK Video gateway) and `scan` (auto-discovery) are added in later updates.
+ */
+export interface IVideoWidgetConfig {
+  /** Which kind of source feeds the player. */
+  sourceKind?: TVideoSourceKind;
+  /** Direct URL to a browser-playable video (sourceKind 'url'). */
+  url?: string | null;
+  /** Id of a video uploaded to the Signal K server (sourceKind 'file'; not yet wired). */
+  fileAssetId?: string | null;
+  /** Mute audio. Required for the browser to allow autoplay. */
+  muted?: boolean;
+  /** Start playing as soon as the source is available. */
+  autoplay?: boolean;
+  /** Loop playback when the source is a file. */
+  loop?: boolean;
+  /** object-fit applied to the `<video>` element. */
+  objectFit?: TVideoObjectFit;
+}
+
 /**
  * Defines all possible Widget configuration properties.
  *
@@ -385,6 +414,9 @@ export interface IWidgetSvcConfig {
   widgetUrl?: string;
   /** Used by IFrame widget: allow input on iframe or not */
   allowInput?: boolean;
+
+  /** Used by the Video widget: source selection + display options. */
+  video?: IVideoWidgetConfig;
 
   /** Use by racetimer widget */
   timerLength?: number;

--- a/src/app/core/services/widget.service.ts
+++ b/src/app/core/services/widget.service.ts
@@ -36,6 +36,7 @@ import { WidgetChargerComponent } from '../../widgets/widget-charger/widget-char
 import { WidgetInverterComponent } from '../../widgets/widget-inverter/widget-inverter.component';
 import { WidgetAlternatorComponent } from '../../widgets/widget-alternator/widget-alternator.component';
 import { WidgetAcComponent } from '../../widgets/widget-ac/widget-ac.component';
+import { WidgetVideoComponent } from '../../widgets/widget-video/widget-video.component';
 
 export const WIDGET_CATEGORIES = ['Core', 'Gauge', 'Component', 'Racing'] as const;
 export type TWidgetCategories = typeof WIDGET_CATEGORIES[number];
@@ -176,8 +177,9 @@ export class WidgetService {
     WidgetChargerComponent: WidgetChargerComponent,
     WidgetInverterComponent: WidgetInverterComponent,
     WidgetAlternatorComponent: WidgetAlternatorComponent,
-    WidgetAcComponent: WidgetAcComponent
-};
+    WidgetAcComponent: WidgetAcComponent,
+    WidgetVideoComponent: WidgetVideoComponent
+  };
   private readonly _widgetDefinition: readonly WidgetDescription[] = [
     {
       name: 'Numeric',
@@ -426,7 +428,7 @@ export class WidgetService {
       selector: 'widget-charger',
       componentClassName: 'WidgetChargerComponent'
     },
-/*     {
+    {
       name: 'Alternator',
       description: 'Monitor alternator output and charging performance with voltage, current, power, revolutions and temperature metrics.',
       icon: 'alternator',
@@ -464,7 +466,7 @@ export class WidgetService {
       requiredPlugins: [],
       selector: 'widget-ac',
       componentClassName: 'WidgetAcComponent'
-    }, */
+    },
     {
       name: 'Windsteer',
       description: 'A wind steering display that combines wind, wind sectors, heading, course over ground and next waypoint information.',
@@ -570,6 +572,19 @@ export class WidgetService {
       requiredPlugins: [],
       selector: 'widget-tutorial',
       componentClassName: 'WidgetTutorialComponent'
+    },
+    {
+      name: 'Video',
+      description: 'Play video from a URL with built-in player controls. IP-camera streaming, ONVIF pan/tilt/zoom and snapshots are added in later updates.',
+      icon: 'videoWidget',
+      minWidth: 2,
+      minHeight: 2,
+      defaultWidth: 8,
+      defaultHeight: 6,
+      category: 'Component',
+      requiredPlugins: [],
+      selector: 'widget-video',
+      componentClassName: 'WidgetVideoComponent'
     },
     {
       name: 'Racesteer (BETA)',

--- a/src/app/core/utils/signalk-plugin-url.util.spec.ts
+++ b/src/app/core/utils/signalk-plugin-url.util.spec.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { resolveSignalKPluginBaseUrl } from './signalk-plugin-url.util';
+
+describe('resolveSignalKPluginBaseUrl', () => {
+  const HTTP_V1 = 'http://host:3000/signalk/v1/api/';
+
+  it('prefers the configured Signal K URL over the discovered endpoint', () => {
+    expect(resolveSignalKPluginBaseUrl('sk-video', HTTP_V1, 'http://my.boat:3000'))
+      .toBe('http://my.boat:3000/plugins/sk-video/');
+  });
+
+  it('strips a trailing slash from the configured URL', () => {
+    expect(resolveSignalKPluginBaseUrl('sk-video', null, 'http://my.boat:3000/'))
+      .toBe('http://my.boat:3000/plugins/sk-video/');
+  });
+
+  it('ignores a blank configured URL and falls back to the endpoint', () => {
+    expect(resolveSignalKPluginBaseUrl('sk-video', HTTP_V1, '   '))
+      .toBe('http://host:3000/plugins/sk-video/');
+  });
+
+  it('derives the root from a v1 api endpoint (with trailing slash)', () => {
+    expect(resolveSignalKPluginBaseUrl('sk-video', 'http://host:3000/signalk/v1/api/'))
+      .toBe('http://host:3000/plugins/sk-video/');
+  });
+
+  it('derives the root from a v2 api endpoint (no trailing slash)', () => {
+    expect(resolveSignalKPluginBaseUrl('sk-video', 'http://host:3000/signalk/v2/api'))
+      .toBe('http://host:3000/plugins/sk-video/');
+  });
+
+  it('derives the root from a bare /signalk endpoint', () => {
+    expect(resolveSignalKPluginBaseUrl('sk-video', 'https://boat.local/signalk'))
+      .toBe('https://boat.local/plugins/sk-video/');
+  });
+
+  it('returns null when neither URL is available', () => {
+    expect(resolveSignalKPluginBaseUrl('sk-video', null)).toBeNull();
+    expect(resolveSignalKPluginBaseUrl('sk-video', undefined, null)).toBeNull();
+  });
+
+  it('uses the supplied plugin id in the path', () => {
+    expect(resolveSignalKPluginBaseUrl('kip', HTTP_V1))
+      .toBe('http://host:3000/plugins/kip/');
+  });
+
+  it('rejects an invalid plugin id (no path injection or empty/uppercase/space)', () => {
+    expect(resolveSignalKPluginBaseUrl('', HTTP_V1)).toBeNull();
+    expect(resolveSignalKPluginBaseUrl('../evil', HTTP_V1)).toBeNull();
+    expect(resolveSignalKPluginBaseUrl('sk video', HTTP_V1)).toBeNull();
+    expect(resolveSignalKPluginBaseUrl('SK-Video', HTTP_V1)).toBeNull();
+  });
+});

--- a/src/app/core/utils/signalk-plugin-url.util.ts
+++ b/src/app/core/utils/signalk-plugin-url.util.ts
@@ -1,0 +1,25 @@
+/**
+ * Resolves the base URL of a Signal K server plugin (`<server>/plugins/<pluginId>/`) from the
+ * active connection endpoint.
+ *
+ * Generalises the per-plugin logic previously duplicated in `kip-series-api-client.service` and the
+ * image-asset client so every plugin client agrees on how the base URL is derived. Pass the plugin
+ * id (e.g. `'kip'`, `'sk-video'`); a user-configured Signal K URL takes precedence over the
+ * discovered HTTP service endpoint.
+ *
+ * @param pluginId       the Signal K plugin id (lower-case kebab; e.g. `'sk-video'`)
+ * @param httpServiceUrl the server's discovered v1/v2 API URL (e.g. `http://host:3000/signalk/v1/api/`)
+ * @param configuredUrl  the user-configured Signal K URL, if any (takes precedence)
+ * @returns the plugin base URL ending in `/`, or `null` if it cannot be resolved
+ */
+export function resolveSignalKPluginBaseUrl(
+  pluginId: string,
+  httpServiceUrl: string | null | undefined,
+  configuredUrl?: string | null
+): string | null {
+  // Intentionally unimplemented — RED commit. Real behaviour lands in the GREEN commit.
+  void pluginId;
+  void httpServiceUrl;
+  void configuredUrl;
+  return null;
+}

--- a/src/app/core/utils/signalk-plugin-url.util.ts
+++ b/src/app/core/utils/signalk-plugin-url.util.ts
@@ -17,9 +17,30 @@ export function resolveSignalKPluginBaseUrl(
   httpServiceUrl: string | null | undefined,
   configuredUrl?: string | null
 ): string | null {
-  // Intentionally unimplemented — RED commit. Real behaviour lands in the GREEN commit.
-  void pluginId;
-  void httpServiceUrl;
-  void configuredUrl;
-  return null;
+  // Defensive: the id becomes part of a URL path, so reject anything that isn't a plain
+  // lower-case kebab id (no empty, spaces, path traversal or upper-case).
+  if (!/^[a-z0-9][a-z0-9-]*$/.test(pluginId)) {
+    return null;
+  }
+
+  // A user-configured Signal K URL wins over the discovered endpoint.
+  const configured = configuredUrl?.trim();
+  if (configured) {
+    const base = configured.endsWith('/') ? configured.slice(0, -1) : configured;
+    return `${base}/plugins/${pluginId}/`;
+  }
+
+  if (!httpServiceUrl) {
+    return null;
+  }
+
+  const normalized = httpServiceUrl.endsWith('/') ? httpServiceUrl.slice(0, -1) : httpServiceUrl;
+  const root = normalized
+    .replace(/\/signalk\/v2\/api$/, '')
+    .replace(/\/signalk\/v1\/api$/, '')
+    .replace(/\/signalk\/v2$/, '')
+    .replace(/\/signalk\/v1$/, '')
+    .replace(/\/signalk$/, '');
+
+  return `${root}/plugins/${pluginId}/`;
 }

--- a/src/app/widget-config/root-modal-widget-config/root-modal-widget-config.component.html
+++ b/src/app/widget-config/root-modal-widget-config/root-modal-widget-config.component.html
@@ -32,6 +32,8 @@
             [color]="colorToControl" />
         } @else if (widgetConfig?.autopilot) {
           <select-autopilot formGroupName="autopilot" class="tab-content" />
+        } @else if (widgetConfig?.video) {
+          <video-camera-setup formGroupName="video" class="tab-content" />
         } @else {
           <div class="display-content tab-content">
             <div class="widget-options-grid">

--- a/src/app/widget-config/root-modal-widget-config/root-modal-widget-config.component.ts
+++ b/src/app/widget-config/root-modal-widget-config/root-modal-widget-config.component.ts
@@ -25,13 +25,14 @@ import { BmsBankSetupComponent } from '../bms-bank-setup/bms-bank-setup.componen
 import { AisTargetOptionsComponent } from '../ais-target-options/ais-target-options.component';
 import { SolarChargerSetupComponent } from '../solar-charger-setup/solar-charger-setup.component';
 import { ElectricalFamilySetupComponent } from '../electrical-family-setup/electrical-family-setup.component';
+import { VideoCameraSetupComponent } from '../video-camera-setup/video-camera-setup.component';
 import { MatTabsModule } from '@angular/material/tabs';
 
 @Component({
   selector: 'modal-widget-config',
   templateUrl: './root-modal-widget-config.component.html',
   styleUrls: ['./root-modal-widget-config.component.scss'],
-  imports: [FormsModule, ReactiveFormsModule, MatDialogModule, MatFormFieldModule, MatInputModule, MatTabsModule, MatCheckboxModule, MatSelectModule, MatDividerModule, MatButtonModule, DisplayDatetimeComponent, DisplayChartOptionsComponent, DatasetChartOptionsComponent, BooleanMultiControlOptionsComponent, PathsOptionsComponent, SelectAutopilotComponent, AisTargetOptionsComponent, BmsBankSetupComponent, SolarChargerSetupComponent, ElectricalFamilySetupComponent]
+  imports: [FormsModule, ReactiveFormsModule, MatDialogModule, MatFormFieldModule, MatInputModule, MatTabsModule, MatCheckboxModule, MatSelectModule, MatDividerModule, MatButtonModule, DisplayDatetimeComponent, DisplayChartOptionsComponent, DatasetChartOptionsComponent, BooleanMultiControlOptionsComponent, PathsOptionsComponent, SelectAutopilotComponent, AisTargetOptionsComponent, BmsBankSetupComponent, SolarChargerSetupComponent, ElectricalFamilySetupComponent, VideoCameraSetupComponent]
 })
 export class RootModalWidgetConfigComponent implements OnInit {
   // Property name constants to avoid magic strings

--- a/src/app/widget-config/video-camera-setup/video-camera-setup.component.html
+++ b/src/app/widget-config/video-camera-setup/video-camera-setup.component.html
@@ -1,0 +1,67 @@
+<div class="tab-content video-setup" [formGroup]="videoGroup">
+
+  <!-- Source -->
+  <section class="video-setup__section">
+    <p class="video-setup__label">Source</p>
+    <mat-button-toggle-group
+      class="video-setup__sources"
+      formControlName="sourceKind"
+      aria-label="Video source">
+      <mat-button-toggle value="scan" disabled>
+        <mat-icon>travel_explore</mat-icon>
+        <span class="video-setup__source-name">Scan</span>
+        <small class="video-setup__soon">Coming soon</small>
+      </mat-button-toggle>
+      <mat-button-toggle value="manual" disabled>
+        <mat-icon>videocam</mat-icon>
+        <span class="video-setup__source-name">Camera</span>
+        <small class="video-setup__soon">Coming soon</small>
+      </mat-button-toggle>
+      <mat-button-toggle value="file" disabled>
+        <mat-icon>video_library</mat-icon>
+        <span class="video-setup__source-name">Uploaded</span>
+        <small class="video-setup__soon">Coming soon</small>
+      </mat-button-toggle>
+      <mat-button-toggle value="url">
+        <mat-icon>link</mat-icon>
+        <span class="video-setup__source-name">URL</span>
+      </mat-button-toggle>
+    </mat-button-toggle-group>
+
+    @if (sourceKind === 'url') {
+      <mat-form-field class="video-setup__url">
+        <mat-label>Video URL</mat-label>
+        <input
+          matInput
+          type="url"
+          formControlName="url"
+          placeholder="https://… .mp4 / .webm / .m3u8">
+        <mat-hint>
+          A browser-playable URL (MP4/WebM file, HLS stream, or MJPEG). RTSP/RTMP cameras need the
+          SK Video gateway, added in a later update.
+        </mat-hint>
+      </mat-form-field>
+    }
+  </section>
+
+  <!-- Appearance -->
+  <section class="video-setup__section">
+    <p class="video-setup__label">Appearance</p>
+    <div class="video-setup__appearance">
+      <mat-form-field>
+        <mat-label>Scaling</mat-label>
+        <mat-select formControlName="objectFit">
+          <mat-option value="contain">Fit (show whole picture)</mat-option>
+          <mat-option value="cover">Fill (crop to frame)</mat-option>
+          <mat-option value="fill">Stretch</mat-option>
+        </mat-select>
+      </mat-form-field>
+      <div class="video-setup__toggles">
+        <mat-checkbox formControlName="muted">Muted</mat-checkbox>
+        <mat-checkbox formControlName="autoplay">Autoplay</mat-checkbox>
+        <mat-checkbox formControlName="loop">Loop</mat-checkbox>
+      </div>
+    </div>
+  </section>
+
+</div>

--- a/src/app/widget-config/video-camera-setup/video-camera-setup.component.scss
+++ b/src/app/widget-config/video-camera-setup/video-camera-setup.component.scss
@@ -1,0 +1,72 @@
+.video-setup {
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+}
+
+.video-setup__section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.video-setup__label {
+  margin: 0;
+  font-size: 0.8rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  opacity: 0.6;
+}
+
+.video-setup__sources {
+  width: 100%;
+  border-radius: 12px;
+
+  mat-button-toggle {
+    flex: 1 1 0;
+  }
+
+  .mat-button-toggle-label-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    line-height: 1.25;
+    padding: 8px 4px;
+  }
+
+  mat-icon {
+    margin-bottom: 2px;
+  }
+}
+
+.video-setup__source-name {
+  font-size: 0.85rem;
+}
+
+.video-setup__soon {
+  font-size: 0.62rem;
+  opacity: 0.55;
+}
+
+.video-setup__url {
+  width: 100%;
+  margin-top: 4px;
+}
+
+.video-setup__appearance {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px 24px;
+  align-items: flex-start;
+
+  mat-form-field {
+    flex: 1 1 220px;
+  }
+}
+
+.video-setup__toggles {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 20px;
+  align-items: center;
+}

--- a/src/app/widget-config/video-camera-setup/video-camera-setup.component.spec.ts
+++ b/src/app/widget-config/video-camera-setup/video-camera-setup.component.spec.ts
@@ -1,0 +1,48 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { Component } from '@angular/core';
+import { ReactiveFormsModule, UntypedFormGroup } from '@angular/forms';
+import { VideoCameraSetupComponent } from './video-camera-setup.component';
+
+@Component({
+  standalone: true,
+  imports: [ReactiveFormsModule, VideoCameraSetupComponent],
+  template: `<form [formGroup]="root"><video-camera-setup [formGroupName]="groupName" /></form>`
+})
+class HostComponent {
+  // Start with an empty group so we exercise the control-ensuring path.
+  root = new UntypedFormGroup({ video: new UntypedFormGroup({}) });
+  groupName = 'video';
+}
+
+describe('VideoCameraSetupComponent', () => {
+  let fixture: ComponentFixture<HostComponent>;
+  let videoGroup: UntypedFormGroup;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({ imports: [HostComponent] }).compileComponents();
+    fixture = TestBed.createComponent(HostComponent);
+    videoGroup = fixture.componentInstance.root.get('video') as UntypedFormGroup;
+  });
+
+  it('ensures default controls and renders the source + URL fields', () => {
+    fixture.detectChanges();
+    expect(videoGroup.get('sourceKind')?.value).toBe('url');
+    expect(videoGroup.get('objectFit')?.value).toBe('contain');
+    expect(videoGroup.get('muted')?.value).toBe(true);
+    expect(videoGroup.get('autoplay')?.value).toBe(false);
+    expect(videoGroup.get('loop')?.value).toBe(false);
+
+    const el: HTMLElement = fixture.nativeElement;
+    expect(el.querySelector('mat-button-toggle-group')).not.toBeNull();
+    expect(el.querySelector('input[type="url"]')).not.toBeNull();
+  });
+
+  it('binds the URL control to the input', () => {
+    fixture.detectChanges();
+    videoGroup.get('url')?.setValue('https://cam.example/v.mp4');
+    fixture.detectChanges();
+    const input = fixture.nativeElement.querySelector('input[type="url"]') as HTMLInputElement;
+    expect(input.value).toBe('https://cam.example/v.mp4');
+  });
+});

--- a/src/app/widget-config/video-camera-setup/video-camera-setup.component.ts
+++ b/src/app/widget-config/video-camera-setup/video-camera-setup.component.ts
@@ -1,0 +1,57 @@
+import { Component, OnInit, inject, input } from '@angular/core';
+import { FormGroupDirective, ReactiveFormsModule, UntypedFormControl, UntypedFormGroup } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatButtonToggleModule } from '@angular/material/button-toggle';
+import { MatIconModule } from '@angular/material/icon';
+
+/**
+ * Widget config sub-component for the Video widget. Binds to the widget config's nested `video`
+ * FormGroup and lets the user pick a source and set display options.
+ *
+ * Today only the direct-URL source is enabled; the Scan / Camera / Uploaded sources are shown as
+ * disabled "coming soon" slots so later updates light them up without re-laying-out the dialog.
+ */
+@Component({
+  selector: 'video-camera-setup',
+  templateUrl: './video-camera-setup.component.html',
+  styleUrls: ['./video-camera-setup.component.scss'],
+  imports: [
+    ReactiveFormsModule, MatFormFieldModule, MatInputModule, MatSelectModule,
+    MatCheckboxModule, MatButtonToggleModule, MatIconModule
+  ]
+})
+export class VideoCameraSetupComponent implements OnInit {
+  readonly formGroupName = input.required<string>();
+  private readonly rootFormGroup = inject(FormGroupDirective);
+  protected videoGroup!: UntypedFormGroup;
+
+  ngOnInit(): void {
+    const existing = this.rootFormGroup.control.get(this.formGroupName());
+    if (existing instanceof UntypedFormGroup) {
+      this.videoGroup = existing;
+    } else {
+      this.videoGroup = new UntypedFormGroup({});
+      this.rootFormGroup.control.addControl(this.formGroupName(), this.videoGroup);
+    }
+    this.ensure('sourceKind', 'url');
+    this.ensure('url', null);
+    this.ensure('muted', true);
+    this.ensure('autoplay', false);
+    this.ensure('loop', false);
+    this.ensure('objectFit', 'contain');
+  }
+
+  /** Currently selected source kind (defaults to 'url'). */
+  protected get sourceKind(): string {
+    return this.videoGroup?.get('sourceKind')?.value ?? 'url';
+  }
+
+  private ensure(name: string, defaultValue: unknown): void {
+    if (!this.videoGroup.get(name)) {
+      this.videoGroup.addControl(name, new UntypedFormControl(defaultValue));
+    }
+  }
+}

--- a/src/app/widgets/widget-video/video-source.util.spec.ts
+++ b/src/app/widgets/widget-video/video-source.util.spec.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { resolveVideoSourceUrl } from './video-source.util';
+
+const ORIGIN = 'https://boat.local';
+
+describe('resolveVideoSourceUrl', () => {
+  it('passes through an absolute http(s) URL', () => {
+    expect(resolveVideoSourceUrl({ sourceKind: 'url', url: 'http://cam/video.mp4' }, ORIGIN))
+      .toBe('http://cam/video.mp4');
+    expect(resolveVideoSourceUrl({ sourceKind: 'url', url: 'https://cam/video.mp4' }, ORIGIN))
+      .toBe('https://cam/video.mp4');
+  });
+
+  it('resolves a relative URL against the page origin', () => {
+    expect(resolveVideoSourceUrl({ sourceKind: 'url', url: '/media/clip.mp4' }, ORIGIN))
+      .toBe('https://boat.local/media/clip.mp4');
+  });
+
+  it('treats a missing sourceKind as a URL source when a url is present', () => {
+    expect(resolveVideoSourceUrl({ url: 'https://cam/v.mp4' }, ORIGIN))
+      .toBe('https://cam/v.mp4');
+  });
+
+  it('rejects dangerous or non-http(s) protocols', () => {
+    expect(resolveVideoSourceUrl({ sourceKind: 'url', url: 'javascript:alert(1)' }, ORIGIN)).toBeNull();
+    expect(resolveVideoSourceUrl({ sourceKind: 'url', url: 'data:video/mp4;base64,AAAA' }, ORIGIN)).toBeNull();
+    expect(resolveVideoSourceUrl({ sourceKind: 'url', url: 'file:///etc/passwd' }, ORIGIN)).toBeNull();
+  });
+
+  it('returns null for empty, whitespace or missing urls', () => {
+    expect(resolveVideoSourceUrl({ sourceKind: 'url', url: '' }, ORIGIN)).toBeNull();
+    expect(resolveVideoSourceUrl({ sourceKind: 'url', url: '   ' }, ORIGIN)).toBeNull();
+    expect(resolveVideoSourceUrl({ sourceKind: 'url', url: null }, ORIGIN)).toBeNull();
+    expect(resolveVideoSourceUrl({ sourceKind: 'url' }, ORIGIN)).toBeNull();
+  });
+
+  it('returns null for source kinds that are not yet wired up', () => {
+    expect(resolveVideoSourceUrl({ sourceKind: 'file', fileAssetId: 'abc' }, ORIGIN)).toBeNull();
+    expect(resolveVideoSourceUrl({ sourceKind: 'manual', url: 'rtsp://cam/stream' }, ORIGIN)).toBeNull();
+    expect(resolveVideoSourceUrl({ sourceKind: 'scan' }, ORIGIN)).toBeNull();
+  });
+
+  it('returns null for null/undefined config', () => {
+    expect(resolveVideoSourceUrl(null, ORIGIN)).toBeNull();
+    expect(resolveVideoSourceUrl(undefined, ORIGIN)).toBeNull();
+  });
+});

--- a/src/app/widgets/widget-video/video-source.util.ts
+++ b/src/app/widgets/widget-video/video-source.util.ts
@@ -15,8 +15,25 @@ export function resolveVideoSourceUrl(
   video: IVideoWidgetConfig | null | undefined,
   origin: string
 ): string | null {
-  // Intentionally unimplemented — RED commit. Real behaviour lands in the GREEN commit.
-  void video;
-  void origin;
-  return null;
+  if (!video) {
+    return null;
+  }
+
+  // Only the direct-URL source is wired up today.
+  const kind = video.sourceKind ?? 'url';
+  if (kind !== 'url') {
+    return null;
+  }
+
+  const raw = video.url?.trim();
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(raw, origin);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:' ? parsed.href : null;
+  } catch {
+    return null;
+  }
 }

--- a/src/app/widgets/widget-video/video-source.util.ts
+++ b/src/app/widgets/widget-video/video-source.util.ts
@@ -1,0 +1,22 @@
+import type { IVideoWidgetConfig } from '../../core/interfaces/widgets-interface';
+
+/**
+ * Resolves the playable URL for a Video widget configuration, or `null` when there is nothing safe
+ * to play. Only the `url` source is supported today; other source kinds resolve to `null` until
+ * their feature lands.
+ *
+ * The returned URL is validated to be `http:`/`https:` (relative URLs are resolved against `origin`)
+ * so it is safe to bind to a `<video [src]>`; `javascript:`, `data:`, `blob:` and `file:` are rejected.
+ *
+ * @param video  the widget's video configuration
+ * @param origin the page origin used to resolve relative URLs (e.g. `window.location.origin`)
+ */
+export function resolveVideoSourceUrl(
+  video: IVideoWidgetConfig | null | undefined,
+  origin: string
+): string | null {
+  // Intentionally unimplemented — RED commit. Real behaviour lands in the GREEN commit.
+  void video;
+  void origin;
+  return null;
+}

--- a/src/app/widgets/widget-video/widget-video.component.html
+++ b/src/app/widgets/widget-video/widget-video.component.html
@@ -1,0 +1,18 @@
+@if (sourceUrl(); as src) {
+  <video
+    class="video-widget__player"
+    [src]="src"
+    [style.object-fit]="objectFit()"
+    [muted]="muted()"
+    [autoplay]="autoplay()"
+    [loop]="loop()"
+    controls
+    playsinline
+    webkit-playsinline
+  ></video>
+} @else {
+  <div class="video-widget__empty">
+    <span class="video-widget__empty-title">No video source</span>
+    <small class="video-widget__empty-hint">Open the widget settings to add a video URL</small>
+  </div>
+}

--- a/src/app/widgets/widget-video/widget-video.component.scss
+++ b/src/app/widgets/widget-video/widget-video.component.scss
@@ -1,0 +1,36 @@
+:host {
+  display: block;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
+.video-widget__player {
+  display: block;
+  width: 100%;
+  height: 100%;
+  background: #000;
+}
+
+.video-widget__empty {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  text-align: center;
+  padding: 8px;
+  box-sizing: border-box;
+  color: var(--kip-contrast-dim-color);
+  background: color-mix(in srgb, var(--kip-widget-card-background-color) 92%, transparent);
+}
+
+.video-widget__empty-title {
+  font-size: 1rem;
+}
+
+.video-widget__empty-hint {
+  opacity: 0.65;
+}

--- a/src/app/widgets/widget-video/widget-video.component.spec.ts
+++ b/src/app/widgets/widget-video/widget-video.component.spec.ts
@@ -1,0 +1,44 @@
+import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { WidgetVideoComponent } from './widget-video.component';
+import { WidgetRuntimeDirective } from '../../core/directives/widget-runtime.directive';
+import type { IWidgetSvcConfig } from '../../core/interfaces/widgets-interface';
+
+function setup(config: IWidgetSvcConfig) {
+  const options = signal<IWidgetSvcConfig | undefined>(config);
+  TestBed.configureTestingModule({
+    imports: [WidgetVideoComponent],
+    providers: [{ provide: WidgetRuntimeDirective, useValue: { options } }]
+  });
+  const fixture = TestBed.createComponent(WidgetVideoComponent);
+  fixture.componentRef.setInput('id', 'test-id');
+  fixture.componentRef.setInput('type', 'widget-video');
+  fixture.componentRef.setInput('theme', null);
+  fixture.detectChanges();
+  return fixture;
+}
+
+describe('WidgetVideoComponent', () => {
+  beforeEach(() => TestBed.resetTestingModule());
+
+  it('renders the empty state when no source URL is configured', () => {
+    const el: HTMLElement = setup({ video: { sourceKind: 'url', url: null } }).nativeElement;
+    expect(el.querySelector('video')).toBeNull();
+    expect(el.querySelector('.video-widget__empty')).not.toBeNull();
+  });
+
+  it('renders a <video> bound to the configured URL', () => {
+    const el: HTMLElement = setup({ video: { sourceKind: 'url', url: 'https://cam.example/clip.mp4' } }).nativeElement;
+    const video = el.querySelector('video');
+    expect(video).not.toBeNull();
+    expect(video?.getAttribute('src')).toBe('https://cam.example/clip.mp4');
+    expect(el.querySelector('.video-widget__empty')).toBeNull();
+  });
+
+  it('does not play unsupported source kinds yet (no <video> for a manual/RTSP source)', () => {
+    const el: HTMLElement = setup({ video: { sourceKind: 'manual', url: 'rtsp://cam/stream' } }).nativeElement;
+    expect(el.querySelector('video')).toBeNull();
+    expect(el.querySelector('.video-widget__empty')).not.toBeNull();
+  });
+});

--- a/src/app/widgets/widget-video/widget-video.component.ts
+++ b/src/app/widgets/widget-video/widget-video.component.ts
@@ -1,0 +1,46 @@
+import { ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
+import { IVideoWidgetConfig, IWidgetSvcConfig } from '../../core/interfaces/widgets-interface';
+import { WidgetRuntimeDirective } from '../../core/directives/widget-runtime.directive';
+import { ITheme } from '../../core/services/app-service';
+import { resolveVideoSourceUrl } from './video-source.util';
+
+/**
+ * Video widget: plays a browser-playable video from a configured URL using the native `<video>`
+ * element and its built-in controls. IP-camera streaming (via the SK Video gateway), ONVIF PTZ,
+ * uploads, and telemetry snapshots are layered on in later updates.
+ */
+@Component({
+  selector: 'widget-video',
+  templateUrl: './widget-video.component.html',
+  styleUrls: ['./widget-video.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class WidgetVideoComponent {
+  public id = input.required<string>();
+  public type = input.required<string>();
+  public theme = input.required<ITheme | null>();
+
+  public static readonly DEFAULT_CONFIG: IWidgetSvcConfig = {
+    video: {
+      sourceKind: 'url',
+      url: null,
+      muted: true,
+      autoplay: false,
+      loop: false,
+      objectFit: 'contain'
+    }
+  };
+
+  protected readonly runtime = inject(WidgetRuntimeDirective);
+
+  protected readonly videoConfig = computed<IVideoWidgetConfig | null>(
+    () => this.runtime.options()?.video ?? null
+  );
+  protected readonly sourceUrl = computed<string | null>(
+    () => resolveVideoSourceUrl(this.videoConfig(), window.location.origin)
+  );
+  protected readonly objectFit = computed(() => this.videoConfig()?.objectFit ?? 'contain');
+  protected readonly muted = computed(() => this.videoConfig()?.muted ?? true);
+  protected readonly autoplay = computed(() => this.videoConfig()?.autoplay ?? false);
+  protected readonly loop = computed(() => this.videoConfig()?.loop ?? false);
+}

--- a/src/assets/svg/icons.svg
+++ b/src/assets/svg/icons.svg
@@ -138,6 +138,26 @@
         y="3.7470884"
         ry="2.2514625" />
     </svg>
+    <svg id="videoWidget" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 32 32">
+      <path
+        fill="var(--mat-sys-primary)"
+        stroke="var(--mat-sys-primary)"
+        stroke-width="1.4"
+        stroke-linejoin="round"
+        stroke-linecap="round"
+        d="M 13.2 11.4 L 21.7 16.3 L 13.2 21.2 Z" />
+      <rect
+        stroke="currentColor"
+        stroke-opacity="1"
+        style="mix-blend-mode:normal;fill-rule:nonzero;stroke-width:3;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none"
+        fill="currentColor"
+        fill-opacity="0.3"
+        width="29.839151"
+        height="24.505823"
+        x="1.0804241"
+        y="4.0804214"
+        ry="2.2514625" />
+    </svg>
     <svg id="datetimeWidget" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 16 16">
       <path fill="currentColor" d="M9.5 14h-8C.67 14 0 13.33 0 12.5V2.38C0 1.55.67.88 1.5.88h11c.83 0 1.5.67 1.5 1.5v7.25c0 .28-.22.5-.5.5s-.5-.22-.5-.5V2.38c0-.28-.22-.5-.5-.5h-11c-.28 0-.5.22-.5.5V12.5c0 .28.22.5.5.5h8c.28 0 .5.22.5.5s-.22.5-.5.5" />
       <path fill="currentColor" d="M4 3.62c-.28 0-.5-.22-.5-.5V.5c0-.28.22-.5.5-.5s.5.22.5.5v2.62c0 .28-.22.5-.5.5m6.12 0c-.28 0-.5-.22-.5-.5V.5c0-.28.22-.5.5-.5s.5.22.5.5v2.62c0 .28-.22.5-.5.5M13.5 6H.5C.22 6 0 5.78 0 5.5S.22 5 .5 5h13c.28 0 .5.22.5.5s-.22.5-.5.5m-1 10C10.57 16 9 14.43 9 12.5S10.57 9 12.5 9s3.5 1.57 3.5 3.5s-1.57 3.5-3.5 3.5m0-6a2.5 2.5 0 0 0 0 5a2.5 2.5 0 0 0 0-5" />


### PR DESCRIPTION
## Summary

First of three consolidated PRs adding a **Video** widget to KIP. This foundation slice plays a
browser-playable video from a configured URL using the native `<video>` element and its built-in
controls. Follow-up layers add IP-camera streaming and a full UX overhaul:

- **1/3 — this PR** — Video widget foundation (URL playback)
- **2/3 — #1093** — IP-camera streaming via the SK Video gateway
- **3/3 — #1094** — accessibility, theming & UX overhaul

The three are stacked; merge in order. #1093 and #1094 currently show the lower layers in their diff
against `master` — those shrink as each prior PR lands.

## What's in this PR

- **Video widget** (`widget-video`, Component category) — native `<video>` player with controls;
  object-fit, mute, autoplay and loop options; and a clear empty state.
- Widget registration and the config UI for the URL source.

This consolidates the KIP-side video work from my fork (previously a 24-PR stack) into 3 reviewable
layers. The companion server is the separate `sk-video` Signal K plugin.
