### PR TITLE
feat: same-origin cookie/SSO authentication mode (additive, dual-mode)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# Unreleased
+## New Features
+* Same-origin Signal K sign-in (SSO): when KIP is served by a Signal K server on the same origin, it authenticates with the server's session cookie instead of its own username/password form. With an OIDC/SSO server, KIP joins the existing session and redirects to the server login when needed — no second sign-in, and OIDC-provisioned users (who have no server-local password) can use KIP. Cross-origin standalone use (a PWA pointed at a remote server) keeps the existing token sign-in.
+## Improvements
+* The Connectivity settings show your Signal K session identity in same-origin mode (including a read-only-session indicator) instead of a credential form.
+* Security: the Signal K login password is no longer stored in the browser; it is used only in memory to obtain a session token.
+## Fixes
+* OIDC/SSO users could not sign in to KIP because it required a server-local password they do not have; same-origin SSO mode resolves this.
+## Behavior changes
+* Cross-origin token sign-in: the Signal K server provides no token-refresh endpoint, so the stored password is no longer re-sent to renew a session. The session token still persists across browser reloads until it expires; when it expires you are prompted to sign in again.
+
 # v4.8.0
 ## New Features
 * Solar Charger Widget: Get instant clarity on your solar system with a compact, purpose-built Solar Charger Widget. Track individual panels or full arrays in real time, including State of Charge, remaining capacity, remaining time, voltage, current, power flow, and temperature. Device discovery is automatic, and Zones support keeps warnings and alarms state highly visible.

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -27,6 +27,7 @@ import { ConfigurationUpgradeService } from './core/services/configuration-upgra
 import { RemoteDashboardsService } from './core/services/remote-dashboards.service';
 import { ToastService } from './core/services/toast.service';
 import { AppNetworkInitService, IBootstrapIssue } from './core/services/app-initNetwork.service';
+import { SsoRedirectService } from './core/services/sso-redirect.service';
 import { DashboardHistorySeriesSyncService } from './core/services/dashboard-history-series-sync.service';
 
 @Component({
@@ -46,6 +47,7 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
   private readonly _deltaService = inject(SignalKDeltaService);
   private readonly _connectionStateMachine = inject(ConnectionStateMachine);
   private readonly _appNetworkInit = inject(AppNetworkInitService);
+  private readonly _ssoRedirect = inject(SsoRedirectService);
   private readonly _historySeriesReconcile = inject(DashboardHistorySeriesSyncService);
   public readonly authenticationService = inject(AuthenticationService);
   private readonly _dataSet = inject(DatasetStreamService);
@@ -82,6 +84,7 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
   private scheduledOpen: number | null = null;
   private readonly OPEN_DELAY_MS = 300; // should match/ exceed sidenav close animation time
   private missingConfigPromptShown = false;
+  private authBlockedPromptShown = false;
 
   // Stable handler refs (prevent leak from rebinding)
   private readonly _swipeLeftHandler = () => this.onSwipeLeft();
@@ -226,6 +229,23 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
             this.settings.resetSettings();
           }
         });
+    });
+
+    // Cookie-mode auth blocked (SSO auto-login looped out of budget, or sign-in required): offer an
+    // explicit Sign in that resets the budget and disables auto-login so it is not auto-bounced.
+    effect(() => {
+      const issue = this.bootstrapIssue();
+      if (issue.reason !== 'auth-blocked' || this.authBlockedPromptShown) {
+        return;
+      }
+      this.authBlockedPromptShown = true;
+      const message = issue.cause === 'budget-exhausted'
+        ? 'Automatic sign-in did not complete. Sign in to Signal K to continue.'
+        : 'Sign in to Signal K to access your configuration.';
+      const ref = this.toast.show(message, 0, true, 'warn', 'Sign in');
+      ref.onAction()
+        .pipe(takeUntilDestroyed(this._destroyRef))
+        .subscribe(() => this._ssoRedirect.manualSignIn());
     });
   }
 

--- a/src/app/core/components/options/signalk/signalk.component.html
+++ b/src/app/core/components/options/signalk/signalk.component.html
@@ -19,18 +19,38 @@
     </tr>
     <tr class="connect-table">
       <td colspan="2">
-        <mat-slide-toggle #useSharedConfigToggle
-          name="useSharedConfigToggle"
-          matTooltip="Activating authentication enables Signal K's user storage feature to save KIP configuration on the server. When authentication is not activated, KIP stores it's configuration locally in the Browser."
-          [(ngModel)]="connectionConfig.useSharedConfig"
-          [ngModelOptions]="{standalone: true}"
-          [disabled]="!connectionConfig.signalKUrl"
-          (change)="useSharedConfigToggleClick($event)">
-            Login to server
-        </mat-slide-toggle>
-        <button mat-flat-button type="button" class="credentials-btn" matTooltip="Configure Signal K user authentication credentials. The user must be a valid pre existing Signal K server user. It is strongly recommended not to use the default Signal K Admin user." [disabled]="!connectionConfig.useSharedConfig" (click)="openUserCredentialModal(null)">
-          Set Credential
-        </button>
+        @if (cookieMode) {
+          <div class="sso-identity" aria-live="polite">
+            @if (isUserSession()) {
+              <span>Signed in@if (loginStatus()?.oidcProviderName) { via {{ loginStatus()?.oidcProviderName }}}@if (loginStatus()?.username) { as {{ loginStatus()?.username }}}.</span>
+              @if (!canWriteUserData()) {
+                <span class="sso-readonly"> Read-only access — configuration changes are disabled on the server.</span>
+              }
+            } @else if (loginStatus(); as status) {
+              @if (status.authenticationRequired === false) {
+                <span>Connected (no sign-in required).</span>
+              } @else {
+                <span>Not signed in. </span>
+                <button mat-flat-button type="button" (click)="signIn()">Sign in</button>
+              }
+            } @else {
+              <span>Checking sign-in status…</span>
+            }
+          </div>
+        } @else {
+          <mat-slide-toggle #useSharedConfigToggle
+            name="useSharedConfigToggle"
+            matTooltip="Activating authentication enables Signal K's user storage feature to save KIP configuration on the server. When authentication is not activated, KIP stores it's configuration locally in the Browser."
+            [(ngModel)]="connectionConfig.useSharedConfig"
+            [ngModelOptions]="{standalone: true}"
+            [disabled]="!connectionConfig.signalKUrl"
+            (change)="useSharedConfigToggleClick($event)">
+              Login to server
+          </mat-slide-toggle>
+          <button mat-flat-button type="button" class="credentials-btn" matTooltip="Configure Signal K user authentication credentials. The user must be a valid pre existing Signal K server user. It is strongly recommended not to use the default Signal K Admin user." [disabled]="!connectionConfig.useSharedConfig" (click)="openUserCredentialModal(null)">
+            Set Credential
+          </button>
+        }
         <br />
         <mat-checkbox [(ngModel)]="connectionConfig.signalKSubscribeAll" [ngModelOptions]="{standalone: false}" name="signalKSubscribeAll">Subscribe to remote sources messages such as AIS and DSC targets. <i>Warning: this maybe generate heavy traffic.</i></mat-checkbox>
       </td>
@@ -51,7 +71,7 @@
       <pre>KIP: {{ app.appVersion() }}
 {{ app.browserVersion() }}, {{ app.osVersion() }}<br />
 {{ endpointServiceStatus.serverDescription }}
-{{ streamStatus.message }}, {{ streamStatus.hasToken ? 'Logged In' : 'Readonly'}}
+{{ streamStatus.message }}, {{ cookieMode ? (isUserSession() ? 'Signed in' : 'Not signed in') : (streamStatus.hasToken ? 'Logged In' : 'Readonly') }}
 Internet: {{ internetAvailabilityLabel() }}</pre>
     </div>
   </div>

--- a/src/app/core/components/options/signalk/signalk.component.ts
+++ b/src/app/core/components/options/signalk/signalk.component.ts
@@ -203,11 +203,9 @@ export class SettingsSignalkComponent implements OnInit, AfterViewInit, OnDestro
 
       console.log('[Settings-SignalK] Validation successful - proceeding with connection');
 
-      // Step 2: Save the new configuration to localStorage
-      this.settings.setConnectionConfig(this.connectionConfig);
-
-      // Step 3: Token mode only — establish the session in-memory so the session JWT (the plaintext
-      // password is no longer persisted) survives the reload that bootstraps the new config.
+      // Step 2: Token mode only — establish the session in-memory FIRST (using the explicit newUrl) so
+      // a failed credential login does not persist a rejected config. The session JWT (the plaintext
+      // password is no longer persisted) then survives the reload that bootstraps the new config.
       if (!newConfigIsCookieMode && this.connectionConfig.useSharedConfig) {
         await this.auth.login({
           usr: this.connectionConfig.loginName,
@@ -215,6 +213,9 @@ export class SettingsSignalkComponent implements OnInit, AfterViewInit, OnDestro
           newUrl: this.connectionConfig.signalKUrl
         });
       }
+
+      // Step 3: Persist the now-validated configuration to localStorage.
+      this.settings.setConnectionConfig(this.connectionConfig);
 
       // Step 4: Properly close WebSocket and HTTP connections
       this.connectionStateMachine.shutdown('Configuration changed - restarting app');

--- a/src/app/core/components/options/signalk/signalk.component.ts
+++ b/src/app/core/components/options/signalk/signalk.component.ts
@@ -1,5 +1,5 @@
 import { ElementRef, Component, OnInit, OnDestroy, AfterViewInit, viewChild, inject, DestroyRef, computed } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { AppService } from '../../../services/app-service';
 import { ToastService } from '../../../services/toast.service';
 import { SettingsService } from '../../../services/settings.service';
@@ -8,6 +8,7 @@ import { SignalKConnectionService, IEndpointStatus } from '../../../services/sig
 import { IDeltaUpdate, DataService } from '../../../services/data.service';
 import { SignalKDeltaService, IStreamStatus } from '../../../services/signalk-delta.service';
 import { AuthenticationService, IAuthorizationToken } from '../../../services/authentication.service';
+import { SsoRedirectService } from '../../../services/sso-redirect.service';
 import { ConnectionStateMachine } from '../../../services/connection-state-machine.service';
 import { ModalUserCredentialComponent } from '../../../components/modal-user-credential/modal-user-credential.component';
 import { compare } from 'compare-versions';
@@ -59,6 +60,7 @@ export class SettingsSignalkComponent implements OnInit, AfterViewInit, OnDestro
   private readonly connectionStateMachine = inject(ConnectionStateMachine);
   private readonly internetReachability = inject(InternetReachabilityService);
   protected readonly auth = inject(AuthenticationService);
+  private readonly ssoRedirect = inject(SsoRedirectService);
   private readonly destroyRef = inject(DestroyRef);
   private readonly canvasService = inject(CanvasService);
 
@@ -67,6 +69,17 @@ export class SettingsSignalkComponent implements OnInit, AfterViewInit, OnDestro
 
   public connectionConfig: IConnectionConfig;
   public isConnecting = false; // Loading state for connect button
+
+  // Cookie mode (same-origin): the Connectivity tab shows session identity instead of the credential
+  // controls. These drive that identity block.
+  protected cookieMode = false;
+  protected readonly loginStatus = toSignal(this.auth.loginStatus$, { initialValue: null });
+  protected readonly isUserSession = toSignal(this.auth.isUserSession$, { initialValue: false });
+  protected readonly canWriteUserData = toSignal(this.auth.canWriteUserData$, { initialValue: false });
+
+  protected signIn(): void {
+    this.ssoRedirect.manualSignIn();
+  }
 
   public authToken: IAuthorizationToken;
 
@@ -96,6 +109,7 @@ export class SettingsSignalkComponent implements OnInit, AfterViewInit, OnDestro
   ngOnInit() {
     // get Signal K connection configuration
     this.connectionConfig = this.settings.getConnectionConfig();
+    this.cookieMode = this.auth.authMode === 'cookie';
 
     // get authentication token status
     this.auth.authToken$.pipe(
@@ -169,7 +183,11 @@ export class SettingsSignalkComponent implements OnInit, AfterViewInit, OnDestro
    * configuration saving, connection cleanup, and app reload.
    */
   public async connectToServer() {
-    if (this.connectionConfig.useSharedConfig && (!this.connectionConfig.loginName || !this.connectionConfig.loginPassword)) {
+    // Cookie mode (same-origin): the session cookie authenticates after reload — no KIP credential
+    // dialog, no in-app login.
+    const newConfigIsCookieMode = this.auth.authModeForConfig(this.connectionConfig) === 'cookie';
+
+    if (!newConfigIsCookieMode && this.connectionConfig.useSharedConfig && (!this.connectionConfig.loginName || !this.connectionConfig.loginPassword)) {
       this.openUserCredentialModal("Credentials required");
       return;
     }
@@ -188,9 +206,9 @@ export class SettingsSignalkComponent implements OnInit, AfterViewInit, OnDestro
       // Step 2: Save the new configuration to localStorage
       this.settings.setConnectionConfig(this.connectionConfig);
 
-      // Step 3: Establish the session in-memory so the session JWT (not the plaintext password,
-      // which is no longer persisted) survives the reload that bootstraps the new config.
-      if (this.connectionConfig.useSharedConfig) {
+      // Step 3: Token mode only — establish the session in-memory so the session JWT (the plaintext
+      // password is no longer persisted) survives the reload that bootstraps the new config.
+      if (!newConfigIsCookieMode && this.connectionConfig.useSharedConfig) {
         await this.auth.login({
           usr: this.connectionConfig.loginName,
           pwd: this.connectionConfig.loginPassword ?? '',
@@ -201,8 +219,9 @@ export class SettingsSignalkComponent implements OnInit, AfterViewInit, OnDestro
       // Step 4: Properly close WebSocket and HTTP connections
       this.connectionStateMachine.shutdown('Configuration changed - restarting app');
 
-      // Step 5: Clean up authentication token if switching from shared to individual config
-      if (this.authToken && !this.connectionConfig.useSharedConfig && !this.authToken.isDeviceAccessToken) {
+      // Step 5: Clear a stored user token when the new config resolves to cookie mode (the session
+      // cookie is authoritative) or when switching from shared to individual config.
+      if (this.authToken && !this.authToken.isDeviceAccessToken && (newConfigIsCookieMode || !this.connectionConfig.useSharedConfig)) {
         this.auth.deleteToken();
       }
 

--- a/src/app/core/components/options/signalk/signalk.component.ts
+++ b/src/app/core/components/options/signalk/signalk.component.ts
@@ -188,15 +188,25 @@ export class SettingsSignalkComponent implements OnInit, AfterViewInit, OnDestro
       // Step 2: Save the new configuration to localStorage
       this.settings.setConnectionConfig(this.connectionConfig);
 
-      // Step 3: Properly close WebSocket and HTTP connections
+      // Step 3: Establish the session in-memory so the session JWT (not the plaintext password,
+      // which is no longer persisted) survives the reload that bootstraps the new config.
+      if (this.connectionConfig.useSharedConfig) {
+        await this.auth.login({
+          usr: this.connectionConfig.loginName,
+          pwd: this.connectionConfig.loginPassword ?? '',
+          newUrl: this.connectionConfig.signalKUrl
+        });
+      }
+
+      // Step 4: Properly close WebSocket and HTTP connections
       this.connectionStateMachine.shutdown('Configuration changed - restarting app');
 
-      // Step 4: Clean up authentication token if switching from shared to individual config
+      // Step 5: Clean up authentication token if switching from shared to individual config
       if (this.authToken && !this.connectionConfig.useSharedConfig && !this.authToken.isDeviceAccessToken) {
         this.auth.deleteToken();
       }
 
-      // Step 5: Reload immediately - APP_INITIALIZER will handle connection and authentication with new URL
+      // Step 6: Reload immediately - APP_INITIALIZER will handle connection and authentication with new URL
       // Skip during unit tests to avoid breaking Karma connection
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       if (!(window as any).__KIP_TEST__) {

--- a/src/app/core/interceptors/authentication-interceptor.spec.ts
+++ b/src/app/core/interceptors/authentication-interceptor.spec.ts
@@ -53,6 +53,15 @@ describe('AuthenticationInterceptor', () => {
     req.flush({ ok: true });
   });
 
+  it('cookie mode: a cross-origin request gets neither credentials nor a token header', () => {
+    auth.authMode = 'cookie';
+    http.get('https://boat.example:3443/signalk/').subscribe();
+    const req = httpMock.expectOne('https://boat.example:3443/signalk/');
+    expect(req.request.withCredentials).toBe(false);
+    expect(req.request.headers.has('authorization')).toBe(false);
+    req.flush({ ok: true });
+  });
+
   it('token mode without a token: no header and no credentials', () => {
     auth.authMode = 'token';
     auth.setToken(null);

--- a/src/app/core/interceptors/authentication-interceptor.spec.ts
+++ b/src/app/core/interceptors/authentication-interceptor.spec.ts
@@ -4,22 +4,26 @@ import { beforeEach, describe, expect, it, afterEach } from 'vitest';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { BehaviorSubject } from 'rxjs';
 import { AuthenticationInterceptor } from './authentication-interceptor';
-import { AuthenticationService, IAuthorizationToken } from '../services/authentication.service';
+import { AuthenticationService, AuthMode, IAuthorizationToken } from '../services/authentication.service';
 
 class AuthServiceStub {
-  private _token$ = new BehaviorSubject<IAuthorizationToken>({ token: 'stub-token' } as IAuthorizationToken);
+  private _token$ = new BehaviorSubject<IAuthorizationToken | null>({ token: 'stub-token' } as IAuthorizationToken);
   public authToken$ = this._token$.asObservable();
+  public authMode: AuthMode = 'token';
+  setToken(token: IAuthorizationToken | null): void { this._token$.next(token); }
 }
 
 describe('AuthenticationInterceptor', () => {
   let http: HttpClient;
   let httpMock: HttpTestingController;
+  let auth: AuthServiceStub;
 
   beforeEach(() => {
+    auth = new AuthServiceStub();
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
       providers: [
-        { provide: AuthenticationService, useClass: AuthServiceStub },
+        { provide: AuthenticationService, useValue: auth },
         { provide: HTTP_INTERCEPTORS, useClass: AuthenticationInterceptor, multi: true }
       ]
     });
@@ -31,10 +35,31 @@ describe('AuthenticationInterceptor', () => {
     httpMock.verify();
   });
 
-  it('should attach JWT Authorization header when token is available', () => {
+  it('token mode: attaches the JWT Authorization header and does not send credentials', () => {
+    auth.authMode = 'token';
     http.get('/api/test').subscribe();
     const req = httpMock.expectOne('/api/test');
     expect(req.request.headers.get('authorization')).toBe('JWT stub-token');
+    expect(req.request.withCredentials).toBe(false);
+    req.flush({ ok: true });
+  });
+
+  it('cookie mode: sends credentials and no Authorization header, even with a stored token', () => {
+    auth.authMode = 'cookie';
+    http.get('/api/test').subscribe();
+    const req = httpMock.expectOne('/api/test');
+    expect(req.request.withCredentials).toBe(true);
+    expect(req.request.headers.has('authorization')).toBe(false);
+    req.flush({ ok: true });
+  });
+
+  it('token mode without a token: no header and no credentials', () => {
+    auth.authMode = 'token';
+    auth.setToken(null);
+    http.get('/api/test').subscribe();
+    const req = httpMock.expectOne('/api/test');
+    expect(req.request.headers.has('authorization')).toBe(false);
+    expect(req.request.withCredentials).toBe(false);
     req.flush({ ok: true });
   });
 });

--- a/src/app/core/interceptors/authentication-interceptor.ts
+++ b/src/app/core/interceptors/authentication-interceptor.ts
@@ -19,16 +19,19 @@ export class AuthenticationInterceptor implements HttpInterceptor, OnDestroy {
   }
 
   intercept(req: HttpRequest<unknown>, next: HttpHandler) {
-    let authReq = req.clone();
+    // Branch on mode first. In cookie mode the same-origin httpOnly session cookie carries auth, so
+    // send credentials and never attach a JWT header — even if a stale token is still in storage.
+    if (this.auth.authMode === 'cookie') {
+      return next.handle(req.clone({ withCredentials: true }));
+    }
 
+    // Token mode (cross-origin): the cookie cannot flow, so attach the JWT header when present.
+    let authReq = req.clone();
     if (this.authToken) {
-      // Clone the request and replace the original headers with
-      // with the authorization token.
       authReq = req.clone({
         headers: req.headers.set('authorization', "JWT " + this.authToken.token)
       });
     }
-    // send cloned request with header to the next handler.
     return next.handle(authReq);
   }
 

--- a/src/app/core/interceptors/authentication-interceptor.ts
+++ b/src/app/core/interceptors/authentication-interceptor.ts
@@ -21,8 +21,11 @@ export class AuthenticationInterceptor implements HttpInterceptor, OnDestroy {
   intercept(req: HttpRequest<unknown>, next: HttpHandler) {
     // Branch on mode first. In cookie mode the same-origin httpOnly session cookie carries auth, so
     // send credentials and never attach a JWT header — even if a stale token is still in storage.
+    // Scope withCredentials to same-origin requests: a cross-origin request in cookie mode (e.g. the
+    // discovery GET under proxy + cross-origin URL) gets neither — the cookie cannot flow cross-origin
+    // and a stale token stays suppressed.
     if (this.auth.authMode === 'cookie') {
-      return next.handle(req.clone({ withCredentials: true }));
+      return next.handle(this.isSameOrigin(req.url) ? req.clone({ withCredentials: true }) : req.clone());
     }
 
     // Token mode (cross-origin): the cookie cannot flow, so attach the JWT header when present.
@@ -33,6 +36,15 @@ export class AuthenticationInterceptor implements HttpInterceptor, OnDestroy {
       });
     }
     return next.handle(authReq);
+  }
+
+  private isSameOrigin(url: string): boolean {
+    try {
+      // Relative URLs resolve against the app origin.
+      return new URL(url, window.location.origin).origin === window.location.origin;
+    } catch {
+      return false;
+    }
   }
 
   ngOnDestroy(): void {

--- a/src/app/core/interfaces/app-settings.interfaces.ts
+++ b/src/app/core/interfaces/app-settings.interfaces.ts
@@ -10,7 +10,9 @@ export interface IConnectionConfig {
   signalKSubscribeAll: boolean;
   useDeviceToken: boolean;
   loginName: string;
-  loginPassword: string;
+  // Transient only: collected by the login dialog and passed to login() in memory.
+  // Never persisted to localStorage (the session JWT is the cross-reload credential).
+  loginPassword?: string;
   useSharedConfig: boolean;
   sharedConfigName: string;
 }

--- a/src/app/core/services/app-initNetwork.service.spec.ts
+++ b/src/app/core/services/app-initNetwork.service.spec.ts
@@ -3,9 +3,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { BehaviorSubject } from 'rxjs';
 import { Router } from '@angular/router';
 
-import { AppNetworkInitService } from './app-initNetwork.service';
+import { AppNetworkInitService, IBootstrapIssue } from './app-initNetwork.service';
 import { SignalKConnectionService } from './signalk-connection.service';
-import { AuthenticationService } from './authentication.service';
+import { AuthenticationService, ILoginStatus } from './authentication.service';
+import { SsoRedirectService } from './sso-redirect.service';
 import { ConnectionState, ConnectionStateMachine } from './connection-state-machine.service';
 import { SignalKDeltaService } from './signalk-delta.service';
 import { DataService } from './data.service';
@@ -13,6 +14,14 @@ import { StorageService } from './storage.service';
 import { InternetReachabilityService } from './internet-reachability.service';
 import { DatasetStreamService } from './dataset-stream.service';
 import { Injector } from '@angular/core';
+import { ensureLocalStorage } from '../../../test-helpers/local-storage.test-helper';
+
+// jsdom has no FontFace; preloadFonts() constructs one during the end-to-end initNetworkServices runs.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+if (typeof (globalThis as any).FontFace === 'undefined') {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).FontFace = class { load() { return Promise.resolve(this); } };
+}
 
 describe('AppNetworkInitService', () => {
     let service: AppNetworkInitService;
@@ -26,7 +35,17 @@ describe('AppNetworkInitService', () => {
 
     const mockAuth = {
         isLoggedIn$,
+        authMode: 'token' as 'cookie' | 'token',
+        loginStatusValue: null as ILoginStatus | null,
+        refreshLoginStatus: vi.fn().mockResolvedValue(null),
         login: vi.fn().mockResolvedValue(undefined)
+    };
+
+    const mockSsoRedirect = {
+        attemptAutoRedirect: vi.fn().mockReturnValue('redirected'),
+        resetBudget: vi.fn(),
+        isBudgetExhausted: vi.fn().mockReturnValue(false),
+        manualSignIn: vi.fn()
     };
 
     const mockConnectionStateMachine = {
@@ -66,6 +85,7 @@ describe('AppNetworkInitService', () => {
     };
 
     beforeEach(() => {
+        ensureLocalStorage();
         isLoggedIn$.next(false);
         state$.next(ConnectionState.Disconnected);
         mockConnectionStateMachine.currentState = ConnectionState.Disconnected;
@@ -73,12 +93,20 @@ describe('AppNetworkInitService', () => {
         mockConnectionStateMachine.isHTTPConnected.mockClear();
         mockConnectionStateMachine.enableWebSocketMode.mockClear();
         mockConnectionStateMachine.startWebSocketConnection.mockClear();
+        mockAuth.authMode = 'token';
+        mockAuth.loginStatusValue = null;
+        mockAuth.refreshLoginStatus.mockClear();
+        mockRouter.navigate.mockClear();
+        mockSsoRedirect.attemptAutoRedirect.mockClear().mockReturnValue('redirected');
+        mockSsoRedirect.resetBudget.mockClear();
+        mockSsoRedirect.isBudgetExhausted.mockClear().mockReturnValue(false);
 
         TestBed.configureTestingModule({
             providers: [
                 AppNetworkInitService,
                 { provide: SignalKConnectionService, useValue: mockConnection },
                 { provide: AuthenticationService, useValue: mockAuth },
+                { provide: SsoRedirectService, useValue: mockSsoRedirect },
                 { provide: ConnectionStateMachine, useValue: mockConnectionStateMachine },
                 { provide: Router, useValue: mockRouter },
                 { provide: SignalKDeltaService, useValue: {} },
@@ -89,6 +117,109 @@ describe('AppNetworkInitService', () => {
             ]
         });
         service = TestBed.inject(AppNetworkInitService);
+    });
+
+    function handleCookieAuth(status: ILoginStatus | null): 'redirecting' | 'proceed' | 'auth-blocked' {
+        return (service as unknown as { handleCookieAuth: (s: ILoginStatus | null) => 'redirecting' | 'proceed' | 'auth-blocked' }).handleCookieAuth(status);
+    }
+
+    function routeToReauth(): void {
+        (service as unknown as { routeToReauth: () => void }).routeToReauth();
+    }
+
+    function latestIssue(): IBootstrapIssue {
+        let issue: IBootstrapIssue = { reason: 'none' };
+        service.bootstrapIssue$.subscribe(i => (issue = i)).unsubscribe();
+        return issue;
+    }
+
+    describe('cookie-mode bootstrap auth (Unit 6)', () => {
+        it('logged-in: proceeds without resetting the budget here (reset deferred to a clean bootstrap)', () => {
+            expect(handleCookieAuth({ status: 'loggedIn' })).toBe('proceed');
+            expect(mockSsoRedirect.resetBudget).not.toHaveBeenCalled();
+            expect(mockSsoRedirect.attemptAutoRedirect).not.toHaveBeenCalled();
+        });
+
+        it('null/unreachable loginStatus: fails closed to auth-blocked, not anonymous-open', () => {
+            expect(handleCookieAuth(null)).toBe('auth-blocked');
+            expect(mockSsoRedirect.attemptAutoRedirect).not.toHaveBeenCalled();
+            expect(latestIssue()).toEqual({ reason: 'auth-blocked', cause: 'sign-in-required' });
+        });
+    });
+
+    describe('mid-bootstrap 401 re-auth routing (Unit 6)', () => {
+        it('token mode routes to /login', () => {
+            mockAuth.authMode = 'token';
+            routeToReauth();
+            expect(mockRouter.navigate).toHaveBeenCalledWith(['/login']);
+            expect(mockSsoRedirect.attemptAutoRedirect).not.toHaveBeenCalled();
+        });
+
+        it('cookie mode with oidcAutoLogin auto-redirects (budget-guarded)', () => {
+            mockAuth.authMode = 'cookie';
+            mockAuth.loginStatusValue = { status: 'loggedIn', oidcAutoLogin: true };
+            mockSsoRedirect.attemptAutoRedirect.mockReturnValue('redirected');
+
+            routeToReauth();
+
+            expect(mockSsoRedirect.attemptAutoRedirect).toHaveBeenCalledWith(mockAuth.loginStatusValue);
+            expect(mockRouter.navigate).not.toHaveBeenCalled();
+        });
+
+        it('cookie mode honors oidcAutoLogin:false (no auto-redirect on a 401)', () => {
+            mockAuth.authMode = 'cookie';
+            mockAuth.loginStatusValue = { status: 'loggedIn', oidcAutoLogin: false };
+
+            routeToReauth();
+
+            expect(mockSsoRedirect.attemptAutoRedirect).not.toHaveBeenCalled();
+            expect(latestIssue()).toEqual({ reason: 'auth-blocked', cause: 'sign-in-required' });
+        });
+
+        it('cookie mode surfaces auth-blocked when the budget is exhausted (no infinite 401 loop)', () => {
+            mockAuth.authMode = 'cookie';
+            mockAuth.loginStatusValue = { status: 'loggedIn', oidcAutoLogin: true };
+            mockSsoRedirect.attemptAutoRedirect.mockReturnValue('budget-exhausted');
+            mockSsoRedirect.isBudgetExhausted.mockReturnValue(true);
+
+            routeToReauth();
+
+            expect(latestIssue()).toEqual({ reason: 'auth-blocked', cause: 'budget-exhausted' });
+        });
+
+        it('not-logged-in + authRequired + oidcAutoLogin: auto-redirects to SSO', () => {
+            mockSsoRedirect.attemptAutoRedirect.mockReturnValue('redirected');
+            const status: ILoginStatus = { status: 'notLoggedIn', authenticationRequired: true, oidcAutoLogin: true, oidcEnabled: true };
+
+            expect(handleCookieAuth(status)).toBe('redirecting');
+
+            expect(mockSsoRedirect.attemptAutoRedirect).toHaveBeenCalledWith(status);
+        });
+
+        it('budget exhausted: proceeds with an auth-blocked/budget-exhausted issue, no loop', () => {
+            mockSsoRedirect.attemptAutoRedirect.mockReturnValue('budget-exhausted');
+            mockSsoRedirect.isBudgetExhausted.mockReturnValue(true);
+
+            expect(handleCookieAuth({ status: 'notLoggedIn', authenticationRequired: true, oidcAutoLogin: true })).toBe('auth-blocked');
+
+            expect(latestIssue()).toEqual({ reason: 'auth-blocked', cause: 'budget-exhausted' });
+        });
+
+        it('oidcAutoLogin disabled: does not auto-redirect, surfaces sign-in-required', () => {
+            const status: ILoginStatus = { status: 'notLoggedIn', authenticationRequired: true, oidcAutoLogin: false, oidcEnabled: true };
+
+            expect(handleCookieAuth(status)).toBe('auth-blocked');
+
+            expect(mockSsoRedirect.attemptAutoRedirect).not.toHaveBeenCalled();
+            expect(latestIssue()).toEqual({ reason: 'auth-blocked', cause: 'sign-in-required' });
+        });
+
+        it('authentication not required: anonymous read, no redirect, no auth-blocked issue', () => {
+            expect(handleCookieAuth({ status: 'notLoggedIn', authenticationRequired: false })).toBe('proceed');
+
+            expect(mockSsoRedirect.attemptAutoRedirect).not.toHaveBeenCalled();
+            expect(latestIssue().reason).not.toBe('auth-blocked');
+        });
     });
 
     it('should be created', () => {
@@ -115,5 +246,59 @@ describe('AppNetworkInitService', () => {
 
         expect(mockConnectionStateMachine.getHttpRetryWindowMs).not.toHaveBeenCalled();
         expect(result).toBe(ConnectionState.PermanentFailure);
+    });
+
+    // End-to-end initNetworkServices() runs — these pin the seam between handleCookieAuth and the
+    // finally that an isolated handleCookieAuth test cannot see (the original P0 loop-guard hole).
+    describe('cookie-mode bootstrap end-to-end (Unit 6 loop-guard seam)', () => {
+        it('budget-exhausted: keeps the auth-blocked recovery state and does NOT reset the budget', async () => {
+            mockAuth.authMode = 'cookie';
+            mockAuth.refreshLoginStatus.mockResolvedValue({ status: 'notLoggedIn', authenticationRequired: true, oidcAutoLogin: true });
+            mockSsoRedirect.attemptAutoRedirect.mockReturnValue('budget-exhausted');
+            mockSsoRedirect.isBudgetExhausted.mockReturnValue(true);
+
+            await service.initNetworkServices();
+
+            expect(latestIssue()).toEqual({ reason: 'auth-blocked', cause: 'budget-exhausted' });
+            expect(mockSsoRedirect.resetBudget).not.toHaveBeenCalled();
+        });
+
+        it('null loginStatus: keeps the auth-blocked recovery state and does NOT reset the budget', async () => {
+            mockAuth.authMode = 'cookie';
+            mockAuth.refreshLoginStatus.mockResolvedValue(null);
+
+            await service.initNetworkServices();
+
+            expect(latestIssue()).toEqual({ reason: 'auth-blocked', cause: 'sign-in-required' });
+            expect(mockSsoRedirect.resetBudget).not.toHaveBeenCalled();
+        });
+
+        it('logged-in clean bootstrap resets the budget', async () => {
+            mockAuth.authMode = 'cookie';
+            mockAuth.refreshLoginStatus.mockImplementation(async () => { isLoggedIn$.next(true); return { status: 'loggedIn' }; });
+
+            await service.initNetworkServices();
+
+            expect(mockSsoRedirect.resetBudget).toHaveBeenCalled();
+        });
+
+        it('does not double-start the WebSocket when a connect is already in flight at the finally', async () => {
+            mockAuth.authMode = 'cookie';
+            mockAuth.refreshLoginStatus.mockImplementation(async () => { isLoggedIn$.next(true); return { status: 'loggedIn' }; });
+            mockConnectionStateMachine.currentState = ConnectionState.WebSocketConnecting;
+
+            await service.initNetworkServices();
+
+            expect(mockConnectionStateMachine.startWebSocketConnection).not.toHaveBeenCalled();
+        });
+
+        it('starts the WebSocket once from a fresh HTTPConnected state', async () => {
+            mockAuth.authMode = 'token';
+            mockConnectionStateMachine.currentState = ConnectionState.HTTPConnected;
+
+            await service.initNetworkServices();
+
+            expect(mockConnectionStateMachine.startWebSocketConnection).toHaveBeenCalledTimes(1);
+        });
     });
 });

--- a/src/app/core/services/app-initNetwork.service.ts
+++ b/src/app/core/services/app-initNetwork.service.ts
@@ -10,7 +10,8 @@ import { inject, Injectable, Injector, OnDestroy } from '@angular/core';
 import { Router } from '@angular/router';
 import { IConfig, IConnectionConfig } from "../interfaces/app-settings.interfaces";
 import { SignalKConnectionService } from "./signalk-connection.service";
-import { AuthenticationService } from './authentication.service';
+import { AuthenticationService, ILoginStatus } from './authentication.service';
+import { SsoRedirectService } from './sso-redirect.service';
 import { DefaultConnectionConfig } from '../../../default-config/config.blank.const';
 import { BehaviorSubject, Observable, Subscription } from 'rxjs';
 import { DataService } from './data.service';
@@ -23,13 +24,15 @@ import { DatasetStreamService } from './dataset-stream.service';
 const configFileVersion = 11; // used to change the Signal K configuration storage file name (ie. 9.0.0.json) that contains the configuration definitions. Applies only to remote storage.
 const CONNECTION_CONFIG_KEY = 'connectionConfig';
 export type TBootstrapStatus = 'starting' | 'ready' | 'degraded';
-export type TBootstrapIssueReason = 'none' | 'missing-shared-config' | 'network-unreachable' | 'unauthorized' | 'unknown';
+export type TBootstrapIssueReason = 'none' | 'missing-shared-config' | 'network-unreachable' | 'unauthorized' | 'unknown' | 'auth-blocked';
+export type TAuthBlockedCause = 'budget-exhausted' | 'sign-in-required';
 
 export interface IBootstrapIssue {
   reason: TBootstrapIssueReason;
   statusCode?: number;
   sharedConfigName?: string;
   legacyUpgradeAvailable?: boolean;
+  cause?: TAuthBlockedCause;
 }
 
 @Injectable()
@@ -40,6 +43,7 @@ export class AppNetworkInitService implements OnDestroy {
 
   private readonly connection = inject(SignalKConnectionService);
   private readonly auth = inject(AuthenticationService);
+  private readonly ssoRedirect = inject(SsoRedirectService);
   private readonly connectionStateMachine = inject(ConnectionStateMachine);
   private readonly router = inject(Router);
   private readonly delta = inject(SignalKDeltaService); // Init to get data before app starts
@@ -66,8 +70,64 @@ export class AppNetworkInitService implements OnDestroy {
     return this.auth.authMode === 'cookie' || !!this.config?.useSharedConfig;
   }
 
+  /**
+   * Cookie-mode bootstrap decision from loginStatus. Returns 'redirecting' when the browser is being
+   * sent to the SK/SSO login (caller should stop), or 'proceed' otherwise:
+   * - loggedIn   → reset the redirect budget; the storage bootstrap then runs (isLoggedIn is true).
+   * - notLoggedIn + authRequired → auto-redirect when allowed by oidcAutoLogin and the budget; else
+   *   surface the auth-blocked recovery state (budget exhausted, or a manual sign-in is required).
+   * - auth not required → anonymous read; proceed with no redirect.
+   */
+  private handleCookieAuth(status: ILoginStatus | null): 'redirecting' | 'proceed' | 'auth-blocked' {
+    if (status?.status === 'loggedIn') {
+      // The budget reset is deferred to a genuinely completed bootstrap (see initNetworkServices'
+      // finally), so a loggedIn -> applicationData-401 -> reauth path cannot reset-then-loop.
+      return 'proceed';
+    }
+    if (!status) {
+      // loginStatus unreachable/unparseable: fail closed — do not assume anonymous-open access.
+      this._bootstrapIssue$.next({ reason: 'auth-blocked', cause: 'sign-in-required' });
+      return 'auth-blocked';
+    }
+    if (status.authenticationRequired) {
+      return this.attemptCookieRedirect(status) === 'redirecting' ? 'redirecting' : 'auth-blocked';
+    }
+    // authentication explicitly not required: anonymous read access, no redirect.
+    return 'proceed';
+  }
+
+  /**
+   * Cookie-mode redirect-or-block decision shared by the bootstrap path and the mid-bootstrap 401
+   * path. Auto-redirects when oidcAutoLogin allows and the budget permits; otherwise surfaces the
+   * auth-blocked recovery state (budget exhausted, or a manual sign-in is required).
+   */
+  private attemptCookieRedirect(status: ILoginStatus | null): 'redirecting' | 'blocked' {
+    if (status?.oidcAutoLogin !== false && this.ssoRedirect.attemptAutoRedirect(status) === 'redirected') {
+      return 'redirecting';
+    }
+    this._bootstrapIssue$.next({
+      reason: 'auth-blocked',
+      cause: this.ssoRedirect.isBudgetExhausted() ? 'budget-exhausted' : 'sign-in-required'
+    });
+    return 'blocked';
+  }
+
+  /**
+   * Mode-aware re-authentication routing for a mid-bootstrap 401. Cookie mode reuses the same
+   * oidcAutoLogin/budget-guarded decision as the bootstrap path (so a 401 cannot loop past the
+   * budget, and honors oidcAutoLogin:false); token mode routes to /login.
+   */
+  private routeToReauth(): void {
+    if (this.auth.authMode === 'cookie') {
+      this.attemptCookieRedirect(this.auth.loginStatusValue);
+      return;
+    }
+    this.router.navigate(['/login']);
+  }
+
   public async initNetworkServices() {
     let startupDegraded = false;
+    let redirecting = false;
     this.loadLocalStorageConfig();
     this.preloadFonts();
     this.internetReachability.start();
@@ -82,7 +142,26 @@ export class AppNetworkInitService implements OnDestroy {
         );
       }
 
-      if (!this.isLoggedIn && this.config?.signalKUrl && this.config?.useSharedConfig && this.config?.loginName && this.config?.loginPassword) {
+      // Cookie mode (same-origin): session state comes from loginStatus, not a credential login.
+      if (this.auth.authMode === 'cookie') {
+        const status = await this.auth.refreshLoginStatus();
+        const outcome = this.handleCookieAuth(status);
+        if (outcome === 'redirecting') {
+          redirecting = true;
+          return; // browser is navigating to the SK/SSO login
+        }
+        if (outcome === 'auth-blocked') {
+          // Not authorized and not auto-redirecting: keep the auth-blocked recovery state (set by
+          // handleCookieAuth), do not reset the loop budget, and finish degraded (not 'ready') so the
+          // recovery UI shows. Returning here also avoids the 'reason: none' overwrite below.
+          startupDegraded = true;
+          this._bootstrapStatus$.next('degraded');
+          return;
+        }
+      }
+
+      // Token mode (cross-origin) credential login. Never runs in cookie mode (no stored password).
+      if (this.auth.authMode !== 'cookie' && !this.isLoggedIn && this.config?.signalKUrl && this.config?.useSharedConfig && this.config?.loginName && this.config?.loginPassword) {
         await this.login();
       }
 
@@ -108,7 +187,8 @@ export class AppNetworkInitService implements OnDestroy {
       // This ensures all chart data is ready before any widget components are created.
       await this.getDatasetService().waitUntilReady();
 
-      if (!this.isLoggedIn && this.config?.signalKUrl && this.config?.useSharedConfig) {
+      // Cookie mode handled its own redirect/auth-blocked state above; only token mode falls to /login.
+      if (this.auth.authMode !== 'cookie' && !this.isLoggedIn && this.config?.signalKUrl && this.config?.useSharedConfig) {
         this.router.navigate(['/login']); // need to set credentials
       }
 
@@ -139,8 +219,8 @@ export class AppNetworkInitService implements OnDestroy {
           await this.router.navigate(['/options']);
         }
       } else if (error.status === 401) {
-        console.warn("[AppInit Network Service] Initialization failed. Unauthorized access. Redirecting to login page.");
-        await this.router.navigate(['/login']);
+        console.warn("[AppInit Network Service] Initialization failed. Unauthorized access. Routing to re-authentication.");
+        this.routeToReauth();
       } else {
         console.warn("[AppInit Network Service] Initialization failed. Error: ", JSON.stringify(error));
         await this.router.navigate(['/options']);
@@ -149,6 +229,12 @@ export class AppNetworkInitService implements OnDestroy {
       this._bootstrapStatus$.next('degraded');
       return;
     } finally {
+      if (!startupDegraded && !redirecting) {
+        // A clean, non-redirecting bootstrap is a stable state: clear the SSO redirect loop budget so
+        // a future genuine logout gets a fresh set of attempts. Not reset on the redirect/degraded
+        // paths, so a loggedIn -> 401 -> reauth loop stays bounded.
+        this.ssoRedirect.resetBudget();
+      }
       if (!startupDegraded) {
         this._bootstrapStatus$.next('ready');
       }
@@ -156,8 +242,10 @@ export class AppNetworkInitService implements OnDestroy {
       // Enable WebSocket functionality now that initialization is complete
       this.connectionStateMachine.enableWebSocketMode();
 
-      // Start WebSocket connection if HTTP discovery was successful
-      if (this.connectionStateMachine.isHTTPConnected()) {
+      // Start the WebSocket only from a fresh HTTPConnected state. In cookie mode the loginStatus
+      // result may already have driven the delta service's isLoggedIn$ reconnect (state ->
+      // WebSocketConnecting); starting again here would close and reopen the in-flight socket.
+      if (this.connectionStateMachine.currentState === ConnectionState.HTTPConnected) {
         console.log("[AppInit Network Service] Starting WebSocket connection after initialization");
         this.connectionStateMachine.startWebSocketConnection();
       }

--- a/src/app/core/services/app-initNetwork.service.ts
+++ b/src/app/core/services/app-initNetwork.service.ts
@@ -242,10 +242,12 @@ export class AppNetworkInitService implements OnDestroy {
       // Enable WebSocket functionality now that initialization is complete
       this.connectionStateMachine.enableWebSocketMode();
 
-      // Start the WebSocket only from a fresh HTTPConnected state. In cookie mode the loginStatus
-      // result may already have driven the delta service's isLoggedIn$ reconnect (state ->
-      // WebSocketConnecting); starting again here would close and reopen the in-flight socket.
-      if (this.connectionStateMachine.currentState === ConnectionState.HTTPConnected) {
+      // Start the WebSocket only on a clean bootstrap from a fresh HTTPConnected state. Skip it when
+      // degraded/redirecting (e.g. the cookie auth-blocked path, where HTTP is connected but there is
+      // no session — an anonymous WS would just churn behind the recovery toast), and when the delta
+      // service's isLoggedIn$ reconnect has already driven the state to WebSocketConnecting (starting
+      // again would close and reopen the in-flight socket).
+      if (this.connectionStateMachine.currentState === ConnectionState.HTTPConnected && !startupDegraded && !redirecting) {
         console.log("[AppInit Network Service] Starting WebSocket connection after initialization");
         this.connectionStateMachine.startWebSocketConnection();
       }

--- a/src/app/core/services/app-initNetwork.service.ts
+++ b/src/app/core/services/app-initNetwork.service.ts
@@ -57,6 +57,15 @@ export class AppNetworkInitService implements OnDestroy {
     })
   }
 
+  /**
+   * Whether remote (server applicationData) config should be bootstrapped: cookie mode regardless of
+   * the stored useSharedConfig flag, or cross-origin shared config. Mirrors SettingsService storage
+   * routing so the two never disagree (avoids the cookie-mode localStorage split-brain).
+   */
+  private useServerStorage(): boolean {
+    return this.auth.authMode === 'cookie' || !!this.config?.useSharedConfig;
+  }
+
   public async initNetworkServices() {
     let startupDegraded = false;
     this.loadLocalStorageConfig();
@@ -77,7 +86,7 @@ export class AppNetworkInitService implements OnDestroy {
         await this.login();
       }
 
-      if (this.isLoggedIn && this.config?.useSharedConfig) {
+      if (this.isLoggedIn && this.useServerStorage()) {
         // Wait for storage to be fully ready before accessing it
         const storageReady = await this.storage.waitUntilReady();
         if (!storageReady) {

--- a/src/app/core/services/authentication.service.spec.ts
+++ b/src/app/core/services/authentication.service.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import { HttpTestingController } from '@angular/common/http/testing';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { firstValueFrom } from 'rxjs';
 import { AuthenticationService, IAuthorizationToken } from './authentication.service';
@@ -164,6 +165,205 @@ describe('AuthenticationService', () => {
       const service = createService();
       expect(await firstValueFrom(service.authToken$)).not.toBeNull();
       expect(await firstValueFrom(service.isLoggedIn$)).toBe(true);
+    });
+  });
+
+  describe('loginStatus session state (Unit 3)', () => {
+    function seedConn(overrides: Record<string, unknown>): void {
+      localStorage.setItem(
+        'connectionConfig',
+        JSON.stringify({
+          configVersion: 12,
+          kipUUID: 'u',
+          signalKUrl: '',
+          proxyEnabled: true,
+          signalKSubscribeAll: false,
+          useDeviceToken: false,
+          loginName: '',
+          useSharedConfig: true,
+          sharedConfigName: 'default',
+          ...overrides
+        })
+      );
+    }
+
+    function expectLoginStatusRequest(httpTesting: HttpTestingController) {
+      return httpTesting.expectOne(
+        req => req.url.endsWith('/skServer/loginStatus') && !req.url.includes('/signalk/v1')
+      );
+    }
+
+    it('logged-in writable session: isLoggedIn/isUserSession/canWriteUserData true, no token', async () => {
+      seedConn({ proxyEnabled: true });
+      const service = createService();
+      const httpTesting = TestBed.inject(HttpTestingController);
+
+      const pending = service.refreshLoginStatus();
+      const req = expectLoginStatusRequest(httpTesting);
+      expect(req.request.method).toBe('GET');
+      expect(req.request.withCredentials).toBe(true);
+      req.flush({ status: 'loggedIn', readOnlyAccess: false, userLevel: 'admin' });
+      await pending;
+
+      expect(await firstValueFrom(service.isLoggedIn$)).toBe(true);
+      expect(await firstValueFrom(service.isUserSession$)).toBe(true);
+      expect(await firstValueFrom(service.canWriteUserData$)).toBe(true);
+      expect(await firstValueFrom(service.authToken$)).toBeNull();
+      httpTesting.verify();
+    });
+
+    it('logged-in read-only session: isUserSession true, canWriteUserData false', async () => {
+      seedConn({ proxyEnabled: true });
+      const service = createService();
+      const httpTesting = TestBed.inject(HttpTestingController);
+
+      const pending = service.refreshLoginStatus();
+      expectLoginStatusRequest(httpTesting).flush({ status: 'loggedIn', readOnlyAccess: true });
+      await pending;
+
+      expect(await firstValueFrom(service.isLoggedIn$)).toBe(true);
+      expect(await firstValueFrom(service.isUserSession$)).toBe(true);
+      expect(await firstValueFrom(service.canWriteUserData$)).toBe(false);
+      httpTesting.verify();
+    });
+
+    it('not-logged-in: all session flags false; OIDC descriptors captured', async () => {
+      seedConn({ proxyEnabled: true });
+      const service = createService();
+      const httpTesting = TestBed.inject(HttpTestingController);
+
+      const pending = service.refreshLoginStatus();
+      expectLoginStatusRequest(httpTesting).flush({
+        status: 'notLoggedIn',
+        authenticationRequired: true,
+        oidcEnabled: true,
+        oidcAutoLogin: true,
+        oidcLoginUrl: '/signalk/v1/auth/oidc/login',
+        oidcProviderName: 'HaLOS SSO'
+      });
+      await pending;
+
+      expect(await firstValueFrom(service.isLoggedIn$)).toBe(false);
+      expect(await firstValueFrom(service.isUserSession$)).toBe(false);
+      expect(await firstValueFrom(service.canWriteUserData$)).toBe(false);
+      const status = await firstValueFrom(service.loginStatus$);
+      expect(status?.authenticationRequired).toBe(true);
+      expect(status?.oidcEnabled).toBe(true);
+      expect(status?.oidcAutoLogin).toBe(true);
+      expect(status?.oidcLoginUrl).toBe('/signalk/v1/auth/oidc/login');
+      httpTesting.verify();
+    });
+
+    it('unreachable server: fails closed (not logged in), returns null, no throw', async () => {
+      seedConn({ proxyEnabled: true });
+      const service = createService();
+      const httpTesting = TestBed.inject(HttpTestingController);
+
+      const pending = service.refreshLoginStatus();
+      expectLoginStatusRequest(httpTesting).flush('down', { status: 503, statusText: 'Service Unavailable' });
+      const result = await pending;
+
+      expect(result).toBeNull();
+      expect(await firstValueFrom(service.isLoggedIn$)).toBe(false);
+      expect(await firstValueFrom(service.isUserSession$)).toBe(false);
+      expect(await firstValueFrom(service.canWriteUserData$)).toBe(false);
+      httpTesting.verify();
+    });
+
+    it('unexpected response shape: not logged in, no throw', async () => {
+      seedConn({ proxyEnabled: true });
+      const service = createService();
+      const httpTesting = TestBed.inject(HttpTestingController);
+
+      const pending = service.refreshLoginStatus();
+      expectLoginStatusRequest(httpTesting).flush({ unexpected: 'shape' });
+      await pending;
+
+      expect(await firstValueFrom(service.isLoggedIn$)).toBe(false);
+      expect(await firstValueFrom(service.isUserSession$)).toBe(false);
+      httpTesting.verify();
+    });
+
+    it('non-object 200 body (e.g. an HTML login page): not logged in, no throw', async () => {
+      seedConn({ proxyEnabled: true });
+      const service = createService();
+      const httpTesting = TestBed.inject(HttpTestingController);
+
+      const pending = service.refreshLoginStatus();
+      expectLoginStatusRequest(httpTesting).flush('<!doctype html><html>login</html>');
+      const result = await pending;
+
+      expect(result).toBeNull();
+      expect(await firstValueFrom(service.isLoggedIn$)).toBe(false);
+      expect(await firstValueFrom(service.isUserSession$)).toBe(false);
+      expect(await firstValueFrom(service.canWriteUserData$)).toBe(false);
+      httpTesting.verify();
+    });
+
+    it('mid-session transition: logged-in -> not-logged-in -> failure flips all signals false and clears descriptors', async () => {
+      seedConn({ proxyEnabled: true });
+      const service = createService();
+      const httpTesting = TestBed.inject(HttpTestingController);
+
+      // 1. Logged in, OIDC descriptors present.
+      const first = service.refreshLoginStatus();
+      expectLoginStatusRequest(httpTesting).flush({
+        status: 'loggedIn',
+        readOnlyAccess: false,
+        oidcEnabled: true,
+        oidcLoginUrl: '/signalk/v1/auth/oidc/login'
+      });
+      await first;
+      expect(await firstValueFrom(service.isLoggedIn$)).toBe(true);
+      expect(await firstValueFrom(service.isUserSession$)).toBe(true);
+      expect(await firstValueFrom(service.canWriteUserData$)).toBe(true);
+      expect((await firstValueFrom(service.loginStatus$))?.oidcLoginUrl).toBe('/signalk/v1/auth/oidc/login');
+
+      // 2. Session ends server-side: re-check returns notLoggedIn; stale OIDC descriptor cleared.
+      const second = service.refreshLoginStatus();
+      expectLoginStatusRequest(httpTesting).flush({ status: 'notLoggedIn' });
+      await second;
+      expect(await firstValueFrom(service.isLoggedIn$)).toBe(false);
+      expect(await firstValueFrom(service.isUserSession$)).toBe(false);
+      expect(await firstValueFrom(service.canWriteUserData$)).toBe(false);
+      expect((await firstValueFrom(service.loginStatus$))?.oidcLoginUrl).toBeUndefined();
+
+      // 3. A later failure re-emits null status (fail-closed) on the already-used instance.
+      const third = service.refreshLoginStatus();
+      expectLoginStatusRequest(httpTesting).flush('down', { status: 503, statusText: 'Service Unavailable' });
+      await third;
+      expect(await firstValueFrom(service.isLoggedIn$)).toBe(false);
+      expect(await firstValueFrom(service.loginStatus$)).toBeNull();
+      httpTesting.verify();
+    });
+
+    it('token mode does not query loginStatus', async () => {
+      seedConn({ proxyEnabled: false, signalKUrl: 'https://boat.example:3443' });
+      const service = createService();
+      const httpTesting = TestBed.inject(HttpTestingController);
+
+      const result = await service.refreshLoginStatus();
+
+      expect(result).toBeNull();
+      httpTesting.verify(); // asserts no loginStatus request was issued
+    });
+
+    it('token-mode user token yields a user session via the derived signals', async () => {
+      seedConn({ proxyEnabled: false, signalKUrl: 'https://boat.example:3443' });
+      seedToken({ expiry: nowSec() + 3600, isDeviceAccessToken: false });
+      const service = createService();
+
+      expect(await firstValueFrom(service.isUserSession$)).toBe(true);
+      expect(await firstValueFrom(service.canWriteUserData$)).toBe(true);
+    });
+
+    it('token-mode device token is not a user session', async () => {
+      seedConn({ proxyEnabled: false, signalKUrl: 'https://boat.example:3443' });
+      seedToken({ expiry: nowSec() + 3600, isDeviceAccessToken: true });
+      const service = createService();
+
+      expect(await firstValueFrom(service.isUserSession$)).toBe(false);
+      expect(await firstValueFrom(service.canWriteUserData$)).toBe(false);
     });
   });
 });

--- a/src/app/core/services/authentication.service.spec.ts
+++ b/src/app/core/services/authentication.service.spec.ts
@@ -212,18 +212,33 @@ describe('AuthenticationService', () => {
       httpTesting.verify();
     });
 
-    it('logged-in read-only session: isUserSession true, canWriteUserData false', async () => {
+    it('logged-in read-only user (userLevel readonly): isUserSession true, canWriteUserData false', async () => {
       seedConn({ proxyEnabled: true });
       const service = createService();
       const httpTesting = TestBed.inject(HttpTestingController);
 
       const pending = service.refreshLoginStatus();
-      expectLoginStatusRequest(httpTesting).flush({ status: 'loggedIn', readOnlyAccess: true });
+      expectLoginStatusRequest(httpTesting).flush({ status: 'loggedIn', userLevel: 'readonly' });
       await pending;
 
       expect(await firstValueFrom(service.isLoggedIn$)).toBe(true);
       expect(await firstValueFrom(service.isUserSession$)).toBe(true);
       expect(await firstValueFrom(service.canWriteUserData$)).toBe(false);
+      httpTesting.verify();
+    });
+
+    it('admin user stays write-capable even when the server allows anonymous read (readOnlyAccess true)', async () => {
+      // readOnlyAccess is the server allow_readonly flag, NOT the user's permission. A signed-in
+      // admin (userLevel admin) must remain write-capable regardless of it.
+      seedConn({ proxyEnabled: true });
+      const service = createService();
+      const httpTesting = TestBed.inject(HttpTestingController);
+
+      const pending = service.refreshLoginStatus();
+      expectLoginStatusRequest(httpTesting).flush({ status: 'loggedIn', userLevel: 'admin', readOnlyAccess: true });
+      await pending;
+
+      expect(await firstValueFrom(service.canWriteUserData$)).toBe(true);
       httpTesting.verify();
     });
 
@@ -309,7 +324,7 @@ describe('AuthenticationService', () => {
       const first = service.refreshLoginStatus();
       expectLoginStatusRequest(httpTesting).flush({
         status: 'loggedIn',
-        readOnlyAccess: false,
+        userLevel: 'admin',
         oidcEnabled: true,
         oidcLoginUrl: '/signalk/v1/auth/oidc/login'
       });

--- a/src/app/core/services/authentication.service.spec.ts
+++ b/src/app/core/services/authentication.service.spec.ts
@@ -242,6 +242,53 @@ describe('AuthenticationService', () => {
       httpTesting.verify();
     });
 
+    it('logged-in readwrite user: canWriteUserData true', async () => {
+      seedConn({ proxyEnabled: true });
+      const service = createService();
+      const httpTesting = TestBed.inject(HttpTestingController);
+
+      const pending = service.refreshLoginStatus();
+      expectLoginStatusRequest(httpTesting).flush({ status: 'loggedIn', userLevel: 'readwrite' });
+      await pending;
+
+      expect(await firstValueFrom(service.canWriteUserData$)).toBe(true);
+      httpTesting.verify();
+    });
+
+    it('logged-in with no userLevel: isUserSession true but canWriteUserData false (fail closed)', async () => {
+      seedConn({ proxyEnabled: true });
+      const service = createService();
+      const httpTesting = TestBed.inject(HttpTestingController);
+
+      const pending = service.refreshLoginStatus();
+      expectLoginStatusRequest(httpTesting).flush({ status: 'loggedIn' });
+      await pending;
+
+      expect(await firstValueFrom(service.isUserSession$)).toBe(true);
+      expect(await firstValueFrom(service.canWriteUserData$)).toBe(false);
+      httpTesting.verify();
+    });
+
+    it('fails closed when loginStatus does not respond within the timeout', async () => {
+      vi.useFakeTimers();
+      try {
+        seedConn({ proxyEnabled: true });
+        const service = createService();
+        const httpTesting = TestBed.inject(HttpTestingController);
+
+        const pending = service.refreshLoginStatus();
+        expectLoginStatusRequest(httpTesting); // request opened, never flushed
+        await vi.advanceTimersByTimeAsync(5001);
+        const result = await pending;
+
+        expect(result).toBeNull();
+        expect(await firstValueFrom(service.isLoggedIn$)).toBe(false);
+        httpTesting.verify();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it('not-logged-in: all session flags false; OIDC descriptors captured', async () => {
       seedConn({ proxyEnabled: true });
       const service = createService();

--- a/src/app/core/services/authentication.service.spec.ts
+++ b/src/app/core/services/authentication.service.spec.ts
@@ -83,4 +83,87 @@ describe('AuthenticationService', () => {
       expect(localStorage.getItem('authorization_token')).toBeNull();
     });
   });
+
+  describe('auth mode detection (Unit 2)', () => {
+    function seedConn(overrides: Record<string, unknown>): void {
+      localStorage.setItem(
+        'connectionConfig',
+        JSON.stringify({
+          configVersion: 12,
+          kipUUID: 'u',
+          signalKUrl: 'http://localhost',
+          proxyEnabled: false,
+          signalKSubscribeAll: false,
+          useDeviceToken: false,
+          loginName: '',
+          useSharedConfig: true,
+          sharedConfigName: 'default',
+          ...overrides
+        })
+      );
+    }
+
+    it("returns 'cookie' when proxy mode is enabled (effective origin is the app)", () => {
+      seedConn({ proxyEnabled: true, signalKUrl: 'https://elsewhere.example:9999' });
+      expect(createService().authMode).toBe('cookie');
+    });
+
+    it("returns 'cookie' when the server URL is empty (defaults to the app origin)", () => {
+      seedConn({ signalKUrl: '' });
+      expect(createService().authMode).toBe('cookie');
+    });
+
+    it("returns 'cookie' when the server URL matches the app origin", () => {
+      seedConn({ signalKUrl: window.location.origin });
+      expect(createService().authMode).toBe('cookie');
+    });
+
+    it("returns 'token' for a cross-origin server URL", () => {
+      seedConn({ signalKUrl: 'https://boat.example:3443' });
+      expect(createService().authMode).toBe('token');
+    });
+  });
+
+  describe('startup token suppression by mode (Unit 2)', () => {
+    function seedConn(overrides: Record<string, unknown>): void {
+      localStorage.setItem(
+        'connectionConfig',
+        JSON.stringify({
+          configVersion: 12,
+          kipUUID: 'u',
+          signalKUrl: 'http://localhost',
+          proxyEnabled: false,
+          signalKSubscribeAll: false,
+          useDeviceToken: false,
+          loginName: '',
+          useSharedConfig: true,
+          sharedConfigName: 'default',
+          ...overrides
+        })
+      );
+    }
+
+    it('ignores a stored user token in cookie mode (cookie/SSO is authoritative)', async () => {
+      seedConn({ proxyEnabled: true });
+      seedToken({ expiry: nowSec() + 3600, isDeviceAccessToken: false });
+      const service = createService();
+      expect(await firstValueFrom(service.authToken$)).toBeNull();
+      expect(await firstValueFrom(service.isLoggedIn$)).toBe(false);
+    });
+
+    it('keeps a stored device token in cookie mode (unattended fallback, not stranded)', async () => {
+      seedConn({ proxyEnabled: true });
+      seedToken({ expiry: nowSec() + 3600, isDeviceAccessToken: true });
+      const service = createService();
+      expect(await firstValueFrom(service.authToken$)).not.toBeNull();
+    });
+
+    it('keeps a stored user token in token mode (cross-origin)', async () => {
+      seedConn({ signalKUrl: 'https://boat.example:3443' });
+      seedToken({ expiry: nowSec() + 3600, isDeviceAccessToken: false });
+      const service = createService();
+      expect(await firstValueFrom(service.authToken$)).not.toBeNull();
+      expect(await firstValueFrom(service.isLoggedIn$)).toBe(true);
+    });
+  });
 });

--- a/src/app/core/services/authentication.service.spec.ts
+++ b/src/app/core/services/authentication.service.spec.ts
@@ -1,16 +1,86 @@
 import { TestBed } from '@angular/core/testing';
-import { beforeEach, describe, expect, it } from 'vitest';
-import { AuthenticationService } from './authentication.service';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { firstValueFrom } from 'rxjs';
+import { AuthenticationService, IAuthorizationToken } from './authentication.service';
+import { ensureLocalStorage } from '../../../test-helpers/local-storage.test-helper';
+
+const nowSec = (): number => Math.floor(Date.now() / 1000);
+
+// The constructor/renewal paths read token.expiry from the stored IAuthorizationToken
+// object, so a decodable JWT is not required for these tests.
+function seedToken(token: Partial<IAuthorizationToken>): void {
+  localStorage.setItem(
+    'authorization_token',
+    JSON.stringify({ token: 'jwt', expiry: null, isDeviceAccessToken: false, ...token })
+  );
+}
+
+function seedConnectionConfig(loginPassword: string): void {
+  localStorage.setItem(
+    'connectionConfig',
+    JSON.stringify({
+      configVersion: 12,
+      kipUUID: 'u',
+      signalKUrl: 'http://localhost',
+      proxyEnabled: false,
+      signalKSubscribeAll: false,
+      useDeviceToken: false,
+      loginName: 'pi',
+      loginPassword,
+      useSharedConfig: true,
+      sharedConfigName: 'default'
+    })
+  );
+}
+
+function createService(): AuthenticationService {
+  // Real AuthenticationService; HttpClient + SignalKConnectionService come from the
+  // global test stubs (src/test.ts).
+  TestBed.configureTestingModule({ providers: [AuthenticationService] });
+  return TestBed.inject(AuthenticationService);
+}
 
 describe('AuthenticationService', () => {
-  let service: AuthenticationService;
-
-  beforeEach(() => {
-    TestBed.configureTestingModule({});
-    service = TestBed.inject(AuthenticationService);
-  });
+  beforeEach(() => ensureLocalStorage());
 
   it('should be created', () => {
-    expect(service).toBeTruthy();
+    expect(createService()).toBeTruthy();
+  });
+
+  describe('startup token handling (Option A: the JWT is the persisted credential)', () => {
+    it('keeps an unexpired user-session token and reports logged in', async () => {
+      seedToken({ expiry: nowSec() + 3600, isDeviceAccessToken: false });
+      const service = createService();
+      expect(await firstValueFrom(service.authToken$)).not.toBeNull();
+      expect(await firstValueFrom(service.isLoggedIn$)).toBe(true);
+      expect(localStorage.getItem('authorization_token')).not.toBeNull();
+    });
+
+    it('deletes an expired user-session token on startup', async () => {
+      seedToken({ expiry: nowSec() - 10, isDeviceAccessToken: false });
+      const service = createService();
+      expect(await firstValueFrom(service.authToken$)).toBeNull();
+      expect(await firstValueFrom(service.isLoggedIn$)).toBe(false);
+      expect(localStorage.getItem('authorization_token')).toBeNull();
+    });
+  });
+
+  describe('token renewal without a stored password', () => {
+    it('deletes the token to surface re-login instead of re-POSTing stored credentials', async () => {
+      // Construct with a far-future token so the constructor does not auto-trigger renewal.
+      seedToken({ expiry: nowSec() + 3600, isDeviceAccessToken: false });
+      const service = createService();
+      const loginSpy = vi.spyOn(service, 'login').mockResolvedValue(undefined);
+
+      // Move the stored token into the renewal window (still valid, < buffer remaining).
+      seedToken({ expiry: nowSec() + 30, isDeviceAccessToken: false });
+      seedConnectionConfig('plaintext-secret-must-not-be-used');
+
+      (service as unknown as { handleTokenRenewal: () => void }).handleTokenRenewal();
+
+      expect(loginSpy).not.toHaveBeenCalled();
+      expect(await firstValueFrom(service.authToken$)).toBeNull();
+      expect(localStorage.getItem('authorization_token')).toBeNull();
+    });
   });
 });

--- a/src/app/core/services/authentication.service.ts
+++ b/src/app/core/services/authentication.service.ts
@@ -1,8 +1,8 @@
 import { SignalKConnectionService, IEndpointStatus } from './signalk-connection.service';
 import { HttpClient, HttpResponse, HttpErrorResponse } from '@angular/common/http';
 import { Injectable, OnDestroy, inject } from '@angular/core';
-import { BehaviorSubject, lastValueFrom, Subscription } from 'rxjs';
-import { distinctUntilChanged } from "rxjs/operators";
+import { BehaviorSubject, combineLatest, lastValueFrom, Subscription } from 'rxjs';
+import { distinctUntilChanged, map } from "rxjs/operators";
 
 export interface IAuthorizationToken {
   expiry: number;
@@ -18,10 +18,29 @@ export interface IAuthorizationToken {
  */
 export type AuthMode = 'cookie' | 'token';
 
+/**
+ * Parsed subset of the Signal K server's `GET /skServer/loginStatus` response. Drives cookie-mode
+ * session state and carries the login/OIDC descriptors the bootstrap redirect needs. All fields are
+ * optional because the response shape is owned by the server and is treated defensively (fail-closed:
+ * a session is only "logged in" when {@link status} is exactly `'loggedIn'`).
+ */
+export interface ILoginStatus {
+  status?: string;
+  authenticationRequired?: boolean;
+  readOnlyAccess?: boolean;
+  userLevel?: string;
+  username?: string;
+  oidcEnabled?: boolean;
+  oidcAutoLogin?: boolean;
+  oidcLoginUrl?: string;
+  oidcProviderName?: string;
+}
+
 const defaultApiPath = '/signalk/v1/'; // Use as default for new server URL changes. We do a Login before ConnectionService has time to send the new endpoitn url
 const loginEndpoint = 'auth/login';
 const logoutEndpoint = 'auth/logout';
 const validateTokenEndpoint = 'auth/validate';
+const loginStatusPath = '/skServer/loginStatus'; // server-origin, not the /signalk/v1 API base
 const tokenRenewalBuffer = 60; // nb of seconds before token expiration
 const MAX_TIMEOUT_MS = 2147483647; // Maximum safe delay for setTimeout (~24.8 days)
 
@@ -36,6 +55,30 @@ export class AuthenticationService implements OnDestroy {
   public isLoggedIn$ = this._IsLoggedIn$.asObservable();
   private _authToken$ = new BehaviorSubject<IAuthorizationToken>(null);
   public authToken$ = this._authToken$.asObservable();
+
+  // Latest parsed loginStatus (cookie mode only; null until refreshed or on any failure).
+  private _loginStatus$ = new BehaviorSubject<ILoginStatus | null>(null);
+  public loginStatus$ = this._loginStatus$.asObservable();
+
+  /**
+   * A real per-user identity is present: cookie-mode logged-in session, or a non-device token in
+   * token mode. Profiles availability and user-scope applicationData key off this, not token presence.
+   */
+  public isUserSession$ = combineLatest([this._authToken$, this._loginStatus$]).pipe(
+    map(([token, status]) => this.deriveIsUserSession(token, status)),
+    distinctUntilChanged()
+  );
+
+  /**
+   * The current session can write user-scope data: a user session that is not server-side read-only.
+   * Write affordances (config save, profile create/rename/delete/switch) gate on this so a read-only
+   * session does not present controls that silently fail server-side.
+   */
+  public canWriteUserData$ = combineLatest([this._authToken$, this._loginStatus$]).pipe(
+    map(([token, status]) => this.deriveCanWriteUserData(token, status)),
+    distinctUntilChanged()
+  );
+
   private connectionEndpointSubscription: Subscription = null;
   private authTokenSubscription: Subscription = null;
   private renewalTimerId: ReturnType<typeof setTimeout> | null = null; // Node & browser compatible handle
@@ -148,6 +191,50 @@ export class AuthenticationService implements OnDestroy {
     } catch {
       return false;
     }
+  }
+
+  /**
+   * Cookie mode: query `GET /skServer/loginStatus` with credentials so the httpOnly session cookie
+   * authenticates the probe, and derive session state from it (fail-closed). Returns the parsed
+   * status (including OIDC descriptors for the bootstrap redirect), or null on any failure or in
+   * token mode (where loginStatus is not consulted). The request targets the served origin — in
+   * cookie mode the effective Signal K origin equals `window.location.origin` by definition — not the
+   * post-discovery `/signalk/v1` base.
+   */
+  public async refreshLoginStatus(): Promise<ILoginStatus | null> {
+    if (this.authMode !== 'cookie') {
+      return null;
+    }
+    const url = window.location.origin + loginStatusPath;
+    try {
+      const raw = await lastValueFrom(this.http.get<ILoginStatus>(url, { withCredentials: true }));
+      return this.applyLoginStatus(raw);
+    } catch {
+      // Unreachable, non-2xx, or unparseable response: treat as not logged in.
+      return this.applyLoginStatus(null);
+    }
+  }
+
+  private applyLoginStatus(raw: unknown): ILoginStatus | null {
+    const status: ILoginStatus | null = raw && typeof raw === 'object' ? (raw as ILoginStatus) : null;
+    this._loginStatus$.next(status);
+    this._IsLoggedIn$.next(status?.status === 'loggedIn');
+    return status;
+  }
+
+  private deriveIsUserSession(token: IAuthorizationToken | null, status: ILoginStatus | null): boolean {
+    if (this.authMode === 'cookie') {
+      return status?.status === 'loggedIn';
+    }
+    return !!token && !token.isDeviceAccessToken;
+  }
+
+  private deriveCanWriteUserData(token: IAuthorizationToken | null, status: ILoginStatus | null): boolean {
+    if (this.authMode === 'cookie') {
+      return status?.status === 'loggedIn' && !status.readOnlyAccess;
+    }
+    // Token mode has no readOnly signal; a user token has always been treated as write-capable.
+    return !!token && !token.isDeviceAccessToken;
   }
 
   private scheduleRenewalChunk(token: IAuthorizationToken) {

--- a/src/app/core/services/authentication.service.ts
+++ b/src/app/core/services/authentication.service.ts
@@ -60,6 +60,11 @@ export class AuthenticationService implements OnDestroy {
   private _loginStatus$ = new BehaviorSubject<ILoginStatus | null>(null);
   public loginStatus$ = this._loginStatus$.asObservable();
 
+  /** Latest parsed loginStatus, read synchronously (e.g. by the SSO redirect). Null until refreshed. */
+  public get loginStatusValue(): ILoginStatus | null {
+    return this._loginStatus$.getValue();
+  }
+
   /**
    * A real per-user identity is present: cookie-mode logged-in session, or a non-device token in
    * token mode. Profiles availability and user-scope applicationData key off this, not token presence.

--- a/src/app/core/services/authentication.service.ts
+++ b/src/app/core/services/authentication.service.ts
@@ -237,10 +237,20 @@ export class AuthenticationService implements OnDestroy {
 
   private deriveCanWriteUserData(token: IAuthorizationToken | null, status: ILoginStatus | null): boolean {
     if (this.authMode === 'cookie') {
-      return status?.status === 'loggedIn' && !status.readOnlyAccess;
+      return status?.status === 'loggedIn' && this.isWriteUserLevel(status.userLevel);
     }
-    // Token mode has no readOnly signal; a user token has always been treated as write-capable.
+    // Token mode has no loginStatus; a user token has always been treated as write-capable.
     return !!token && !token.isDeviceAccessToken;
+  }
+
+  /**
+   * Whether a Signal K userLevel (skPrincipal.permissions) can write user-scope data. SK treats
+   * 'admin' and 'readwrite' as write-capable; 'readonly' (or an absent level) cannot. Note this is
+   * NOT loginStatus.readOnlyAccess — that field is the server's allow_readonly (anonymous read)
+   * config and is independent of the signed-in user's permission.
+   */
+  private isWriteUserLevel(userLevel?: string): boolean {
+    return userLevel === 'admin' || userLevel === 'readwrite';
   }
 
   private scheduleRenewalChunk(token: IAuthorizationToken) {

--- a/src/app/core/services/authentication.service.ts
+++ b/src/app/core/services/authentication.service.ts
@@ -10,6 +10,14 @@ export interface IAuthorizationToken {
   isDeviceAccessToken: boolean;
 }
 
+/**
+ * Auth carriage mode, derived synchronously from the connection config:
+ * - 'cookie': KIP is served same-origin as the Signal K server; the httpOnly session cookie
+ *   carries auth (no token header / WS token param).
+ * - 'token': cross-origin; auth is carried by the stored JWT (header + WS query param).
+ */
+export type AuthMode = 'cookie' | 'token';
+
 const defaultApiPath = '/signalk/v1/'; // Use as default for new server URL changes. We do a Login before ConnectionService has time to send the new endpoitn url
 const loginEndpoint = 'auth/login';
 const logoutEndpoint = 'auth/logout';
@@ -55,10 +63,14 @@ export class AuthenticationService implements OnDestroy {
           console.log('[Authentication Service] Device Access Token found in Local Storage');
           this._authToken$.next(token);
         }
+      } else if (this.authMode === 'cookie') {
+        // Cookie mode (same-origin): the SSO/session cookie is authoritative, so a stored user
+        // token is ignored for carriage (authToken$ stays null). Device tokens are still kept
+        // (above) as the unattended same-origin fallback.
+        console.log('[Authentication Service] User session token ignored in cookie mode (session cookie is authoritative)');
       } else {
-        // User session token: keep it across reloads (Option A — the session JWT is the
-        // persisted credential now that the plaintext password is no longer stored). Delete
-        // only when expired; mirrors the device-token handling above.
+        // Token mode (cross-origin): keep the unexpired user JWT across reloads (Option A — the
+        // session JWT is the persisted credential now that the plaintext password is not stored).
         if (token.expiry === null) {
           console.log('[Authentication Service] User session token found with expiry: NEVER');
           this._IsLoggedIn$.next(true);
@@ -98,6 +110,44 @@ export class AuthenticationService implements OnDestroy {
         this.validateTokenUrl = httpApiUrl + validateTokenEndpoint;
       }
     });
+  }
+
+  /**
+   * Synchronous auth carriage mode (no async / no connection discovery), so the HTTP interceptor
+   * and bootstrap can branch on it from the very first request. See {@link AuthMode}.
+   */
+  public get authMode(): AuthMode {
+    return this.effectiveOriginIsSameAsApp() ? 'cookie' : 'token';
+  }
+
+  /**
+   * Whether the effective Signal K request origin equals the origin KIP is served from. True when
+   * proxy mode is enabled (endpoints are rewritten to the app origin) or the configured server URL
+   * resolves to the app origin (an empty URL defaults to the app origin). Conservative on any gap:
+   * an unreadable config or unparseable URL is treated as cross-origin (token mode), preserving
+   * existing behavior.
+   */
+  private effectiveOriginIsSameAsApp(): boolean {
+    let config: { proxyEnabled?: boolean; signalKUrl?: string } | null = null;
+    try {
+      config = JSON.parse(localStorage.getItem('connectionConfig'));
+    } catch {
+      config = null;
+    }
+    if (!config) {
+      return false;
+    }
+    if (config.proxyEnabled) {
+      return true;
+    }
+    if (!config.signalKUrl) {
+      return true;
+    }
+    try {
+      return new URL(config.signalKUrl).origin === window.location.origin;
+    } catch {
+      return false;
+    }
   }
 
   private scheduleRenewalChunk(token: IAuthorizationToken) {

--- a/src/app/core/services/authentication.service.ts
+++ b/src/app/core/services/authentication.service.ts
@@ -165,36 +165,37 @@ export class AuthenticationService implements OnDestroy {
    * and bootstrap can branch on it from the very first request. See {@link AuthMode}.
    */
   public get authMode(): AuthMode {
-    return this.effectiveOriginIsSameAsApp() ? 'cookie' : 'token';
+    return this.authModeForConfig(this.readConnectionConfig());
   }
 
   /**
-   * Whether the effective Signal K request origin equals the origin KIP is served from. True when
-   * proxy mode is enabled (endpoints are rewritten to the app origin) or the configured server URL
-   * resolves to the app origin (an empty URL defaults to the app origin). Conservative on any gap:
-   * an unreadable config or unparseable URL is treated as cross-origin (token mode), preserving
-   * existing behavior.
+   * Resolves the carriage mode for a given connection config (not necessarily the stored one — the
+   * Connectivity tab uses this to pre-check a config being edited). Cookie mode when proxy is enabled
+   * (endpoints rewrite to the app origin) or the server URL resolves to the app origin (an empty URL
+   * defaults to it). Conservative on any gap: an unreadable config or unparseable URL is token mode.
    */
-  private effectiveOriginIsSameAsApp(): boolean {
-    let config: { proxyEnabled?: boolean; signalKUrl?: string } | null = null;
-    try {
-      config = JSON.parse(localStorage.getItem('connectionConfig'));
-    } catch {
-      config = null;
-    }
+  public authModeForConfig(config: { proxyEnabled?: boolean; signalKUrl?: string } | null): AuthMode {
     if (!config) {
-      return false;
+      return 'token';
     }
     if (config.proxyEnabled) {
-      return true;
+      return 'cookie';
     }
     if (!config.signalKUrl) {
-      return true;
+      return 'cookie';
     }
     try {
-      return new URL(config.signalKUrl).origin === window.location.origin;
+      return new URL(config.signalKUrl).origin === window.location.origin ? 'cookie' : 'token';
     } catch {
-      return false;
+      return 'token';
+    }
+  }
+
+  private readConnectionConfig(): { proxyEnabled?: boolean; signalKUrl?: string } | null {
+    try {
+      return JSON.parse(localStorage.getItem('connectionConfig'));
+    } catch {
+      return null;
     }
   }
 

--- a/src/app/core/services/authentication.service.ts
+++ b/src/app/core/services/authentication.service.ts
@@ -1,7 +1,7 @@
 import { SignalKConnectionService, IEndpointStatus } from './signalk-connection.service';
 import { HttpClient, HttpResponse, HttpErrorResponse } from '@angular/common/http';
 import { Injectable, OnDestroy, inject } from '@angular/core';
-import { BehaviorSubject, combineLatest, lastValueFrom, Subscription } from 'rxjs';
+import { BehaviorSubject, combineLatest, lastValueFrom, Subscription, timeout } from 'rxjs';
 import { distinctUntilChanged, map } from "rxjs/operators";
 
 export interface IAuthorizationToken {
@@ -27,7 +27,6 @@ export type AuthMode = 'cookie' | 'token';
 export interface ILoginStatus {
   status?: string;
   authenticationRequired?: boolean;
-  readOnlyAccess?: boolean;
   userLevel?: string;
   username?: string;
   oidcEnabled?: boolean;
@@ -39,8 +38,8 @@ export interface ILoginStatus {
 const defaultApiPath = '/signalk/v1/'; // Use as default for new server URL changes. We do a Login before ConnectionService has time to send the new endpoitn url
 const loginEndpoint = 'auth/login';
 const logoutEndpoint = 'auth/logout';
-const validateTokenEndpoint = 'auth/validate';
 const loginStatusPath = '/skServer/loginStatus'; // server-origin, not the /signalk/v1 API base
+const loginStatusTimeoutMs = 5000; // bounded so a hung endpoint cannot block the APP_INITIALIZER
 const tokenRenewalBuffer = 60; // nb of seconds before token expiration
 const MAX_TIMEOUT_MS = 2147483647; // Maximum safe delay for setTimeout (~24.8 days)
 
@@ -92,7 +91,6 @@ export class AuthenticationService implements OnDestroy {
   // Network connection
   private loginUrl = null;
   private logoutUrl = null;
-  private validateTokenUrl = null;
 
   constructor()
   {
@@ -155,7 +153,6 @@ export class AuthenticationService implements OnDestroy {
         const httpApiUrl: string = endpoint.httpServiceUrl.substring(0, endpoint.httpServiceUrl.length - 4); // this removes 'api/' from the end
         this.loginUrl = httpApiUrl + loginEndpoint;
         this.logoutUrl = httpApiUrl + logoutEndpoint;
-        this.validateTokenUrl = httpApiUrl + validateTokenEndpoint;
       }
     });
   }
@@ -213,7 +210,7 @@ export class AuthenticationService implements OnDestroy {
     }
     const url = window.location.origin + loginStatusPath;
     try {
-      const raw = await lastValueFrom(this.http.get<ILoginStatus>(url, { withCredentials: true }));
+      const raw = await lastValueFrom(this.http.get<ILoginStatus>(url, { withCredentials: true }).pipe(timeout(loginStatusTimeoutMs)));
       return this.applyLoginStatus(raw);
     } catch {
       // Unreachable, non-2xx, or unparseable response: treat as not logged in.
@@ -444,11 +441,6 @@ export class AuthenticationService implements OnDestroy {
       date.setUTCSeconds(dateAsSeconds);
     }
     return date;
-  }
-
-  // not yet implemented by Signal K but part of the specs. Using contained token string expiration value instead for now
-  private renewToken() {
-    return this.http.post<HttpResponse<Response>>(this.validateTokenUrl, null, {observe: 'response'});
   }
 
   /**

--- a/src/app/core/services/authentication.service.ts
+++ b/src/app/core/services/authentication.service.ts
@@ -56,9 +56,21 @@ export class AuthenticationService implements OnDestroy {
           this._authToken$.next(token);
         }
       } else {
-        console.log('[Authentication Service] User session token found in Local Storage');
-        console.log('[Authentication Service] Deleting user session token');
-        localStorage.removeItem('authorization_token');
+        // User session token: keep it across reloads (Option A — the session JWT is the
+        // persisted credential now that the plaintext password is no longer stored). Delete
+        // only when expired; mirrors the device-token handling above.
+        if (token.expiry === null) {
+          console.log('[Authentication Service] User session token found with expiry: NEVER');
+          this._IsLoggedIn$.next(true);
+          this._authToken$.next(token);
+        } else if (this.isTokenExpired(token.expiry)) {
+          console.log('[Authentication Service] User session token expired. Deleting token');
+          localStorage.removeItem('authorization_token');
+        } else {
+          console.log('[Authentication Service] User session token found in Local Storage');
+          this._IsLoggedIn$.next(true);
+          this._authToken$.next(token);
+        }
       }
     }
 
@@ -148,18 +160,12 @@ export class AuthenticationService implements OnDestroy {
         this.isRenewingToken = false;
         this.scheduleRenewalChunk(token);
       } else {
-        console.log(`[Authentication Service] User session Token within renewal window (${remainingSec}s remaining). Renewing token...`);
-        const connectionConfig = JSON.parse(localStorage.getItem('connectionConfig'));
-        this.login({ usr: connectionConfig.loginName, pwd: connectionConfig.loginPassword })
-          .then(() => {
-            console.log('[Authentication Service] Token successfully renewed.');
-          })
-          .catch((error: HttpErrorResponse) => {
-            console.error('[Authentication Service] Token renewal failed. Server returned:', error.error);
-          })
-          .finally(() => {
-            this.isRenewingToken = false;
-          });
+        // No silent refresh available: auth/validate is unimplemented on the server and the
+        // plaintext password is no longer stored. Surface re-login by dropping the token rather
+        // than re-POSTing stored credentials.
+        console.log(`[Authentication Service] User session token within renewal window (${remainingSec}s remaining); no refresh available. Signing out to surface re-login.`);
+        this.deleteToken();
+        this.isRenewingToken = false;
       }
     }
   }

--- a/src/app/core/services/settings.service.spec.ts
+++ b/src/app/core/services/settings.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { SettingsService } from './settings.service';
 import { StorageService } from './storage.service';
 import { ensureLocalStorage } from '../../../test-helpers/local-storage.test-helper';
@@ -53,5 +53,52 @@ describe('SettingsService — connection credential persistence', () => {
     const cfg = createService().getConnectionConfig();
     expect(cfg.loginName).toBe('captain');
     expect(Object.prototype.hasOwnProperty.call(cfg, 'loginPassword')).toBe(false);
+  });
+});
+
+describe('SettingsService — storage routing by mode (Unit 5)', () => {
+  beforeEach(() => ensureLocalStorage());
+
+  // authMode is derived by the real AuthenticationService from the seeded connectionConfig:
+  // proxyEnabled => cookie; a cross-origin signalKUrl => token.
+  const COOKIE = { proxyEnabled: true };
+  const CROSS_ORIGIN = { signalKUrl: 'https://boat.example:3443' };
+
+  function setup(connExtra: Record<string, unknown>) {
+    seedConnectionConfig(connExtra);
+    TestBed.configureTestingModule({ providers: [SettingsService, StorageService] });
+    const storage = TestBed.inject(StorageService);
+    const patchSpy = vi.spyOn(storage, 'patchConfig').mockImplementation(() => undefined);
+    const service = TestBed.inject(SettingsService);
+    return { service, patchSpy };
+  }
+
+  it('cookie mode routes a setting write to server applicationData, not localStorage', () => {
+    const { service, patchSpy } = setup({ ...COOKIE, useSharedConfig: false });
+    localStorage.removeItem('themeConfig');
+
+    service.setThemeName('cookie-theme');
+
+    expect(patchSpy).toHaveBeenCalledWith('IThemeConfig', { themeName: 'cookie-theme' });
+    expect(localStorage.getItem('themeConfig')).toBeNull();
+  });
+
+  it('cross-origin shared config still routes to server applicationData (unchanged)', () => {
+    const { service, patchSpy } = setup({ ...CROSS_ORIGIN, useSharedConfig: true });
+    localStorage.removeItem('themeConfig');
+
+    service.setThemeName('shared-theme');
+
+    expect(patchSpy).toHaveBeenCalledWith('IThemeConfig', { themeName: 'shared-theme' });
+    expect(localStorage.getItem('themeConfig')).toBeNull();
+  });
+
+  it('cross-origin local config still routes to localStorage (unchanged)', () => {
+    const { service, patchSpy } = setup({ ...CROSS_ORIGIN, useSharedConfig: false });
+
+    service.setThemeName('local-theme');
+
+    expect(patchSpy).not.toHaveBeenCalled();
+    expect(JSON.parse(localStorage.getItem('themeConfig') as string)).toEqual({ themeName: 'local-theme' });
   });
 });

--- a/src/app/core/services/settings.service.spec.ts
+++ b/src/app/core/services/settings.service.spec.ts
@@ -1,16 +1,57 @@
 import { TestBed } from '@angular/core/testing';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { SettingsService } from './settings.service';
+import { StorageService } from './storage.service';
+import { ensureLocalStorage } from '../../../test-helpers/local-storage.test-helper';
 
-describe('SettingsService', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [SettingsService]
-    });
+function seedConnectionConfig(extra: Record<string, unknown> = {}): void {
+  localStorage.setItem('authorization_token', JSON.stringify(null));
+  localStorage.setItem(
+    'connectionConfig',
+    JSON.stringify({
+      configVersion: 12,
+      kipUUID: 'test-uuid',
+      signalKUrl: 'http://localhost',
+      proxyEnabled: false,
+      signalKSubscribeAll: false,
+      useDeviceToken: false,
+      loginName: 'pi',
+      useSharedConfig: true,
+      sharedConfigName: 'default',
+      ...extra
+    })
+  );
+}
+
+function createService(): SettingsService {
+  // localStorage is installed+cleared in beforeEach; the test seeds before calling this.
+  // Provide both services so the transitive chain resolves to the global stubs
+  // (AuthenticationService / SignalKConnectionService) rather than the real root services.
+  TestBed.configureTestingModule({ providers: [SettingsService, StorageService] });
+  return TestBed.inject(SettingsService);
+}
+
+describe('SettingsService — connection credential persistence', () => {
+  beforeEach(() => ensureLocalStorage());
+
+  it('getConnectionConfig() does not expose a loginPassword key', () => {
+    seedConnectionConfig();
+    const cfg = createService().getConnectionConfig();
+    expect(Object.prototype.hasOwnProperty.call(cfg, 'loginPassword')).toBe(false);
   });
 
-  it('should be created', () => {
-    const service = TestBed.inject(SettingsService);
-    expect(service).toBeTruthy();
+  it('strips a persisted loginPassword from a legacy connectionConfig on load, without a version bump', () => {
+    seedConnectionConfig({ loginPassword: 'plaintext-secret' });
+    createService();
+    const persisted = JSON.parse(localStorage.getItem('connectionConfig') as string);
+    expect(Object.prototype.hasOwnProperty.call(persisted, 'loginPassword')).toBe(false);
+    expect(persisted.configVersion).toBe(12);
+  });
+
+  it('preserves loginName while dropping the password', () => {
+    seedConnectionConfig({ loginName: 'captain', loginPassword: 'secret' });
+    const cfg = createService().getConnectionConfig();
+    expect(cfg.loginName).toBe('captain');
+    expect(Object.prototype.hasOwnProperty.call(cfg, 'loginPassword')).toBe(false);
   });
 });

--- a/src/app/core/services/settings.service.spec.ts
+++ b/src/app/core/services/settings.service.spec.ts
@@ -66,6 +66,11 @@ describe('SettingsService — storage routing by mode (Unit 5)', () => {
 
   function setup(connExtra: Record<string, unknown>) {
     seedConnectionConfig(connExtra);
+    // Seed the local config keys so the localStorage startup() branch (cross-origin/local routing)
+    // loads cleanly instead of throwing an (unhandled, suite-masking) JSON parse error.
+    localStorage.setItem('appConfig', JSON.stringify({ configVersion: 12, dataSets: [], unitDefaults: {}, notificationConfig: {} }));
+    localStorage.setItem('dashboardsConfig', JSON.stringify([]));
+    localStorage.setItem('themeConfig', JSON.stringify({ themeName: '' }));
     TestBed.configureTestingModule({ providers: [SettingsService, StorageService] });
     const storage = TestBed.inject(StorageService);
     const patchSpy = vi.spyOn(storage, 'patchConfig').mockImplementation(() => undefined);

--- a/src/app/core/services/settings.service.ts
+++ b/src/app/core/services/settings.service.ts
@@ -16,6 +16,7 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { StorageService } from './storage.service';
 import { Dashboard } from './dashboard.service';
 import { SignalKConnectionService } from '../services/signalk-connection.service';
+import { AuthenticationService } from './authentication.service';
 import { compare } from 'compare-versions';
 
 
@@ -29,6 +30,7 @@ export class SettingsService {
   private readonly storage = inject(StorageService);
   private readonly snackBar = inject(MatSnackBar);
   private readonly server = inject(SignalKConnectionService);
+  private readonly auth = inject(AuthenticationService);
 
   private unitDefaults: BehaviorSubject<IUnitDefaults> = new BehaviorSubject<IUnitDefaults>({});
   private themeName: BehaviorSubject<string> = new BehaviorSubject<string>(defaultTheme);
@@ -76,8 +78,18 @@ export class SettingsService {
     }
   }
 
+  /**
+   * Whether config persistence should target the server's applicationData rather than localStorage.
+   * True in cookie mode (same-origin SSO session) regardless of the stored useSharedConfig flag, and
+   * in cross-origin mode when shared config is enabled. Decouples storage routing from useSharedConfig
+   * the same way auth carriage is — avoids the cookie-mode localStorage split-brain.
+   */
+  private get useServerStorage(): boolean {
+    return this.auth.authMode === 'cookie' || this.useSharedConfig;
+  }
+
   private async startup(): Promise<void> {
-    if (this.useSharedConfig) {
+    if (this.useServerStorage) {
       if (!this.storage.isRemoteContextBootstrapped() || this.storage.initConfig === null) {
         console.warn('[AppSettings Service] Shared configuration enabled but remote bootstrap handoff is missing. Waiting for explicit recovery action.');
         return;
@@ -282,7 +294,7 @@ export class SettingsService {
   }
   public setDefaultUnits(newDefaults: IUnitDefaults) {
     this.unitDefaults.next(newDefaults);
-    if (this.useSharedConfig) {
+    if (this.useServerStorage) {
       this.storage.patchConfig('Array<IUnitDefaults>', newDefaults);
 
     } else {
@@ -343,7 +355,7 @@ export class SettingsService {
 
   public setThemeName(newTheme: string) {
     this.themeName.next(newTheme);
-    if (this.useSharedConfig) {
+    if (this.useServerStorage) {
       const theme: IThemeConfig = {
         themeName: newTheme
       }
@@ -366,7 +378,7 @@ export class SettingsService {
     this.autoNightMode.next(enabled);
     const appConf = this.buildAppStorageObject();
 
-    if (this.useSharedConfig) {
+    if (this.useServerStorage) {
       this.storage.patchConfig('IAppConfig', appConf);
     } else {
       this.saveAppConfigToLocalStorage();
@@ -390,7 +402,7 @@ export class SettingsService {
     this.redNightMode.next(enabled);
     const appConf = this.buildAppStorageObject();
 
-    if (this.useSharedConfig) {
+    if (this.useServerStorage) {
       this.storage.patchConfig('IAppConfig', appConf);
     } else {
       this.saveAppConfigToLocalStorage();
@@ -410,7 +422,7 @@ export class SettingsService {
     this.isRemoteControl.next(enabled);
     const appConf = this.buildAppStorageObject();
 
-    if (this.useSharedConfig) {
+    if (this.useServerStorage) {
       this.storage.patchConfig('IAppConfig', appConf);
     } else {
       this.saveAppConfigToLocalStorage();
@@ -430,7 +442,7 @@ export class SettingsService {
     this.instanceName.next(name);
     const appConf = this.buildAppStorageObject();
 
-    if (this.useSharedConfig) {
+    if (this.useServerStorage) {
       this.storage.patchConfig('IAppConfig', appConf);
     } else {
       this.saveAppConfigToLocalStorage();
@@ -456,7 +468,7 @@ export class SettingsService {
     this.splitShellEnabled.next(enabled);
     const appConf = this.buildAppStorageObject();
 
-    if (this.useSharedConfig) {
+    if (this.useServerStorage) {
       this.storage.patchConfig('IAppConfig', appConf);
     } else {
       this.saveAppConfigToLocalStorage();
@@ -473,7 +485,7 @@ export class SettingsService {
     this.splitShellSide.next(side);
     const appConf = this.buildAppStorageObject();
 
-    if (this.useSharedConfig) {
+    if (this.useServerStorage) {
       this.storage.patchConfig('IAppConfig', appConf);
     } else {
       this.saveAppConfigToLocalStorage();
@@ -490,7 +502,7 @@ export class SettingsService {
     this.widgetHistoryDisabled.next(disabled);
     const appConf = this.buildAppStorageObject();
 
-    if (this.useSharedConfig) {
+    if (this.useServerStorage) {
       this.storage.patchConfig('IAppConfig', appConf);
     } else {
       this.saveAppConfigToLocalStorage();
@@ -507,7 +519,7 @@ export class SettingsService {
     this.splitShellSwipeDisabled.next(enabled);
     const appConf = this.buildAppStorageObject();
 
-    if (this.useSharedConfig) {
+    if (this.useServerStorage) {
       this.storage.patchConfig('IAppConfig', appConf);
     } else {
       this.saveAppConfigToLocalStorage();
@@ -526,7 +538,7 @@ export class SettingsService {
     this.splitShellWidth.next(ratio);
     const appConf = this.buildAppStorageObject();
 
-    if (this.useSharedConfig) {
+    if (this.useServerStorage) {
       this.storage.patchConfig('IAppConfig', appConf);
     } else {
       this.saveAppConfigToLocalStorage();
@@ -541,7 +553,7 @@ export class SettingsService {
     this.nightModeBrightness.next(brightness);
     const appConf = this.buildAppStorageObject();
 
-    if (this.useSharedConfig) {
+    if (this.useServerStorage) {
       this.storage.patchConfig('IAppConfig', appConf);
     } else {
       this.saveAppConfigToLocalStorage();
@@ -554,7 +566,7 @@ export class SettingsService {
   }
 
   public saveDashboards(dashboards: Dashboard[]) {
-    if (this.useSharedConfig) {
+    if (this.useServerStorage) {
       if (this.storage.storageServiceReady$.getValue()) {
         this.storage.patchConfig('Dashboards', dashboards);
       }
@@ -567,7 +579,7 @@ export class SettingsService {
   // DataSets
   public saveDataSets(dataSets: IDatasetServiceDatasetConfig[]) {
     this.dataSets = dataSets;
-    if (this.useSharedConfig) {
+    if (this.useServerStorage) {
       this.storage.patchConfig('Array<IDatasetDef>', dataSets);
     } else {
       this.saveAppConfigToLocalStorage();
@@ -586,7 +598,7 @@ export class SettingsService {
   }
   public setNotificationConfig(notificationConfig: INotificationConfig) {
     this.kipKNotificationConfig.next(notificationConfig);
-    if (this.useSharedConfig) {
+    if (this.useServerStorage) {
       this.storage.patchConfig('INotificationConfig', notificationConfig);
     } else {
       this.saveAppConfigToLocalStorage();
@@ -601,7 +613,7 @@ export class SettingsService {
     newDefaultConfig.theme = this.getDefaultThemeConfig();
     newDefaultConfig.dashboards = this.getDefaultDashboardsConfig();
 
-      if (this.useSharedConfig) {
+      if (this.useServerStorage) {
         if (this.storage.storageServiceReady$.getValue()) {
           this.storage.setConfig('user', this.sharedConfigName, newDefaultConfig)
             .then(() => {
@@ -644,13 +656,13 @@ export class SettingsService {
   }
 
   public loadDemoConfig() {
-    if (this.useSharedConfig) {
+    if (this.useServerStorage) {
       const demoConfig: IConfig = {
         app: DemoAppConfig,
         dashboards: DemoDashboardsConfig,
         theme: DemoThemeConfig
       };
-      console.log("[AppSettings Service] Loading Demo configuration settings as remote config: " + this.useSharedConfig + " and reloading app.");
+      console.log("[AppSettings Service] Loading Demo configuration settings as remote config: " + this.useServerStorage + " and reloading app.");
       this.storage.setConfig('user', this.sharedConfigName, demoConfig);
       this.reloadApp();
     } else {

--- a/src/app/core/services/settings.service.ts
+++ b/src/app/core/services/settings.service.ts
@@ -90,8 +90,10 @@ export class SettingsService {
 
   private async startup(): Promise<void> {
     if (this.useServerStorage) {
-      if (!this.storage.isRemoteContextBootstrapped() || this.storage.initConfig === null) {
-        console.warn('[AppSettings Service] Shared configuration enabled but remote bootstrap handoff is missing. Waiting for explicit recovery action.');
+      // A missing server config comes back as {} (not a 404), so guard on the presence of app config —
+      // an empty/appless object must not fall through to pushSettings() and dereference activeConfig.app.
+      if (!this.storage.isRemoteContextBootstrapped() || !this.storage.initConfig?.app) {
+        console.warn('[AppSettings Service] Shared configuration enabled but remote bootstrap handoff is missing or empty. Waiting for explicit recovery action.');
         return;
       }
 
@@ -325,9 +327,9 @@ export class SettingsService {
     if (this.signalkUrl) {
       this.signalkUrl.url = value.signalKUrl;
     }
-    if (!value.useSharedConfig) {
-      this.useDeviceToken = true;
-    } else this.useDeviceToken = false;
+    // useDeviceToken and useSharedConfig are one "cross-origin intent" axis (device token only when
+    // not using shared config).
+    this.useDeviceToken = !value.useSharedConfig;
     this.saveConnectionConfigToLocalStorage();
   }
 

--- a/src/app/core/services/settings.service.ts
+++ b/src/app/core/services/settings.service.ts
@@ -119,10 +119,17 @@ export class SettingsService {
     this.signalKSubscribeAll = config.signalKSubscribeAll;
     this.useDeviceToken = config.useDeviceToken;
     this.loginName = config.loginName;
-    this.loginPassword = config.loginPassword;
+    this.loginPassword = ''; // transient only; never loaded from storage
     this.useSharedConfig = config.useSharedConfig;
     this.sharedConfigName = config.sharedConfigName;
     this.kipUUID = config.kipUUID;
+
+    // Idempotent purge: strip any plaintext password persisted by an older version.
+    // Targeted rewrite preserves all other fields (incl. configVersion) exactly.
+    if (Object.prototype.hasOwnProperty.call(config, 'loginPassword')) {
+      delete config.loginPassword;
+      localStorage.setItem("connectionConfig", JSON.stringify(config));
+    }
   }
 
   public resetConnection() {
@@ -299,7 +306,7 @@ export class SettingsService {
 
   public setConnectionConfig(value: IConnectionConfig) {
     this.loginName = value.loginName;
-    this.loginPassword = value.loginPassword;
+    this.loginPassword = value.loginPassword ?? ''; // transient; not persisted
     this.useSharedConfig = value.useSharedConfig;
     this.proxyEnabled = value.proxyEnabled;
     this.signalKSubscribeAll = value.signalKSubscribeAll;
@@ -695,7 +702,7 @@ export class SettingsService {
       signalKSubscribeAll: this.signalKSubscribeAll,
       useDeviceToken: this.useDeviceToken,
       loginName: this.loginName,
-      loginPassword: this.loginPassword,
+      // loginPassword intentionally omitted: never persisted (transient in-memory only).
       useSharedConfig: this.useSharedConfig,
       sharedConfigName: this.sharedConfigName
     }

--- a/src/app/core/services/signalk-delta.service.spec.ts
+++ b/src/app/core/services/signalk-delta.service.spec.ts
@@ -1,15 +1,159 @@
-import { TestBed, inject } from '@angular/core/testing';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { BehaviorSubject } from 'rxjs';
 import { SignalKDeltaService } from './signalk-delta.service';
+import { AuthenticationService } from './authentication.service';
+import { SignalKConnectionService } from './signalk-connection.service';
+import { ConnectionStateMachine } from './connection-state-machine.service';
 
-describe('SignalkDeltaService', () => {
+class AuthStub {
+  isLoggedIn$ = new BehaviorSubject<boolean>(false);
+  authToken$ = new BehaviorSubject<unknown>(null);
+  authMode: 'cookie' | 'token' = 'token';
+  refreshLoginStatus = vi.fn(async () => null);
+}
+
+class ConnStub {
+  serverServiceEndpoint$ = new BehaviorSubject<{ operation: number; WsServiceUrl?: string; subscribeAll?: boolean }>({ operation: 0 });
+  setServerInfo(): void { /* noop */ }
+}
+
+class CsmStub {
+  state$ = new BehaviorSubject<string>('Disconnected');
+  setWebSocketRetryCallback = vi.fn();
+  isFullyConnected = vi.fn(() => false);
+  isHTTPConnected = vi.fn(() => true);
+  startWebSocketConnection = vi.fn();
+  onWebSocketConnected = vi.fn();
+  onWebSocketError = vi.fn();
+  currentState = 'HTTPConnected';
+}
+
+interface DeltaInternals { buildWebSocketUrl(): string }
+
+function setup() {
+  const auth = new AuthStub();
+  const conn = new ConnStub();
+  const csm = new CsmStub();
+  TestBed.configureTestingModule({
+    providers: [
+      SignalKDeltaService,
+      { provide: AuthenticationService, useValue: auth },
+      { provide: SignalKConnectionService, useValue: conn },
+      { provide: ConnectionStateMachine, useValue: csm },
+    ]
+  });
+  const service = TestBed.inject(SignalKDeltaService);
+  return { service, auth, conn, csm };
+}
+
+describe('SignalKDeltaService', () => {
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [SignalKDeltaService]
+    TestBed.resetTestingModule();
+  });
+
+  it('should be created', () => {
+    expect(setup().service).toBeTruthy();
+  });
+
+  describe('WebSocket token carriage by mode (Unit 4)', () => {
+    it('cookie mode omits &token= even when a token is present', () => {
+      const { service, auth, conn } = setup();
+      auth.authMode = 'cookie';
+      conn.serverServiceEndpoint$.next({ operation: 2, WsServiceUrl: 'wss://host/signalk/v1/stream', subscribeAll: false });
+      auth.authToken$.next({ token: 'should-not-appear', expiry: null, isDeviceAccessToken: false });
+
+      const url = (service as unknown as DeltaInternals).buildWebSocketUrl();
+      expect(url).not.toContain('token=');
+      expect(url.startsWith('wss://host/signalk/v1/stream')).toBe(true);
+    });
+
+    it('token mode appends &token= when a token is present', () => {
+      const { service, auth, conn } = setup();
+      auth.authMode = 'token';
+      conn.serverServiceEndpoint$.next({ operation: 2, WsServiceUrl: 'wss://host/signalk/v1/stream', subscribeAll: false });
+      auth.authToken$.next({ token: 'abc123', expiry: 9999999999, isDeviceAccessToken: false });
+
+      const url = (service as unknown as DeltaInternals).buildWebSocketUrl();
+      expect(url).toContain('&token=abc123');
     });
   });
 
-  it('should be created', inject([SignalKDeltaService], (service: SignalKDeltaService) => {
-    expect(service).toBeTruthy();
-  }));
+  describe('cookie-mode session-driven (re)connect (Unit 4)', () => {
+    it('a login transition triggers a WS (re)connect via the isFullyConnected guard', () => {
+      const { auth, csm } = setup();
+      auth.authMode = 'cookie';
+      csm.startWebSocketConnection.mockClear();
+
+      auth.isLoggedIn$.next(true);
+
+      expect(csm.startWebSocketConnection).toHaveBeenCalled();
+    });
+
+    it('does not start a WS connect when already fully connected (no double-connect)', () => {
+      const { auth, csm } = setup();
+      auth.authMode = 'cookie';
+      csm.isFullyConnected.mockReturnValue(true);
+      csm.startWebSocketConnection.mockClear();
+
+      auth.isLoggedIn$.next(true);
+
+      expect(csm.startWebSocketConnection).not.toHaveBeenCalled();
+    });
+
+    it('does not start a second WS connect while one is already in flight (WebSocketConnecting)', () => {
+      const { auth, csm } = setup();
+      auth.authMode = 'cookie';
+      // Bootstrap already opened the socket: not yet Connected, but a connect is in flight.
+      csm.isFullyConnected.mockReturnValue(false);
+      csm.currentState = 'WebSocketConnecting';
+      csm.startWebSocketConnection.mockClear();
+
+      auth.isLoggedIn$.next(true);
+
+      expect(csm.startWebSocketConnection).not.toHaveBeenCalled();
+    });
+
+    it('token mode does not drive the cookie reconnect path on a login transition', () => {
+      const { auth, csm } = setup();
+      auth.authMode = 'token';
+      csm.startWebSocketConnection.mockClear();
+
+      auth.isLoggedIn$.next(true);
+
+      expect(csm.startWebSocketConnection).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('cookie-mode loginStatus re-check on WS drop (Unit 4)', () => {
+    it('re-checks loginStatus on a non-clean close', () => {
+      const { service, auth } = setup();
+      auth.authMode = 'cookie';
+      auth.refreshLoginStatus.mockClear();
+
+      service.socketWSCloseEvent$.next({ wasClean: false } as CloseEvent);
+
+      expect(auth.refreshLoginStatus).toHaveBeenCalled();
+    });
+
+    it('does not re-check loginStatus on a clean close', () => {
+      const { service, auth } = setup();
+      auth.authMode = 'cookie';
+      auth.refreshLoginStatus.mockClear();
+
+      service.socketWSCloseEvent$.next({ wasClean: true } as CloseEvent);
+
+      expect(auth.refreshLoginStatus).not.toHaveBeenCalled();
+    });
+
+    it('token mode does not re-check loginStatus on a non-clean close', () => {
+      const { service, auth } = setup();
+      auth.authMode = 'token';
+      auth.refreshLoginStatus.mockClear();
+
+      service.socketWSCloseEvent$.next({ wasClean: false } as CloseEvent);
+
+      expect(auth.refreshLoginStatus).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/app/core/services/signalk-delta.service.ts
+++ b/src/app/core/services/signalk-delta.service.ts
@@ -1,5 +1,6 @@
 import { DestroyRef, inject, Injectable, OnDestroy } from '@angular/core';
 import { BehaviorSubject, Observable, Subject, fromEvent } from 'rxjs';
+import { distinctUntilChanged } from 'rxjs/operators';
 import { webSocket, WebSocketSubject } from 'rxjs/webSocket';
 
 import { ISignalKDataValueUpdate, ISignalKDeltaMessage, ISignalKMeta, ISignalKUpdateMessage } from '../interfaces/signalk-interfaces';
@@ -136,6 +137,17 @@ export class SignalKDeltaService implements OnDestroy {
         }
       });
 
+    // Cookie mode has no token, so the authToken$ reconnect above never fires. Drive the WS
+    // (re)connect off the session signal instead, reusing checkAndReconnect's isFullyConnected
+    // guard so we do not double-connect with the bootstrap's startWebSocketConnection().
+    this.auth.isLoggedIn$
+      .pipe(distinctUntilChanged(), takeUntilDestroyed(this._destroyRef))
+      .subscribe((loggedIn: boolean) => {
+        if (loggedIn && this.auth.authMode === 'cookie') {
+          this.checkAndReconnect('Cookie session established');
+        }
+      });
+
     // WebSocket Open Event Handling
     this.socketWSOpenEvent$
       .pipe(takeUntilDestroyed(this._destroyRef))
@@ -168,6 +180,12 @@ export class SignalKDeltaService implements OnDestroy {
 
           // Notify ConnectionStateMachine of WebSocket error
           this.connectionStateMachine.onWebSocketError('WebSocket connection lost');
+
+          // In cookie mode a drop may mean the session cookie expired; re-check loginStatus so
+          // session state (and the UI) reflect a server-side logout rather than retrying blindly.
+          if (this.auth.authMode === 'cookie') {
+            void this.auth.refreshLoginStatus();
+          }
         }
         this.streamEndpoint$.next(this.streamEndpoint);
       });
@@ -259,18 +277,27 @@ export class SignalKDeltaService implements OnDestroy {
   }
 
   /**
-   * Handles connection arguments, token and links socket Open/Close Observers
+   * Builds the WebSocket URL including the subscription/meta args and, in token mode only, the
+   * auth token. Mode-first: in cookie mode the same-origin session cookie authenticates the WS
+   * upgrade, so &token= is never appended (even if a stale token is present).
    */
-  private getNewWebSocket(): WebSocketSubject<object> {
+  private buildWebSocketUrl(): string {
     let args = this.WS_CONNECTION_SUBSCRIBE + this.SubscriptionType + this.WS_CONNECTION_META;
-    if (this.authToken != null) {
+    if (this.auth.authMode === 'token' && this.authToken != null) {
       args += "&token=" + this.authToken.token;
       this.streamEndpoint.hasToken = true;
     } else {
       this.streamEndpoint.hasToken = false;
     }
+    return this.endpointWS + args;
+  }
+
+  /**
+   * Handles connection arguments, token and links socket Open/Close Observers
+   */
+  private getNewWebSocket(): WebSocketSubject<object> {
     return webSocket({
-      url: this.endpointWS + args,
+      url: this.buildWebSocketUrl(),
       closeObserver: this.socketWSCloseEvent$,
       openObserver: this.socketWSOpenEvent$
     })
@@ -498,7 +525,12 @@ export class SignalKDeltaService implements OnDestroy {
    */
   private checkAndReconnect(reason: string): void {
     if (!this.connectionStateMachine.isFullyConnected()) {
-      if (this.connectionStateMachine.isHTTPConnected()  && this.connectionStateMachine.currentState !== ConnectionState.WebSocketRetrying) {
+      // Do not start a second connect while one is already in flight (WebSocketConnecting) or being
+      // retried — that would close and reopen the in-flight socket. This matters for the cookie-mode
+      // isLoggedIn$ reconnect, which can race the bootstrap's own startWebSocketConnection().
+      if (this.connectionStateMachine.isHTTPConnected()
+          && this.connectionStateMachine.currentState !== ConnectionState.WebSocketRetrying
+          && this.connectionStateMachine.currentState !== ConnectionState.WebSocketConnecting) {
         console.log(`[Delta Service] ${reason}: WebSocket disconnected, requesting reconnection...`);
         this.connectionStateMachine.startWebSocketConnection();
       } else {

--- a/src/app/core/services/sso-redirect.service.spec.ts
+++ b/src/app/core/services/sso-redirect.service.spec.ts
@@ -1,0 +1,125 @@
+import { TestBed } from '@angular/core/testing';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SsoRedirectService } from './sso-redirect.service';
+import { AuthenticationService, ILoginStatus } from './authentication.service';
+import { ensureLocalStorage, ensureSessionStorage } from '../../../test-helpers/local-storage.test-helper';
+
+class AuthStub {
+  loginStatusValue: ILoginStatus | null = null;
+}
+
+const OIDC_STATUS: ILoginStatus = {
+  status: 'notLoggedIn',
+  authenticationRequired: true,
+  oidcEnabled: true,
+  oidcAutoLogin: true,
+  oidcLoginUrl: '/signalk/v1/auth/oidc/login'
+};
+
+function setup(authStub: AuthStub = new AuthStub()) {
+  ensureLocalStorage();
+  ensureSessionStorage();
+  TestBed.configureTestingModule({
+    providers: [SsoRedirectService, { provide: AuthenticationService, useValue: authStub }]
+  });
+  const service = TestBed.inject(SsoRedirectService);
+  const navSpy = vi
+    .spyOn(service as unknown as { navigate: (u: string) => void }, 'navigate')
+    .mockImplementation(() => undefined);
+  return { service, navSpy, authStub };
+}
+
+describe('SsoRedirectService', () => {
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  it('redirects to the OIDC login and records one budget attempt', () => {
+    const { service, navSpy } = setup();
+
+    expect(service.attemptAutoRedirect(OIDC_STATUS)).toBe('redirected');
+
+    expect(navSpy).toHaveBeenCalledTimes(1);
+    expect(navSpy.mock.calls[0][0]).toContain('/signalk/v1/auth/oidc/login');
+    expect(service.attempts()).toBe(1);
+  });
+
+  it('stops redirecting once the budget is exhausted (kiosk auto-login loop guard)', () => {
+    const { service, navSpy } = setup();
+
+    expect(service.attemptAutoRedirect(OIDC_STATUS)).toBe('redirected');
+    expect(service.attemptAutoRedirect(OIDC_STATUS)).toBe('redirected');
+    expect(service.attemptAutoRedirect(OIDC_STATUS)).toBe('redirected');
+    navSpy.mockClear();
+
+    expect(service.attemptAutoRedirect(OIDC_STATUS)).toBe('budget-exhausted');
+    expect(navSpy).not.toHaveBeenCalled();
+  });
+
+  it('resetBudget clears the attempt count', () => {
+    const { service } = setup();
+    service.attemptAutoRedirect(OIDC_STATUS);
+    expect(service.attempts()).toBe(1);
+
+    service.resetBudget();
+
+    expect(service.attempts()).toBe(0);
+    expect(service.isBudgetExhausted()).toBe(false);
+  });
+
+  it('manualSignIn resets the budget and disables auto-login', () => {
+    const authStub = new AuthStub();
+    authStub.loginStatusValue = OIDC_STATUS;
+    const { service, navSpy } = setup(authStub);
+    service.attemptAutoRedirect(OIDC_STATUS);
+    service.attemptAutoRedirect(OIDC_STATUS);
+    navSpy.mockClear();
+
+    service.manualSignIn();
+
+    expect(service.attempts()).toBe(0);
+    expect(navSpy).toHaveBeenCalledTimes(1);
+    expect(navSpy.mock.calls[0][0]).toContain('/signalk/v1/auth/oidc/login');
+    expect(navSpy.mock.calls[0][0]).toContain('noAutoLogin=true');
+  });
+
+  it('falls back to the admin login when OIDC is not enabled', () => {
+    const { service, navSpy } = setup();
+
+    service.attemptAutoRedirect({ status: 'notLoggedIn', authenticationRequired: true, oidcEnabled: false });
+
+    expect(navSpy.mock.calls[0][0]).toContain('/admin/#/login');
+  });
+
+  it('fails closed (does not auto-redirect) when sessionStorage is unavailable', () => {
+    const { service, navSpy } = setup();
+    const original = window.sessionStorage;
+    Object.defineProperty(window, 'sessionStorage', {
+      configurable: true,
+      get() { throw new Error('storage blocked'); }
+    });
+
+    try {
+      expect(service.attemptAutoRedirect(OIDC_STATUS)).toBe('budget-exhausted');
+      expect(navSpy).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(window, 'sessionStorage', { configurable: true, value: original });
+    }
+  });
+
+  it('fails closed when sessionStorage silently discards writes (probe read-back mismatch)', () => {
+    const { service, navSpy } = setup();
+    const original = window.sessionStorage;
+    Object.defineProperty(window, 'sessionStorage', {
+      configurable: true,
+      value: { setItem() { /* accepted but discarded */ }, getItem() { return null; }, removeItem() { /* noop */ } }
+    });
+
+    try {
+      expect(service.attemptAutoRedirect(OIDC_STATUS)).toBe('budget-exhausted');
+      expect(navSpy).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(window, 'sessionStorage', { configurable: true, value: original });
+    }
+  });
+});

--- a/src/app/core/services/sso-redirect.service.ts
+++ b/src/app/core/services/sso-redirect.service.ts
@@ -1,0 +1,116 @@
+import { inject, Injectable } from '@angular/core';
+import { AuthenticationService, ILoginStatus } from './authentication.service';
+import { buildLoginRedirectUrl, isSafeReturnTo } from '../utils/login-redirect.util';
+
+const REDIRECT_BUDGET_KEY = 'kip.ssoRedirectAttempts';
+const MAX_REDIRECT_ATTEMPTS = 3;
+const ADMIN_LOGIN_URL = '/admin/#/login'; // non-OIDC same-origin fallback login
+
+export type TAutoRedirectOutcome = 'redirected' | 'budget-exhausted';
+
+/**
+ * Owns the cookie-mode SSO redirect: where to send the browser to sign in, and a reload-surviving
+ * attempt budget so a kiosk with oidcAutoLogin cannot loop forever. The budget lives in
+ * sessionStorage (per-tab, cleared on a fresh session), resets on a confirmed login, and is bypassed
+ * by an explicit user sign-in.
+ */
+@Injectable({ providedIn: 'root' })
+export class SsoRedirectService {
+  private readonly auth = inject(AuthenticationService);
+
+  public attempts(): number {
+    try {
+      const raw = window.sessionStorage.getItem(REDIRECT_BUDGET_KEY);
+      const n = raw ? parseInt(raw, 10) : 0;
+      return Number.isFinite(n) && n > 0 ? n : 0;
+    } catch {
+      return 0;
+    }
+  }
+
+  public isBudgetExhausted(): boolean {
+    return this.attempts() >= MAX_REDIRECT_ATTEMPTS;
+  }
+
+  public resetBudget(): void {
+    try {
+      window.sessionStorage.removeItem(REDIRECT_BUDGET_KEY);
+    } catch {
+      /* ignore */
+    }
+  }
+
+  private recordAttempt(): void {
+    try {
+      window.sessionStorage.setItem(REDIRECT_BUDGET_KEY, String(this.attempts() + 1));
+    } catch {
+      /* ignore */
+    }
+  }
+
+  /**
+   * Whether the reload-surviving budget storage actually works. If sessionStorage is blocked (some
+   * kiosk WebViews, private modes), the budget cannot bound a cross-reload loop, so auto-redirect must
+   * fail closed rather than redirect forever.
+   */
+  private budgetStorageWorks(): boolean {
+    try {
+      const probe = `${REDIRECT_BUDGET_KEY}.probe`;
+      window.sessionStorage.setItem(probe, '1');
+      // Read back: a storage that accepts writes but silently discards them (some locked-down kiosk
+      // WebViews) would otherwise leave the budget permanently at 0 and loop. Fail closed on a mismatch.
+      const persisted = window.sessionStorage.getItem(probe) === '1';
+      window.sessionStorage.removeItem(probe);
+      return persisted;
+    } catch {
+      return false;
+    }
+  }
+
+  private resolveLoginUrl(status: ILoginStatus | null): string {
+    if (status?.oidcEnabled && status.oidcLoginUrl) {
+      return status.oidcLoginUrl;
+    }
+    return ADMIN_LOGIN_URL;
+  }
+
+  private currentReturnTo(): string | undefined {
+    const relative = window.location.pathname + window.location.search + window.location.hash;
+    return isSafeReturnTo(relative) ? relative : undefined;
+  }
+
+  /**
+   * Bootstrap auto-redirect to the SK login. Honors the budget, records an attempt and navigates, or
+   * reports the budget is spent so the caller can show the auth-blocked recovery state instead.
+   */
+  public attemptAutoRedirect(status: ILoginStatus | null): TAutoRedirectOutcome {
+    // Fail closed: if the budget cannot be tracked across reloads, do not auto-redirect (an explicit
+    // user Sign in still can). Treating an untrackable budget as "0 attempts" would loop forever.
+    if (!this.budgetStorageWorks() || this.isBudgetExhausted()) {
+      return 'budget-exhausted';
+    }
+    this.recordAttempt();
+    this.navigate(buildLoginRedirectUrl({
+      loginUrl: this.resolveLoginUrl(status),
+      returnTo: this.currentReturnTo()
+    }));
+    return 'redirected';
+  }
+
+  /**
+   * Explicit user sign-in (recovery). Resets the budget and disables SK auto-login (noAutoLogin) so a
+   * manual retry is not immediately bounced back by an auto-login loop.
+   */
+  public manualSignIn(): void {
+    this.resetBudget();
+    this.navigate(buildLoginRedirectUrl({
+      loginUrl: this.resolveLoginUrl(this.auth.loginStatusValue),
+      returnTo: this.currentReturnTo(),
+      noAutoLogin: true
+    }));
+  }
+
+  protected navigate(url: string): void {
+    window.location.replace(url);
+  }
+}

--- a/src/app/core/services/storage.service.ts
+++ b/src/app/core/services/storage.service.ts
@@ -6,8 +6,10 @@ import { IConfig } from "../interfaces/app-settings.interfaces";
 import { compare } from 'compare-versions';
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { Subject } from 'rxjs/internal/Subject';
-import { tap, concatMap, catchError, lastValueFrom, BehaviorSubject } from 'rxjs';
+import { tap, concatMap, catchError, lastValueFrom, BehaviorSubject, EMPTY, timeout } from 'rxjs';
 import { AuthenticationService } from './authentication.service';
+
+const REMOTE_CONFIG_TIMEOUT_MS = 5000; // bounded so a hung applicationData fetch cannot stall the bootstrap
 
 export interface Config {
   name: string,
@@ -84,7 +86,15 @@ export class StorageService {
 
     // Patch request queue to insure JSON Patch requests to SK server don't run over each other and cause collisions/conflicts. SK does not handle multiple async applicationData access calls
     this.patchQueue$
-      .pipe(concatMap((arg: IPatchAction) => this.patch(arg)), takeUntilDestroyed())
+      .pipe(
+        // Keep the queue alive when one patch fails (e.g. a read-only session's 401): without this,
+        // a thrown inner error terminates the subscription and silently drops every later save.
+        concatMap((arg: IPatchAction) => this.patch(arg).pipe(catchError((err) => {
+          console.error('[Storage Service] Config patch failed; keeping the queue alive:', err);
+          return EMPTY;
+        }))),
+        takeUntilDestroyed()
+      )
       .subscribe(() => { /* queue item processed */ });
   }
 
@@ -223,7 +233,7 @@ export class StorageService {
     }
 
     try {
-      const remoteConfig = await lastValueFrom(this.http.get<IConfig>(url));
+      const remoteConfig = await lastValueFrom(this.http.get<IConfig>(url).pipe(timeout(REMOTE_CONFIG_TIMEOUT_MS)));
       if (this._logIO) {
         const appVer: unknown = (remoteConfig && typeof remoteConfig === 'object') ? (remoteConfig as IConfig)?.app?.configVersion : undefined;
         console.debug('[StorageService.getConfig Response]', { scope, configName, ver, appConfigVersion: appVer });

--- a/src/app/core/utils/login-redirect.util.spec.ts
+++ b/src/app/core/utils/login-redirect.util.spec.ts
@@ -24,6 +24,11 @@ describe('isSafeReturnTo', () => {
     expect(isSafeReturnTo('/\\/evil.example')).toBe(false);
   });
 
+  it('rejects a dot-segment path that normalizes to a protocol-relative path', () => {
+    expect(isSafeReturnTo('/a/..//evil.example')).toBe(false);
+    expect(isSafeReturnTo('/foo/../..//evil.example')).toBe(false);
+  });
+
   it('rejects control characters', () => {
     expect(isSafeReturnTo('/path\x00')).toBe(false);
     expect(isSafeReturnTo('/path\nmore')).toBe(false);

--- a/src/app/core/utils/login-redirect.util.spec.ts
+++ b/src/app/core/utils/login-redirect.util.spec.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { isSafeReturnTo, buildLoginRedirectUrl } from './login-redirect.util';
+
+describe('isSafeReturnTo', () => {
+  it('accepts a site-relative path', () => {
+    expect(isSafeReturnTo('/dashboard')).toBe(true);
+    expect(isSafeReturnTo('/dashboard/2?foo=bar')).toBe(true);
+  });
+
+  it('rejects empty / non-string', () => {
+    expect(isSafeReturnTo('')).toBe(false);
+    expect(isSafeReturnTo(null)).toBe(false);
+    expect(isSafeReturnTo(undefined)).toBe(false);
+  });
+
+  it('rejects protocol-relative and absolute URLs', () => {
+    expect(isSafeReturnTo('//evil.example')).toBe(false);
+    expect(isSafeReturnTo('https://evil.example/x')).toBe(false);
+    expect(isSafeReturnTo('http://evil.example')).toBe(false);
+  });
+
+  it('rejects a backslash (browsers normalize it to /)', () => {
+    expect(isSafeReturnTo('/\\evil.example')).toBe(false);
+    expect(isSafeReturnTo('/\\/evil.example')).toBe(false);
+  });
+
+  it('rejects control characters', () => {
+    expect(isSafeReturnTo('/path\x00')).toBe(false);
+    expect(isSafeReturnTo('/path\nmore')).toBe(false);
+    expect(isSafeReturnTo('/path\x7f')).toBe(false);
+  });
+
+  it('rejects a non-relative target (no leading slash)', () => {
+    expect(isSafeReturnTo('dashboard')).toBe(false);
+    expect(isSafeReturnTo('javascript:alert(1)')).toBe(false);
+  });
+
+  it('rejects the login self-route (avoids a redirect loop)', () => {
+    expect(isSafeReturnTo('/login')).toBe(false);
+  });
+});
+
+describe('buildLoginRedirectUrl', () => {
+  it('appends a validated returnTo to a query-style (OIDC) login URL', () => {
+    const url = buildLoginRedirectUrl({ loginUrl: '/signalk/v1/auth/oidc/login', returnTo: '/dashboard' });
+    expect(url).toBe('/signalk/v1/auth/oidc/login?returnTo=%2Fdashboard');
+  });
+
+  it('drops an unsafe returnTo but still returns the login URL', () => {
+    const url = buildLoginRedirectUrl({ loginUrl: '/signalk/v1/auth/oidc/login', returnTo: '//evil.example' });
+    expect(url).toBe('/signalk/v1/auth/oidc/login');
+  });
+
+  it('adds noAutoLogin for a recovery (manual) sign-in', () => {
+    const url = buildLoginRedirectUrl({ loginUrl: '/signalk/v1/auth/oidc/login', returnTo: '/x', noAutoLogin: true });
+    expect(url).toBe('/signalk/v1/auth/oidc/login?returnTo=%2Fx&noAutoLogin=true');
+  });
+
+  it('places params in the hash fragment for an admin hash-route login URL', () => {
+    const url = buildLoginRedirectUrl({ loginUrl: '/admin/#/login', noAutoLogin: true });
+    expect(url).toBe('/admin/#/login?noAutoLogin=true');
+  });
+
+  it('returns the login URL unchanged when there are no params', () => {
+    expect(buildLoginRedirectUrl({ loginUrl: '/signalk/v1/auth/oidc/login' })).toBe('/signalk/v1/auth/oidc/login');
+  });
+});

--- a/src/app/core/utils/login-redirect.util.ts
+++ b/src/app/core/utils/login-redirect.util.ts
@@ -33,6 +33,11 @@ export function isSafeReturnTo(target: string | null | undefined): boolean {
   if (resolved.origin !== window.location.origin) {
     return false;
   }
+  // Reject a normalized protocol-relative path (e.g. raw '/a/..//evil' resolves to '//evil'), so the
+  // check holds on the resolved path, not just the raw string.
+  if (resolved.pathname.startsWith('//')) {
+    return false;
+  }
   return !SELF_ROUTE_PATHS.includes(resolved.pathname);
 }
 

--- a/src/app/core/utils/login-redirect.util.ts
+++ b/src/app/core/utils/login-redirect.util.ts
@@ -1,0 +1,72 @@
+// KIP routes that must never be a returnTo target — redirecting back to them would loop the
+// SSO bounce instead of returning the user to real content.
+const SELF_ROUTE_PATHS = ['/login'];
+
+/**
+ * Validates a returnTo target for the SSO redirect. Accepts only site-relative paths on the app's
+ * own origin; rejects protocol-relative (`//host`), backslash (normalized to `/` by browsers),
+ * control characters, absolute/scheme URLs, cross-origin targets, and KIP's own login route (loop).
+ * Mirrors the Signal K server's loginRedirect validation so KIP cannot construct an open redirect.
+ */
+export function isSafeReturnTo(target: string | null | undefined): boolean {
+  if (!target || typeof target !== 'string') {
+    return false;
+  }
+  if (!target.startsWith('/') || target.startsWith('//')) {
+    return false;
+  }
+  if (target.includes('\\')) {
+    return false;
+  }
+  for (let i = 0; i < target.length; i++) {
+    const code = target.charCodeAt(i);
+    if (code < 0x20 || code === 0x7f) {
+      return false;
+    }
+  }
+  let resolved: URL;
+  try {
+    resolved = new URL(target, window.location.origin);
+  } catch {
+    return false;
+  }
+  if (resolved.origin !== window.location.origin) {
+    return false;
+  }
+  return !SELF_ROUTE_PATHS.includes(resolved.pathname);
+}
+
+/**
+ * Builds the login redirect URL, appending a validated `returnTo` and an optional `noAutoLogin`
+ * flag. Handles both query-style login URLs (OIDC, e.g. `/signalk/v1/auth/oidc/login`) and hash
+ * routes (admin login, e.g. `/admin/#/login`) by placing the params in the correct component.
+ * An unsafe `returnTo` is dropped (the redirect still proceeds without it).
+ */
+export function buildLoginRedirectUrl(opts: {
+  loginUrl: string;
+  returnTo?: string | null;
+  noAutoLogin?: boolean;
+}): string {
+  const params: [string, string][] = [];
+  if (opts.returnTo && isSafeReturnTo(opts.returnTo)) {
+    params.push(['returnTo', opts.returnTo]);
+  }
+  if (opts.noAutoLogin) {
+    params.push(['noAutoLogin', 'true']);
+  }
+  if (params.length === 0) {
+    return opts.loginUrl;
+  }
+
+  const query = params.map(([k, v]) => `${k}=${encodeURIComponent(v)}`).join('&');
+  const hashIndex = opts.loginUrl.indexOf('#');
+  if (hashIndex >= 0) {
+    // Hash route: the params belong to the hash fragment's own query string.
+    const base = opts.loginUrl.slice(0, hashIndex);
+    const hash = opts.loginUrl.slice(hashIndex);
+    const sep = hash.includes('?') ? '&' : '?';
+    return `${base}${hash}${sep}${query}`;
+  }
+  const sep = opts.loginUrl.includes('?') ? '&' : '?';
+  return `${opts.loginUrl}${sep}${query}`;
+}

--- a/src/app/widgets/widget-freeboardsk/freeboard-sk-url.util.spec.ts
+++ b/src/app/widgets/widget-freeboardsk/freeboard-sk-url.util.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { buildFreeboardSkUrl } from './freeboard-sk-url.util';
+
+describe('buildFreeboardSkUrl', () => {
+  it('cookie mode: uses the served origin and no token, ignoring a cross-origin server URL and any token', () => {
+    expect(
+      buildFreeboardSkUrl({
+        cookieMode: true,
+        appOrigin: 'https://boat.hal:4430',
+        serverUrl: 'https://elsewhere.example:9999',
+        token: 'should-not-appear'
+      })
+    ).toBe('https://boat.hal:4430/@signalk/freeboard-sk/');
+  });
+
+  it('token mode with a token: uses the server URL and appends ?token=', () => {
+    expect(
+      buildFreeboardSkUrl({
+        cookieMode: false,
+        appOrigin: 'https://app.example',
+        serverUrl: 'https://boat.example:3000',
+        token: 'abc123'
+      })
+    ).toBe('https://boat.example:3000/@signalk/freeboard-sk/?token=abc123');
+  });
+
+  it('token mode without a token: uses the server URL and no token param', () => {
+    expect(
+      buildFreeboardSkUrl({
+        cookieMode: false,
+        appOrigin: 'https://app.example',
+        serverUrl: 'https://boat.example:3000',
+        token: null
+      })
+    ).toBe('https://boat.example:3000/@signalk/freeboard-sk/');
+  });
+});

--- a/src/app/widgets/widget-freeboardsk/freeboard-sk-url.util.ts
+++ b/src/app/widgets/widget-freeboardsk/freeboard-sk-url.util.ts
@@ -1,0 +1,23 @@
+const FREEBOARD_SK_PATH = '/@signalk/freeboard-sk/';
+
+/**
+ * Builds the embedded Freeboard-SK iframe URL.
+ *
+ * In cookie mode the iframe must load from the origin KIP is served from (proxy mode leaves the
+ * configured server URL cross-origin) and carry no token, so the same-origin session cookie
+ * authenticates it. In token mode it loads from the configured server URL and appends the JWT as a
+ * query param when one is present.
+ */
+export function buildFreeboardSkUrl(params: {
+  cookieMode: boolean;
+  appOrigin: string;
+  serverUrl: string;
+  token?: string | null;
+}): string {
+  if (params.cookieMode) {
+    return `${params.appOrigin}${FREEBOARD_SK_PATH}`;
+  }
+  return params.token
+    ? `${params.serverUrl}${FREEBOARD_SK_PATH}?token=${params.token}`
+    : `${params.serverUrl}${FREEBOARD_SK_PATH}`;
+}

--- a/src/app/widgets/widget-freeboardsk/widget-freeboardsk.component.ts
+++ b/src/app/widgets/widget-freeboardsk/widget-freeboardsk.component.ts
@@ -5,6 +5,7 @@ import { AfterViewInit, Component, ElementRef, effect, inject, input, OnDestroy,
 import { ChangeDetectionStrategy } from '@angular/core';
 import { SafePipe } from "../../core/pipes/safe.pipe";
 import { generateSwipeScript } from '../../core/utils/iframe-inputs-inject.utils';
+import { buildFreeboardSkUrl } from './freeboard-sk-url.util';
 import { WidgetRuntimeDirective } from '../../core/directives/widget-runtime.directive';
 import { IWidgetSvcConfig } from '../../core/interfaces/widgets-interface';
 import { AppService, ITheme } from '../../core/services/app-service';
@@ -57,10 +58,12 @@ export class WidgetFreeboardskComponent implements AfterViewInit, OnDestroy {
       const token = this.authToken();
 
       untracked(() => {
-        const loginToken = token?.token;
-        this.widgetUrl = loginToken
-          ? `${this.appSettings.signalkUrl.url}/@signalk/freeboard-sk/?token=${loginToken}`
-          : `${this.appSettings.signalkUrl.url}/@signalk/freeboard-sk/`;
+        this.widgetUrl = buildFreeboardSkUrl({
+          cookieMode: this.auth.authMode === 'cookie',
+          appOrigin: window.location.origin,
+          serverUrl: this.appSettings.signalkUrl.url,
+          token: token?.token
+        });
       });
     });
 

--- a/src/app/widgets/widget-login/widget-login.component.html
+++ b/src/app/widgets/widget-login/widget-login.component.html
@@ -1,0 +1,5 @@
+@if (redirecting) {
+  <div class="sso-redirecting" role="status" aria-live="polite">
+    <p>Signing in via Signal K…</p>
+  </div>
+}

--- a/src/app/widgets/widget-login/widget-login.component.ts
+++ b/src/app/widgets/widget-login/widget-login.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit, inject } from '@angular/core';
 import { ChangeDetectionStrategy } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { AuthenticationService } from "../../core/services/authentication.service";
+import { SsoRedirectService } from '../../core/services/sso-redirect.service';
 import { SettingsService } from '../../core/services/settings.service';
 import { ModalUserCredentialComponent } from '../../core/components/modal-user-credential/modal-user-credential.component';
 import { IConnectionConfig } from "../../core/interfaces/app-settings.interfaces";
@@ -18,12 +19,21 @@ import { ToastService } from '../../core/services/toast.service';
 export class WidgetLoginComponent implements OnInit {
   dialog = inject(MatDialog);
   private auth = inject(AuthenticationService);
+  private ssoRedirect = inject(SsoRedirectService);
   private toast = inject(ToastService);
   private settings = inject(SettingsService);
 
   public connectionConfig: IConnectionConfig = null;
+  public redirecting = false;
 
   ngOnInit(): void {
+    if (this.auth.authMode === 'cookie') {
+      // Same-origin: no KIP-managed credential form. Redirect to the SK/SSO login instead (explicit
+      // sign-in: resets the redirect budget and disables auto-login so this is not auto-bounced).
+      this.redirecting = true;
+      this.ssoRedirect.manualSignIn();
+      return;
+    }
     this.connectionConfig = this.settings.getConnectionConfig();
     this.openUserCredentialModal("Sign in failed: Incorrect user/password. Enter valide credentials or access the Confifuration/Settings menu, validate the server URL or/and disable the user Sign in option");
   }

--- a/src/app/widgets/widget-login/widget-login.component.ts
+++ b/src/app/widgets/widget-login/widget-login.component.ts
@@ -51,7 +51,7 @@ export class WidgetLoginComponent implements OnInit {
   }
 
   private serverLogin(newUrl?: string) {
-    this.auth.login({ usr: this.connectionConfig.loginName, pwd: this.connectionConfig.loginPassword, newUrl })
+    this.auth.login({ usr: this.connectionConfig.loginName, pwd: this.connectionConfig.loginPassword ?? '', newUrl })
     .then(() => {
       this.settings.reloadApp();
     })

--- a/src/default-config/config.blank.const.ts
+++ b/src/default-config/config.blank.const.ts
@@ -37,7 +37,6 @@ export const DefaultConnectionConfig: IConnectionConfig = {
   "signalKSubscribeAll": false,
   "useDeviceToken": false,
   "loginName": null,
-  "loginPassword": null,
   "useSharedConfig": false,
   "sharedConfigName": "default"
 }

--- a/src/default-config/config.demo.const.ts
+++ b/src/default-config/config.demo.const.ts
@@ -778,7 +778,6 @@ export const DemoConnectionConfig: IConnectionConfig = {
   "signalKSubscribeAll": false,
   "useDeviceToken": false,
   "loginName": null,
-  "loginPassword": null,
   "useSharedConfig": false,
   "sharedConfigName": "default"
 }

--- a/src/test-helpers/local-storage.test-helper.ts
+++ b/src/test-helpers/local-storage.test-helper.ts
@@ -1,0 +1,63 @@
+/**
+ * jsdom with an opaque origin (no document URL) does not expose Web Storage, so
+ * `window.localStorage` / the global `localStorage` are undefined under the unit-test
+ * runner. Services that read storage in their constructor then crash. This helper
+ * installs a minimal in-memory Storage when one is missing and returns a cleared
+ * instance for deterministic per-test seeding. It is a no-op (just clears) in
+ * environments that already provide localStorage.
+ */
+class MemoryStorage implements Storage {
+  private store = new Map<string, string>();
+
+  get length(): number {
+    return this.store.size;
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.store.has(key) ? (this.store.get(key) as string) : null;
+  }
+
+  key(index: number): string | null {
+    return Array.from(this.store.keys())[index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.store.set(key, String(value));
+  }
+}
+
+export function ensureLocalStorage(): Storage {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const g = globalThis as any;
+
+  let existing: Storage | undefined;
+  try {
+    existing = g.localStorage;
+  } catch {
+    existing = undefined;
+  }
+
+  if (!existing) {
+    const mem = new MemoryStorage();
+    Object.defineProperty(g, 'localStorage', { configurable: true, value: mem });
+    if (typeof window !== 'undefined') {
+      try {
+        Object.defineProperty(window, 'localStorage', { configurable: true, value: mem });
+      } catch {
+        /* ignore environments that forbid redefining window.localStorage */
+      }
+    }
+    existing = mem;
+  }
+
+  existing.clear();
+  return existing;
+}

--- a/src/test-helpers/local-storage.test-helper.ts
+++ b/src/test-helpers/local-storage.test-helper.ts
@@ -34,25 +34,25 @@ class MemoryStorage implements Storage {
   }
 }
 
-export function ensureLocalStorage(): Storage {
+function ensureStorage(prop: 'localStorage' | 'sessionStorage'): Storage {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const g = globalThis as any;
 
   let existing: Storage | undefined;
   try {
-    existing = g.localStorage;
+    existing = g[prop];
   } catch {
     existing = undefined;
   }
 
   if (!existing) {
     const mem = new MemoryStorage();
-    Object.defineProperty(g, 'localStorage', { configurable: true, value: mem });
+    Object.defineProperty(g, prop, { configurable: true, value: mem });
     if (typeof window !== 'undefined') {
       try {
-        Object.defineProperty(window, 'localStorage', { configurable: true, value: mem });
+        Object.defineProperty(window, prop, { configurable: true, value: mem });
       } catch {
-        /* ignore environments that forbid redefining window.localStorage */
+        /* ignore environments that forbid redefining the storage */
       }
     }
     existing = mem;
@@ -60,4 +60,16 @@ export function ensureLocalStorage(): Storage {
 
   existing.clear();
   return existing;
+}
+
+export function ensureLocalStorage(): Storage {
+  return ensureStorage('localStorage');
+}
+
+/**
+ * Same in-memory shim as {@link ensureLocalStorage}, for the SSO redirect budget which lives in
+ * sessionStorage (also undefined under the jsdom opaque origin).
+ */
+export function ensureSessionStorage(): Storage {
+  return ensureStorage('sessionStorage');
 }

--- a/src/test.ts
+++ b/src/test.ts
@@ -226,6 +226,15 @@ class AuthenticationServiceStub {
   public isLoggedIn$ = this._isLoggedIn$.asObservable();
   private _authToken$ = new BehaviorSubject<{ expiry: number | null; token: string | null; isDeviceAccessToken: boolean }>(null);
   public authToken$ = this._authToken$.asObservable();
+  // Cookie-mode session surface (Unit 3). Default to token mode so existing specs are unaffected.
+  public authMode: 'cookie' | 'token' = 'token';
+  private _loginStatus$ = new BehaviorSubject<unknown>(null);
+  public loginStatus$ = this._loginStatus$.asObservable();
+  private _isUserSession$ = new BehaviorSubject<boolean>(false);
+  public isUserSession$ = this._isUserSession$.asObservable();
+  private _canWriteUserData$ = new BehaviorSubject<boolean>(false);
+  public canWriteUserData$ = this._canWriteUserData$.asObservable();
+  refreshLoginStatus = async (): Promise<unknown> => null;
   login = async () => { this._isLoggedIn$.next(true); };
   logout = async () => { this._isLoggedIn$.next(false); this._authToken$.next(null); };
 }

--- a/src/test.ts
+++ b/src/test.ts
@@ -215,7 +215,7 @@ class MatBottomSheetRefStub { dismiss(): void { /* noop */ } }
 class MatDialogRefStub { close(): void { /* noop */ } }
 class AppNetworkInitServiceStub {
   private _bootstrapStatusSubject = new BehaviorSubject<'starting' | 'ready' | 'degraded'>('ready');
-  private _bootstrapIssueSubject = new BehaviorSubject<{ reason: 'none' | 'missing-shared-config' | 'network-unreachable' | 'unauthorized' | 'unknown'; statusCode?: number; sharedConfigName?: string; legacyUpgradeAvailable?: boolean }>({ reason: 'none' });
+  private _bootstrapIssueSubject = new BehaviorSubject<{ reason: 'none' | 'missing-shared-config' | 'network-unreachable' | 'unauthorized' | 'unknown' | 'auth-blocked'; statusCode?: number; sharedConfigName?: string; legacyUpgradeAvailable?: boolean; cause?: 'budget-exhausted' | 'sign-in-required' }>({ reason: 'none' });
 
   public bootstrapStatus$ = this._bootstrapStatusSubject.asObservable();
   public bootstrapIssue$ = this._bootstrapIssueSubject.asObservable();
@@ -234,7 +234,10 @@ class AuthenticationServiceStub {
   public isUserSession$ = this._isUserSession$.asObservable();
   private _canWriteUserData$ = new BehaviorSubject<boolean>(false);
   public canWriteUserData$ = this._canWriteUserData$.asObservable();
+  public get loginStatusValue(): unknown { return this._loginStatus$.getValue(); }
   refreshLoginStatus = async (): Promise<unknown> => null;
+  authModeForConfig = (): 'cookie' | 'token' => this.authMode;
+  deleteToken = () => { this._authToken$.next(null); this._isLoggedIn$.next(false); };
   login = async () => { this._isLoggedIn$.next(true); };
   logout = async () => { this._isLoggedIn$.next(false); this._authToken$.next(null); };
 }


### PR DESCRIPTION
## Motivation

KIP manages its own username/password login and JWT. When KIP is served by a Signal K server that authenticates via OIDC/SSO, users logged in through SSO have no SK-local password, so KIP's login form can't authenticate them — they hit a second login they can't satisfy.

This adds the Signal K-documented embedded-webapp auth pattern as an **opt-in, auto-detected mode**, without removing the existing token model.

## Approach (dual-mode, detected by origin)

- **Same-origin** (KIP served by the SK server): the httpOnly session cookie carries auth. Session state is read from `GET /skServer/loginStatus`; when not logged in, KIP redirects to the login URL loginStatus advertises (OIDC when enabled, else admin login). No JWT in localStorage and no token in the WS query string — the cookie authorizes REST, the WS upgrade, and the embedded Freeboard iframe.
- **Cross-origin** (KIP as a standalone PWA pointed at a remote server): unchanged — keeps the JWT/device-token model, since cookies can't flow cross-origin.
- Mode is derived synchronously by comparing the configured server origin to KIP's own origin.

## Backward compatibility

Additive: cross-origin/standalone behavior is unchanged, and same-origin-without-SSO still works via the cookie session. The "logged-in"/storage-routing gating moves from token-presence to a loginStatus/session notion so cookie sessions are first-class.

## Security hardening (independent of mode)

- Stop persisting the plaintext login password in localStorage (the session JWT is the cross-reload credential; no silent re-POST of stored credentials).
- `withCredentials` scoped to same-origin requests; bootstrap network calls are timeout-bounded; the config patch queue survives a failed write; open-redirect guard on the SSO return URL.

## Testing

Unit tests (Vitest) for mode detection, interceptor behavior in both modes, loginStatus-driven state, the SSO redirect budget/recovery, and the return-URL guard. Verified live against signalk-server v2.27.0 behind OIDC SSO: cookie authorizes REST + WS with no stored JWT, and not-logged-in triggers the SSO redirect.

*Note: ~50 component specs fail pre-existing under the unit runner due to a jsdom localStorage limitation unrelated to this change.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
