### PR TITLE
feat: multiple profiles (named configuration slots)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# Unreleased
+## New Features
+* Same-origin Signal K sign-in (SSO): when KIP is served by a Signal K server on the same origin, it authenticates with the server's session cookie instead of its own username/password form. With an OIDC/SSO server, KIP joins the existing session and redirects to the server login when needed — no second sign-in, and OIDC-provisioned users (who have no server-local password) can use KIP. Cross-origin standalone use (a PWA pointed at a remote server) keeps the existing token sign-in.
+## Improvements
+* The Connectivity settings show your Signal K session identity in same-origin mode (including a read-only-session indicator) instead of a credential form.
+* Security: the Signal K login password is no longer stored in the browser; it is used only in memory to obtain a session token.
+## Fixes
+* OIDC/SSO users could not sign in to KIP because it required a server-local password they do not have; same-origin SSO mode resolves this.
+## Behavior changes
+* Cross-origin token sign-in: the Signal K server provides no token-refresh endpoint, so the stored password is no longer re-sent to renew a session. The session token still persists across browser reloads until it expires; when it expires you are prompted to sign in again.
+
 # v4.8.0
 ## New Features
 * Solar Charger Widget: Get instant clarity on your solar system with a compact, purpose-built Solar Charger Widget. Track individual panels or full arrays in real time, including State of Charge, remaining capacity, remaining time, voltage, current, power flow, and temperature. Device discovery is automatic, and Zones support keeps warnings and alarms state highly visible.

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -27,6 +27,7 @@ import { ConfigurationUpgradeService } from './core/services/configuration-upgra
 import { RemoteDashboardsService } from './core/services/remote-dashboards.service';
 import { ToastService } from './core/services/toast.service';
 import { AppNetworkInitService, IBootstrapIssue } from './core/services/app-initNetwork.service';
+import { SsoRedirectService } from './core/services/sso-redirect.service';
 import { DashboardHistorySeriesSyncService } from './core/services/dashboard-history-series-sync.service';
 
 @Component({
@@ -46,6 +47,7 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
   private readonly _deltaService = inject(SignalKDeltaService);
   private readonly _connectionStateMachine = inject(ConnectionStateMachine);
   private readonly _appNetworkInit = inject(AppNetworkInitService);
+  private readonly _ssoRedirect = inject(SsoRedirectService);
   private readonly _historySeriesReconcile = inject(DashboardHistorySeriesSyncService);
   public readonly authenticationService = inject(AuthenticationService);
   private readonly _dataSet = inject(DatasetStreamService);
@@ -82,6 +84,7 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
   private scheduledOpen: number | null = null;
   private readonly OPEN_DELAY_MS = 300; // should match/ exceed sidenav close animation time
   private missingConfigPromptShown = false;
+  private authBlockedPromptShown = false;
 
   // Stable handler refs (prevent leak from rebinding)
   private readonly _swipeLeftHandler = () => this.onSwipeLeft();
@@ -226,6 +229,23 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
             this.settings.resetSettings();
           }
         });
+    });
+
+    // Cookie-mode auth blocked (SSO auto-login looped out of budget, or sign-in required): offer an
+    // explicit Sign in that resets the budget and disables auto-login so it is not auto-bounced.
+    effect(() => {
+      const issue = this.bootstrapIssue();
+      if (issue.reason !== 'auth-blocked' || this.authBlockedPromptShown) {
+        return;
+      }
+      this.authBlockedPromptShown = true;
+      const message = issue.cause === 'budget-exhausted'
+        ? 'Automatic sign-in did not complete. Sign in to Signal K to continue.'
+        : 'Sign in to Signal K to access your configuration.';
+      const ref = this.toast.show(message, 0, true, 'warn', 'Sign in');
+      ref.onAction()
+        .pipe(takeUntilDestroyed(this._destroyRef))
+        .subscribe(() => this._ssoRedirect.manualSignIn());
     });
   }
 

--- a/src/app/core/components/options/configuration/config.component.html
+++ b/src/app/core/components/options/configuration/config.component.html
@@ -28,12 +28,12 @@
                 @if (!profile.isActive) {
                   <button mat-button color="accent" (click)="switchProfile(profile.name)">Switch</button>
                 }
-                <button mat-button (click)="renameProfile(profile.name)">Rename</button>
-                <button mat-button (click)="duplicateProfile(profile.name)">Duplicate</button>
+                <button mat-button [disabled]="!canWriteUserData()" (click)="renameProfile(profile.name)">Rename</button>
+                <button mat-button [disabled]="!canWriteUserData()" (click)="duplicateProfile(profile.name)">Duplicate</button>
                 <button
                   mat-button
                   color="warn"
-                  [disabled]="profile.isActive || profile.name === 'default' || profiles().length <= 1"
+                  [disabled]="profile.isActive || profile.name === 'default' || profiles().length <= 1 || !canWriteUserData()"
                   (click)="deleteProfile(profile.name)"
                   >
                   Delete
@@ -47,7 +47,10 @@
 
         <div class="formActionFooter">
           <mat-divider class="formActionDivider"></mat-divider>
-          <button mat-flat-button color="accent" (click)="createProfile()">New</button>
+          <button mat-flat-button color="accent" [disabled]="!canWriteUserData()" (click)="createProfile()">New</button>
+          @if (!canWriteUserData()) {
+            <p class="empty-note">Read-only session — profile changes are disabled.</p>
+          }
         </div>
       } @else {
         <div class="no-token-notice">
@@ -73,7 +76,7 @@
         </div>
         <div class="upload-btn btn-div">
           <input type="file" #fileInput (change)="uploadJsonConfig($event)" accept=".json" hidden />
-          <button mat-flat-button class="adv-btn" (click)="fileInput.click()">Import</button>
+          <button mat-flat-button class="adv-btn" [disabled]="!canWriteUserData()" (click)="fileInput.click()">Import</button>
         </div>
 
         <div class="demo-txt">

--- a/src/app/core/components/options/configuration/config.component.html
+++ b/src/app/core/components/options/configuration/config.component.html
@@ -47,8 +47,7 @@
 
         <div class="formActionFooter">
           <mat-divider class="formActionDivider"></mat-divider>
-          <button mat-flat-button color="accent" (click)="createProfile('current')">New from current</button>
-          <button mat-stroked-button (click)="createProfile('blank')">New blank</button>
+          <button mat-flat-button color="accent" (click)="createProfile()">New</button>
         </div>
       } @else {
         <div class="no-token-notice">

--- a/src/app/core/components/options/configuration/config.component.html
+++ b/src/app/core/components/options/configuration/config.component.html
@@ -1,237 +1,104 @@
 <div class="page-content">
   <p>
-    Recommended Reading: To understand configuration management and storage
-    options, consult the
+    A profile is a named set of dashboards, layouts and theme. Switching is remembered
+    <strong>on this device only</strong>, so each display can show a different profile from the same
+    Signal K login. See the
     <a routerLink="/help/configuration">Login and Configuration</a> help section.
   </p>
+
   <div class="flex-container">
     <div class="flex-item-rounded-card rounded-card-color">
-      <form
-        name="saveConfigForm"
-        (ngSubmit)="saveConfig(this.getActiveConfig(), saveConfigScope, saveConfigName)"
-        #saveConfigForm="ngForm"
-        >
-        <h3>Backup</h3>
-        <p style="margin-bottom: 16px">
-          Create a backup of the current active configuration on the server.
-        </p>
-        @if (hasToken) {
-          <div>
-            <mat-form-field style="width: 25%">
-              <mat-label>Scope</mat-label>
-              <mat-select
-                name="serverConfiScope"
-                [(ngModel)]="saveConfigScope"
-                required
-                >
-                <mat-option value="global"> Global </mat-option>
-                <mat-option value="user"> User </mat-option>
-              </mat-select>
-            </mat-form-field>
-            <mat-form-field style="width: 70%; padding-left: 3%">
-              <mat-label>Configuration Name</mat-label>
-              <input
-                matInput
-                name="serverConfigName"
-                placeholder="Enter a name for the configuration"
-                [(ngModel)]="saveConfigName"
-                [ngModelOptions]="{ standalone: false }"
-                required
-                />
-            </mat-form-field>
-            @if (!hasToken) {
-              <div>
-                Writing to the server requires "Login to Server" authentication or a
-                Device token
+      <h3>Profiles</h3>
+
+      @if (profilesAvailable()) {
+        <mat-divider></mat-divider>
+        <div class="profile-list">
+          @for (profile of profiles(); track profile.name) {
+            <div class="profile-row" [class.active]="profile.isActive">
+              <div class="profile-name">
+                @if (profile.isActive) {
+                  <mat-icon class="active-icon" svgIcon="dashboard-dashboard"></mat-icon>
+                }
+                <span>{{ profile.name }}</span>
+                @if (profile.isActive) {
+                  <span class="active-tag">Active on this device</span>
+                }
               </div>
-            }
-          </div>
-        } @else {
-          <div class="no-token-notice">
-            <p>Server authentication or Device Token required</p>
-          </div>
-        }
-        <div class="formActionFooter">
-          <mat-divider class="formActionDivider"></mat-divider>
-          <button
-            mat-flat-button
-            type="submit"
-            [disabled]="!hasToken || !saveConfigForm.valid"
-            color="accent"
-            >
-            Create
-          </button>
-        </div>
-      </form>
-    </div>
-    <div class="flex-item-rounded-card rounded-card-color">
-      <form
-        name="deleteConfigForm"
-        (ngSubmit)="deleteConfigByKey(deleteConfigKey)"
-        #deleteConfigForm="ngForm"
-        >
-        <h3>Delete</h3>
-        <p style="margin-bottom: 16px">
-          Select a backup configuration to permanently delete from the server.
-        </p>
-        @if (hasToken) {
-          <div>
-            <mat-form-field style="width: 100%">
-              <mat-label>Configuration</mat-label>
-              <mat-select
-                name="selectedDeleteItem"
-                [(ngModel)]="deleteConfigKey"
-                required
-                >
-                @for (config of serverConfigOptions(); track config.key) {
-                  <mat-option
-                    [value]="config.key"
-                    >
-                    {{ config.scope }} / {{ config.name }}
-                  </mat-option>
+              <div class="profile-actions">
+                @if (!profile.isActive) {
+                  <button mat-button color="accent" (click)="switchProfile(profile.name)">Switch</button>
                 }
-              </mat-select>
-            </mat-form-field>
-          </div>
-        } @else {
-          <div class="no-token-notice">
-            <p>Authentication or Device Token required</p>
-          </div>
-        }
+                <button mat-button (click)="renameProfile(profile.name)">Rename</button>
+                <button mat-button (click)="duplicateProfile(profile.name)">Duplicate</button>
+                <button
+                  mat-button
+                  color="warn"
+                  [disabled]="profile.isActive || profile.name === 'default' || profiles().length <= 1"
+                  (click)="deleteProfile(profile.name)"
+                  >
+                  Delete
+                </button>
+              </div>
+            </div>
+          } @empty {
+            <p class="empty-note">No profiles found yet.</p>
+          }
+        </div>
+
         <div class="formActionFooter">
           <mat-divider class="formActionDivider"></mat-divider>
-          <button
-            mat-flat-button
-            type="submit"
-            [disabled]="!hasToken || !deleteConfigForm.valid"
-            color="accent"
-            >
-            Delete
-          </button>
+          <button mat-flat-button color="accent" (click)="createProfile('current')">New from current</button>
+          <button mat-stroked-button (click)="createProfile('blank')">New blank</button>
         </div>
-      </form>
-    </div>
-    <div class="flex-item-rounded-card rounded-card-color">
-      <form [formGroup]="copyConfigForm" (ngSubmit)="copyConfig()">
-        <h3>Restore</h3>
-        <p style="margin-bottom: 16px">
-          Replace the current configuration with a backup from the server.
-        </p>
-        @if (hasToken) {
-          <div>
-            <mat-form-field style="width: 100%">
-              <mat-label>Configuration</mat-label>
-              <mat-select formControlName="sourceTarget">
-                @for (config of serverConfigOptions(); track config.key) {
-                  <mat-option
-                    [value]="config.key"
-                    >
-                    {{ config.scope }} / {{ config.name }}
-                  </mat-option>
-                }
-              </mat-select>
-            </mat-form-field>
-          </div>
-        } @else {
-          <div class="no-token-notice">
-            <p>Authentication or Device Token required</p>
-          </div>
-        }
-        <div class="formActionFooter">
-          <mat-divider class="formActionDivider"></mat-divider>
-          <button
-            mat-flat-button
-            type="submit"
-            color="accent"
-            [disabled]="!this.copyConfigForm.valid"
-            >
-            Restore
-          </button>
+      } @else {
+        <div class="no-token-notice">
+          <p>Profiles require logging in to Signal K with a user account.</p>
         </div>
-      </form>
+      }
     </div>
+
     <div class="flex-item-reset rounded-card-color">
       <h3>Advanced</h3>
       <div class="config-operation-container" style="margin-top: 20px">
         <div class="download-txt">
-          To reuse your configuration on different devices, simply login using the same credential
-            from any device (See <a routerLink="/help/configuration">Login and Configuration</a> for more information). If
-            you need to move your configuration between different Signal K servers, you can use Download
-            to obtain a copy of the active configuration to a file.
+          Download a copy of the active profile's configuration to a file, for backup or to move it
+          to another Signal K server.
         </div>
         <div class="download-btn btn-div">
-          <button
-            mat-flat-button
-            type="button"
-            class="adv-btn"
-            (click)="downloadJsonConfig()"
-            >
-            Download
-          </button>
+          <button mat-flat-button type="button" class="adv-btn" (click)="downloadJsonConfig()">Download</button>
         </div>
+
         <div class="upload-txt">
-            Select a configuration file to upload. The file must be a valid KIP
-            configuration file of JSON format.
-            <br /><strong>WARNING: This will permanently overwrite active configuration.</strong>
+          Import a KIP configuration file as a <strong>new profile</strong>. This never overwrites an
+          existing profile.
         </div>
         <div class="upload-btn btn-div">
-          <!-- Hidden file input -->
-          <input
-            type="file"
-            #fileInput
-            (change)="uploadJsonConfig($event)"
-            accept=".json"
-            hidden
-            />
-          <!-- Material button to trigger file input -->
-          <button mat-flat-button class="adv-btn" (click)="fileInput.click()">
-            Upload
-          </button>
+          <input type="file" #fileInput (change)="uploadJsonConfig($event)" accept=".json" hidden />
+          <button mat-flat-button class="adv-btn" (click)="fileInput.click()">Import</button>
         </div>
+
         <div class="demo-txt">
-            Load the demonstration configuration and connection to Signal K demo
-            server.
-            <br /><strong>WARNING: This will permanently reset your active configuration.</strong>
+          Load the demonstration configuration and connect to the Signal K demo server.
+          <br /><strong>WARNING: This replaces the active profile's configuration.</strong>
         </div>
         <div class="demo-btn btn-div">
-          <button
-            mat-flat-button
-            type="button"
-            class="adv-btn"
-            (click)="loadDemoConfig()"
-            >
-            Demo
-          </button>
+          <button mat-flat-button type="button" class="adv-btn" (click)="loadDemoConfig()">Demo</button>
         </div>
+
         <div class="reset-txt">
-            Reset all your settings to default. The default configuration has a
-            single Getting Started instruction widget. Your Signal K server
-            connection settings will remain.
-            <br /><strong>WARNING: This will permanently reset your active configuration.</strong>
+          Reset the active profile to defaults (a single Getting Started widget). Your Signal K
+          connection settings remain.
+          <br /><strong>WARNING: This replaces the active profile's configuration.</strong>
         </div>
         <div class="reset-btn btn-div">
-          <button
-            mat-flat-button
-            type="button"
-            class="adv-btn"
-            (click)="resetConfigToDefault()"
-            >
-            Default
-          </button>
+          <button mat-flat-button type="button" class="adv-btn" (click)="resetConfigToDefault()">Default</button>
         </div>
+
         <div class="config-txt">
-          Clear the current connection configuration. This only affects
-          Connectivity settings tab.
+          Clear the current connection configuration. This only affects the Connectivity settings tab.
         </div>
         <div class="config-btn btn-div">
-          <button
-            mat-flat-button
-            type="button"
-            class="adv-btn"
-            (click)="resetConnectionToDefault()"
-            >
-            Connection
-          </button>
+          <button mat-flat-button type="button" class="adv-btn" (click)="resetConnectionToDefault()">Connection</button>
         </div>
       </div>
     </div>

--- a/src/app/core/components/options/configuration/config.component.scss
+++ b/src/app/core/components/options/configuration/config.component.scss
@@ -154,3 +154,53 @@ a:link, a:visited {
 .config-btn {
   grid-area: config-btn;
 }
+
+.profile-list {
+  display: flex;
+  flex-direction: column;
+  margin-top: 8px;
+}
+
+.profile-row {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 8px 4px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.profile-row.active {
+  font-weight: 500;
+}
+
+.profile-name {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.active-icon {
+  flex: 0 0 auto;
+}
+
+.active-tag {
+  font-size: 12px;
+  font-style: italic;
+  opacity: 0.7;
+}
+
+.profile-actions {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+}
+
+.empty-note {
+  font-style: italic;
+  opacity: 0.7;
+  padding: 8px 4px;
+}

--- a/src/app/core/components/options/configuration/config.component.scss
+++ b/src/app/core/components/options/configuration/config.component.scss
@@ -169,7 +169,7 @@ a:link, a:visited {
   flex-wrap: wrap;
   gap: 8px;
   padding: 8px 4px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  border-bottom: 1px solid var(--mat-sys-outline-variant);
 }
 
 .profile-row.active {

--- a/src/app/core/components/options/configuration/config.component.spec.ts
+++ b/src/app/core/components/options/configuration/config.component.spec.ts
@@ -14,6 +14,7 @@ describe('SettingsConfigComponent', () => {
   let component: SettingsConfigComponent;
   let fixture: ComponentFixture<SettingsConfigComponent>;
   let isUserSessionSubject: BehaviorSubject<boolean>;
+  let canWriteUserDataSubject: BehaviorSubject<boolean>;
   let profilesSignal: ReturnType<typeof signal<IProfileSummary[]>>;
   let profileMock: {
     profiles: typeof profilesSignal;
@@ -33,6 +34,7 @@ describe('SettingsConfigComponent', () => {
 
   beforeEach(async () => {
     isUserSessionSubject = new BehaviorSubject<boolean>(false);
+    canWriteUserDataSubject = new BehaviorSubject<boolean>(true);
     profilesSignal = signal<IProfileSummary[]>([
       { name: 'default', isActive: false },
       { name: 'profileA', isActive: true }
@@ -56,7 +58,7 @@ describe('SettingsConfigComponent', () => {
     await TestBed.configureTestingModule({
       imports: [SettingsConfigComponent],
       providers: [
-        { provide: AuthenticationService, useValue: { isUserSession$: isUserSessionSubject.asObservable() } },
+        { provide: AuthenticationService, useValue: { isUserSession$: isUserSessionSubject.asObservable(), canWriteUserData$: canWriteUserDataSubject.asObservable() } },
         { provide: StorageService, useValue: { isAppDataSupported: true } },
         { provide: ToastService, useValue: toastMock },
         { provide: ProfileService, useValue: profileMock },
@@ -102,6 +104,16 @@ describe('SettingsConfigComponent', () => {
     fixture.detectChanges();
     expect(component['profilesAvailable']()).toBe(false);
     expect(profileMock.refresh).not.toHaveBeenCalled();
+  });
+
+  it('keeps profiles visible but disables the New (write) control for a read-only session', () => {
+    isUserSessionSubject.next(true);
+    canWriteUserDataSubject.next(false);
+    fixture.detectChanges();
+    expect(component['profilesAvailable']()).toBe(true);
+    expect(component['canWriteUserData']()).toBe(false);
+    const newBtn = fixture.nativeElement.querySelector('.formActionFooter button') as HTMLButtonElement | null;
+    expect(newBtn?.disabled).toBe(true);
   });
 
   it('switchProfile confirms then delegates to ProfileService', async () => {

--- a/src/app/core/components/options/configuration/config.component.spec.ts
+++ b/src/app/core/components/options/configuration/config.component.spec.ts
@@ -3,24 +3,17 @@ import { signal } from '@angular/core';
 import { BehaviorSubject, of } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { SettingsConfigComponent } from './config.component';
-import { AuthenticationService, IAuthorizationToken } from '../../../services/authentication.service';
+import { AuthenticationService } from '../../../services/authentication.service';
 import { StorageService } from '../../../services/storage.service';
 import { ToastService } from '../../../services/toast.service';
 import { SettingsService } from '../../../services/settings.service';
 import { ProfileService, IProfileSummary } from '../../../services/profile.service';
 import { DialogService } from '../../../services/dialog.service';
 
-const createToken = (overrides: Partial<IAuthorizationToken> = {}): IAuthorizationToken => ({
-  token: 'token',
-  expiry: Date.now() / 1000 + 3600,
-  isDeviceAccessToken: false,
-  ...overrides
-});
-
 describe('SettingsConfigComponent', () => {
   let component: SettingsConfigComponent;
   let fixture: ComponentFixture<SettingsConfigComponent>;
-  let authTokenSubject: BehaviorSubject<IAuthorizationToken | null>;
+  let isUserSessionSubject: BehaviorSubject<boolean>;
   let profilesSignal: ReturnType<typeof signal<IProfileSummary[]>>;
   let profileMock: {
     profiles: typeof profilesSignal;
@@ -39,7 +32,7 @@ describe('SettingsConfigComponent', () => {
   let toastMock: { show: ReturnType<typeof vi.fn> };
 
   beforeEach(async () => {
-    authTokenSubject = new BehaviorSubject<IAuthorizationToken | null>(null);
+    isUserSessionSubject = new BehaviorSubject<boolean>(false);
     profilesSignal = signal<IProfileSummary[]>([
       { name: 'default', isActive: false },
       { name: 'profileA', isActive: true }
@@ -63,7 +56,7 @@ describe('SettingsConfigComponent', () => {
     await TestBed.configureTestingModule({
       imports: [SettingsConfigComponent],
       providers: [
-        { provide: AuthenticationService, useValue: { authToken$: authTokenSubject.asObservable() } },
+        { provide: AuthenticationService, useValue: { isUserSession$: isUserSessionSubject.asObservable() } },
         { provide: StorageService, useValue: { isAppDataSupported: true } },
         { provide: ToastService, useValue: toastMock },
         { provide: ProfileService, useValue: profileMock },
@@ -96,18 +89,18 @@ describe('SettingsConfigComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('loads profiles when logged in with a user token', () => {
-    authTokenSubject.next(createToken({ isDeviceAccessToken: false }));
+  it('makes profiles available and loads them on a user session — cookie mode, no token', () => {
+    isUserSessionSubject.next(true);
     fixture.detectChanges();
-    expect(component.hasToken).toBe(true);
-    expect(component.isTokenTypeDevice).toBe(false);
+    expect(component['profilesAvailable']()).toBe(true);
     expect(profileMock.refresh).toHaveBeenCalled();
   });
 
-  it('does not load profiles for a device token (profiles are user-scope)', () => {
+  it('does not make profiles available without a user session (device token or anonymous)', () => {
     profileMock.refresh.mockClear();
-    authTokenSubject.next(createToken({ isDeviceAccessToken: true }));
+    isUserSessionSubject.next(false);
     fixture.detectChanges();
+    expect(component['profilesAvailable']()).toBe(false);
     expect(profileMock.refresh).not.toHaveBeenCalled();
   });
 

--- a/src/app/core/components/options/configuration/config.component.spec.ts
+++ b/src/app/core/components/options/configuration/config.component.spec.ts
@@ -116,10 +116,10 @@ describe('SettingsConfigComponent', () => {
     expect(profileMock.switchProfile).not.toHaveBeenCalled();
   });
 
-  it('createProfile passes the chosen name and seed', async () => {
-    component['createProfile']('current');
+  it('createProfile passes the chosen name and creates a blank profile', async () => {
+    component['createProfile']();
     await Promise.resolve();
-    expect(profileMock.createProfile).toHaveBeenCalledWith('cockpit', 'current');
+    expect(profileMock.createProfile).toHaveBeenCalledWith('cockpit');
   });
 
   it('deleteProfile confirms then delegates', async () => {

--- a/src/app/core/components/options/configuration/config.component.spec.ts
+++ b/src/app/core/components/options/configuration/config.component.spec.ts
@@ -1,16 +1,19 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { BehaviorSubject } from 'rxjs';
+import { signal } from '@angular/core';
+import { BehaviorSubject, of } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { SettingsConfigComponent } from './config.component';
 import { AuthenticationService, IAuthorizationToken } from '../../../services/authentication.service';
 import { StorageService } from '../../../services/storage.service';
 import { ToastService } from '../../../services/toast.service';
 import { SettingsService } from '../../../services/settings.service';
+import { ProfileService, IProfileSummary } from '../../../services/profile.service';
+import { DialogService } from '../../../services/dialog.service';
 
 const createToken = (overrides: Partial<IAuthorizationToken> = {}): IAuthorizationToken => ({
   token: 'token',
   expiry: Date.now() / 1000 + 3600,
-  isDeviceAccessToken: true,
+  isDeviceAccessToken: false,
   ...overrides
 });
 
@@ -18,54 +21,61 @@ describe('SettingsConfigComponent', () => {
   let component: SettingsConfigComponent;
   let fixture: ComponentFixture<SettingsConfigComponent>;
   let authTokenSubject: BehaviorSubject<IAuthorizationToken | null>;
-  let storageMock: {
-    isAppDataSupported: boolean;
-    listConfigs: ReturnType<typeof vi.fn>;
-    removeItem: ReturnType<typeof vi.fn>;
-    getConfig: ReturnType<typeof vi.fn>;
-    setConfig: ReturnType<typeof vi.fn>;
+  let profilesSignal: ReturnType<typeof signal<IProfileSummary[]>>;
+  let profileMock: {
+    profiles: typeof profilesSignal;
+    refresh: ReturnType<typeof vi.fn>;
+    switchProfile: ReturnType<typeof vi.fn>;
+    createProfile: ReturnType<typeof vi.fn>;
+    renameProfile: ReturnType<typeof vi.fn>;
+    duplicateProfile: ReturnType<typeof vi.fn>;
+    deleteProfile: ReturnType<typeof vi.fn>;
+    importProfile: ReturnType<typeof vi.fn>;
   };
-  let toastMock: {
-    show: ReturnType<typeof vi.fn>;
+  let dialogMock: {
+    openConfirmationDialog: ReturnType<typeof vi.fn>;
+    openNameDialog: ReturnType<typeof vi.fn>;
   };
+  let toastMock: { show: ReturnType<typeof vi.fn> };
 
   beforeEach(async () => {
     authTokenSubject = new BehaviorSubject<IAuthorizationToken | null>(null);
-    storageMock = {
-      isAppDataSupported: true,
-      listConfigs: vi.fn().mockResolvedValue([
-        { scope: 'global', name: 'multi-test2' },
-        { scope: 'user', name: 'default' },
-        { scope: 'user', name: 'race-config' }
-      ]),
-      removeItem: vi.fn(),
-      getConfig: vi.fn().mockResolvedValue({ app: {}, dashboards: [], theme: {} }),
-      setConfig: vi.fn().mockReturnValue(true)
+    profilesSignal = signal<IProfileSummary[]>([
+      { name: 'default', isActive: false },
+      { name: 'profileA', isActive: true }
+    ]);
+    profileMock = {
+      profiles: profilesSignal,
+      refresh: vi.fn().mockResolvedValue(undefined),
+      switchProfile: vi.fn().mockResolvedValue(undefined),
+      createProfile: vi.fn().mockResolvedValue(undefined),
+      renameProfile: vi.fn().mockResolvedValue(undefined),
+      duplicateProfile: vi.fn().mockResolvedValue(undefined),
+      deleteProfile: vi.fn().mockResolvedValue(undefined),
+      importProfile: vi.fn().mockResolvedValue(undefined)
     };
-    toastMock = {
-      show: vi.fn()
+    dialogMock = {
+      openConfirmationDialog: vi.fn().mockReturnValue(of(true)),
+      openNameDialog: vi.fn().mockReturnValue({ afterClosed: () => of({ name: 'cockpit' }) })
     };
+    toastMock = { show: vi.fn() };
 
     await TestBed.configureTestingModule({
       imports: [SettingsConfigComponent],
       providers: [
-        {
-          provide: AuthenticationService,
-          useValue: {
-            authToken$: authTokenSubject.asObservable()
-          }
-        },
-        { provide: StorageService, useValue: storageMock },
+        { provide: AuthenticationService, useValue: { authToken$: authTokenSubject.asObservable() } },
+        { provide: StorageService, useValue: { isAppDataSupported: true } },
         { provide: ToastService, useValue: toastMock },
+        { provide: ProfileService, useValue: profileMock },
+        { provide: DialogService, useValue: dialogMock },
         {
           provide: SettingsService,
           useValue: {
-            useSharedConfig: false,
+            useSharedConfig: true,
             getAppConfig: vi.fn(),
             getDashboardConfig: vi.fn(),
             getThemeConfig: vi.fn(),
             loadConfigFromLocalStorage: vi.fn(),
-            replaceConfig: vi.fn(),
             reloadApp: vi.fn(),
             resetSettings: vi.fn(),
             resetConnection: vi.fn(),
@@ -73,8 +83,7 @@ describe('SettingsConfigComponent', () => {
           }
         }
       ]
-    })
-      .compileComponents();
+    }).compileComponents();
   });
 
   beforeEach(() => {
@@ -87,34 +96,47 @@ describe('SettingsConfigComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('derives auth state and config options from signals', async () => {
+  it('loads profiles when logged in with a user token', () => {
+    authTokenSubject.next(createToken({ isDeviceAccessToken: false }));
+    fixture.detectChanges();
+    expect(component.hasToken).toBe(true);
+    expect(component.isTokenTypeDevice).toBe(false);
+    expect(profileMock.refresh).toHaveBeenCalled();
+  });
+
+  it('does not load profiles for a device token (profiles are user-scope)', () => {
+    profileMock.refresh.mockClear();
     authTokenSubject.next(createToken({ isDeviceAccessToken: true }));
     fixture.detectChanges();
+    expect(profileMock.refresh).not.toHaveBeenCalled();
+  });
+
+  it('switchProfile confirms then delegates to ProfileService', async () => {
+    await component['switchProfile']('cockpit');
+    expect(dialogMock.openConfirmationDialog).toHaveBeenCalled();
+    expect(profileMock.switchProfile).toHaveBeenCalledWith('cockpit');
+  });
+
+  it('switchProfile does nothing when the confirmation is cancelled', async () => {
+    dialogMock.openConfirmationDialog.mockReturnValueOnce(of(false));
+    await component['switchProfile']('cockpit');
+    expect(profileMock.switchProfile).not.toHaveBeenCalled();
+  });
+
+  it('createProfile passes the chosen name and seed', async () => {
+    component['createProfile']('current');
     await Promise.resolve();
-    await fixture.whenStable();
-    fixture.detectChanges();
-
-    expect(component.hasToken).toBe(true);
-    expect(component.isTokenTypeDevice).toBe(true);
-    expect(component.saveConfigScope).toBe('global');
-    expect(storageMock.listConfigs).toHaveBeenCalled();
-
-    expect(component.serverConfigOptions()).toEqual([
-      { scope: 'global', name: 'multi-test2', key: 'global::multi-test2' },
-      { scope: 'user', name: 'race-config', key: 'user::race-config' }
-    ]);
+    expect(profileMock.createProfile).toHaveBeenCalledWith('cockpit', 'current');
   });
 
-  it('deletes configuration using parsed key', () => {
-    component.deleteConfigByKey('global::multi-test2');
-
-    expect(storageMock.removeItem).toHaveBeenCalledWith('global', 'multi-test2', undefined);
+  it('deleteProfile confirms then delegates', async () => {
+    await component['deleteProfile']('old');
+    expect(profileMock.deleteProfile).toHaveBeenCalledWith('old');
   });
 
-  it('shows error when delete key is invalid', () => {
-    component.deleteConfigByKey('');
-
-    expect(toastMock.show).toHaveBeenCalledWith('Please select a valid configuration to delete.', 0, false, 'error');
-    expect(storageMock.removeItem).not.toHaveBeenCalled();
+  it('surfaces ProfileService errors via toast', async () => {
+    profileMock.switchProfile.mockRejectedValueOnce(new Error('boom'));
+    await component['switchProfile']('cockpit');
+    expect(toastMock.show).toHaveBeenCalledWith('boom', 0, false, 'error');
   });
 });

--- a/src/app/core/components/options/configuration/config.component.ts
+++ b/src/app/core/components/options/configuration/config.component.ts
@@ -8,7 +8,7 @@ import { ToastService } from '../../../services/toast.service';
 import { SettingsService } from '../../../services/settings.service';
 import { IConfig } from '../../../interfaces/app-settings.interfaces';
 import { StorageService } from '../../../services/storage.service';
-import { ProfileService, ProfileSeed } from '../../../services/profile.service';
+import { ProfileService } from '../../../services/profile.service';
 import { DialogService } from '../../../services/dialog.service';
 import { MatButton } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
@@ -69,10 +69,10 @@ export class SettingsConfigComponent {
     }
   }
 
-  protected createProfile(seed: ProfileSeed): void {
+  protected createProfile(): void {
     this.dialog
       .openNameDialog({
-        title: seed === 'current' ? 'New profile from current' : 'New blank profile',
+        title: 'New profile',
         name: '',
         confirmBtnText: 'Create',
         cancelBtnText: 'Cancel'
@@ -83,7 +83,7 @@ export class SettingsConfigComponent {
           return;
         }
         try {
-          await this.profileService.createProfile(result.name, seed);
+          await this.profileService.createProfile(result.name);
         } catch (err) {
           this.reportError(err);
         }

--- a/src/app/core/components/options/configuration/config.component.ts
+++ b/src/app/core/components/options/configuration/config.component.ts
@@ -41,8 +41,10 @@ export class SettingsConfigComponent {
   protected profilesAvailable = computed(() =>
     this.supportApplicationData && this.isUserSession()
   );
+  // Read is available to any user session; profile mutations (create/rename/duplicate/delete/import)
+  // need write capability — a read-only session must not get live write controls.
+  protected canWriteUserData = toSignal(this.auth.canWriteUserData$, { initialValue: false });
   protected profiles = this.profileService.profiles;
-  protected jsonData: IConfig = null;
 
   private readonly profileLoadEffect = effect(() => {
     if (this.profilesAvailable()) {

--- a/src/app/core/components/options/configuration/config.component.ts
+++ b/src/app/core/components/options/configuration/config.component.ts
@@ -1,49 +1,48 @@
-import { Component, computed, effect, inject, signal } from '@angular/core';
+import { Component, computed, effect, inject } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { UntypedFormBuilder, UntypedFormGroup, Validators, FormsModule, ReactiveFormsModule }    from '@angular/forms';
+import { firstValueFrom } from 'rxjs';
+import { FormsModule } from '@angular/forms';
 
 import { AuthenticationService } from '../../../services/authentication.service';
 import { ToastService } from '../../../services/toast.service';
 import { SettingsService } from '../../../services/settings.service';
 import { IConfig } from '../../../interfaces/app-settings.interfaces';
 import { StorageService } from '../../../services/storage.service';
-import { HttpErrorResponse } from '@angular/common/http';
-import { MatInput, MatInputModule } from '@angular/material/input';
-import { MatOption } from '@angular/material/core';
-import { MatSelect } from '@angular/material/select';
-import { MatFormField, MatLabel } from '@angular/material/form-field';
+import { ProfileService, ProfileSeed } from '../../../services/profile.service';
+import { DialogService } from '../../../services/dialog.service';
 import { MatButton } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
 import { MatDivider } from '@angular/material/divider';
 import { RouterLink } from '@angular/router';
-
-interface IRemoteConfig {
-  scope: string,
-  name: string
-}
-
-interface IRemoteConfigOption extends IRemoteConfig {
-  key: string
-}
 
 @Component({
     selector: 'settings-config',
     templateUrl: './config.component.html',
     styleUrls: ['./config.component.scss'],
-    imports: [RouterLink, FormsModule, MatDivider, MatButton, MatFormField, MatLabel, MatSelect, MatOption, MatInput, ReactiveFormsModule, MatInputModule]
+    imports: [RouterLink, FormsModule, MatDivider, MatButton, MatIconModule]
 })
 export class SettingsConfigComponent {
   private settings = inject(SettingsService);
   private storageSvc = inject(StorageService);
   private toast = inject(ToastService);
   private auth = inject(AuthenticationService);
-  private fb = inject(UntypedFormBuilder);
+  private profileService = inject(ProfileService);
+  private dialog = inject(DialogService);
 
   private authToken = toSignal(this.auth.authToken$, { initialValue: null });
-  private serverConfigListSignal = signal<IRemoteConfig[]>([]);
   private hasTokenSignal = computed(() => Boolean(this.authToken()?.token));
   private isTokenTypeDeviceSignal = computed(() => Boolean(this.authToken()?.isDeviceAccessToken));
 
-  protected readonly pageTitle: string = "Configurations";
+  protected readonly pageTitle = 'Profiles';
+  public supportApplicationData = this.storageSvc.isAppDataSupported;
+
+  // Profiles are user-scope: available only when logged in with a Signal K user account
+  // (a device token resolves to the shared 'global' scope, so profiles do not apply).
+  protected profilesAvailable = computed(() =>
+    this.supportApplicationData && this.hasTokenSignal() && !this.isTokenTypeDeviceSignal()
+  );
+  protected profiles = this.profileService.profiles;
+  protected jsonData: IConfig = null;
 
   public get hasToken(): boolean {
     return this.hasTokenSignal();
@@ -53,229 +52,187 @@ export class SettingsConfigComponent {
     return this.isTokenTypeDeviceSignal();
   }
 
-  public supportApplicationData = this.storageSvc.isAppDataSupported;
-  public serverConfigOptions = computed<IRemoteConfigOption[]>(() => this.serverConfigListSignal().map((config) => ({
-    scope: config.scope,
-    name: config.name,
-    key: `${config.scope}::${config.name}`
-  })));
-  public serverUpgradableConfigList: IRemoteConfig[] = [];
-
-  public copyConfigForm: UntypedFormGroup = this.fb.group({
-    sourceTarget: [{value: '', disabled: false}, Validators.required]
-  });
-  public storageLocation: string = null;
-  public locations: string[] = ["Local Storage", "Server Storage"];
-
-  public saveConfigName: string = null;
-  public saveConfigScope: string = null;
-  public deleteConfigKey: string = null;
-  public jsonData: IConfig = null;
-
-  private readonly authStateEffect = effect(() => {
-    if (!this.supportApplicationData) {
-      return;
+  private readonly profileLoadEffect = effect(() => {
+    if (this.profilesAvailable()) {
+      this.profileService.refresh().catch((err) => this.reportError(err));
     }
-
-    if (this.hasTokenSignal()) {
-      this.saveConfigScope = this.isTokenTypeDeviceSignal() ? 'global' : 'user';
-      this.getServerConfigList();
-      return;
-    }
-
-    this.deleteConfigKey = null;
   });
 
-  public getServerConfigList(configFileVersionName?: number) {
-    if (this.supportApplicationData) {
-      this.storageSvc.listConfigs(configFileVersionName)
-      .then((configs) => {
-        // Filter out entries with scope 'user' and name 'default'
-        const filteredConfigs = configs.filter(config => !(config.scope === 'user' && config.name === 'default'));
-
-        // see if we have an old config file
-        if(configFileVersionName) {
-          this.serverUpgradableConfigList = filteredConfigs;
-        } else {
-          this.serverConfigListSignal.set(filteredConfigs);
-        }
+  protected async switchProfile(name: string): Promise<void> {
+    const confirmed = await firstValueFrom(
+      this.dialog.openConfirmationDialog({
+        title: 'Switch profile',
+        message: `Switch this device to "${name}"? KIP will reload to load the profile.`,
+        confirmBtnText: 'Switch',
+        cancelBtnText: 'Cancel'
       })
-      .catch((error: HttpErrorResponse) => {
-        switch (error.status) {
-          case 401:
-            this.toast.show("Storage Service: " + error.statusText + ". Signal K configuration must meet the following requirements; 1) Security enabled. 2) Application Data Storage Interface: On. 3) Either Allow Readonly Access enabled, or connecting with a user.", 0, false, 'error');
-            break;
-
-          default: this.toast.show("Cannot list configurations: " + error, 0, false, 'error' );
-            break;
-        }
-      });
-    }
-  }
-
-  public saveConfig(conf: IConfig, scope: string, name: string, dontRefreshConfigList?: boolean, forceSave?: boolean) {
-    if (this.supportApplicationData) {
-      // Prevent saving with scope 'user' and name 'default'
-      if ((scope === 'user' && name === 'default') && !forceSave) {
-        this.toast.show("Saving configuration with scope 'user' and name 'default' is not allowed.", 0, false, 'error');
-        return;
-      }
-
-      if (this.storageSvc.setConfig(scope, name, conf)) {
-        this.toast.show(`Configuration [${name}] saved to [${scope}] storage scope`, 1000, true, 'success');
-        if (!dontRefreshConfigList || undefined) {
-          this.getServerConfigList();
-        }
-      } else {
-        this.toast.show("Configuration not saved to server", 0, false, 'error');
-      }
-    }
-  }
-
-  /**
-   * Save config to local storage
-   */
-  public saveToLocalstorage(config: IConfig) {
-    this.settings.replaceConfig("appConfig", config.app, false);
-    this.settings.replaceConfig("dashboardsConfig", config.dashboards, false);
-    this.settings.replaceConfig("themeConfig", config.theme, false);
-  }
-
-  public async copyConfig() {
-    const sourceTarget = this.parseConfigKey(this.copyConfigForm.value.sourceTarget);
-    if (!sourceTarget) {
-      this.toast.show('Please select a valid configuration to restore.', 0, false, 'error');
+    );
+    if (!confirmed) {
       return;
     }
-
-    let conf: IConfig = null;
     try {
-      await this.storageSvc.getConfig(sourceTarget.scope, sourceTarget.name)
-      .then((config: IConfig) => {
-        conf = config
+      await this.profileService.switchProfile(name);
+    } catch (err) {
+      this.reportError(err);
+    }
+  }
+
+  protected createProfile(seed: ProfileSeed): void {
+    this.dialog
+      .openNameDialog({
+        title: seed === 'current' ? 'New profile from current' : 'New blank profile',
+        name: '',
+        confirmBtnText: 'Create',
+        cancelBtnText: 'Cancel'
+      })
+      .afterClosed()
+      .subscribe(async (result) => {
+        if (!result?.name) {
+          return;
+        }
+        try {
+          await this.profileService.createProfile(result.name, seed);
+        } catch (err) {
+          this.reportError(err);
+        }
       });
-    } catch (error) {
-      this.toast.show("Cannot retrieve server configuration: " + error.statusText, 0, false, 'error');
+  }
+
+  protected renameProfile(name: string): void {
+    this.dialog
+      .openNameDialog({ title: 'Rename profile', name, confirmBtnText: 'Rename', cancelBtnText: 'Cancel' })
+      .afterClosed()
+      .subscribe(async (result) => {
+        if (!result?.name || result.name === name) {
+          return;
+        }
+        try {
+          await this.profileService.renameProfile(name, result.name);
+        } catch (err) {
+          this.reportError(err);
+        }
+      });
+  }
+
+  protected duplicateProfile(name: string): void {
+    this.dialog
+      .openNameDialog({ title: 'Duplicate profile', name: `${name} copy`, confirmBtnText: 'Duplicate', cancelBtnText: 'Cancel' })
+      .afterClosed()
+      .subscribe(async (result) => {
+        if (!result?.name) {
+          return;
+        }
+        try {
+          await this.profileService.duplicateProfile(name, result.name);
+        } catch (err) {
+          this.reportError(err);
+        }
+      });
+  }
+
+  protected async deleteProfile(name: string): Promise<void> {
+    const confirmed = await firstValueFrom(
+      this.dialog.openConfirmationDialog({
+        title: 'Delete profile',
+        message: `Permanently delete profile "${name}"? This cannot be undone.`,
+        confirmBtnText: 'Delete',
+        cancelBtnText: 'Cancel'
+      })
+    );
+    if (!confirmed) {
       return;
     }
-
-    this.saveConfig(conf, 'user', 'default', false, true);
-    this.settings.reloadApp();
-  }
-
-  public deleteConfigByKey(configKey: string) {
-    const config = this.parseConfigKey(configKey);
-    if (!config) {
-      this.toast.show('Please select a valid configuration to delete.', 0, false, 'error');
-      return;
+    try {
+      await this.profileService.deleteProfile(name);
+    } catch (err) {
+      this.reportError(err);
     }
-
-    this.deleteConfig(config.scope, config.name);
-  }
-
-  public deleteConfig (scope: string, name: string, forceConfigFileVersion?: number, dontRefreshConfigList?: boolean) {
-    this.storageSvc.removeItem(scope, name, forceConfigFileVersion);
-    this.toast.show(`Configuration [${name}] deleted from [${scope}] storage scope`, 1000, false, 'success');
-    if (!dontRefreshConfigList) {
-      this.getServerConfigList();
-    }
-  }
-
-  private parseConfigKey(configKey: string | null): IRemoteConfig | null {
-    if (!configKey) {
-      return null;
-    }
-
-    const [scope, ...nameParts] = configKey.split('::');
-    const name = nameParts.join('::');
-    if (!scope || !name) {
-      return null;
-    }
-
-    return { scope, name };
-  }
-
-  public resetConfigToDefault() {
-    this.settings.resetSettings();
-  }
-
-  public resetConnectionToDefault() {
-    this.settings.resetConnection();
-  }
-
-  public loadDemoConfig() {
-    this.settings.loadDemoConfig();
   }
 
   public getActiveConfig(): IConfig {
-    let conf: IConfig;
-    if (this.settings.useSharedConfig) {
-      conf = this.getLocalConfigFromMemory();
-    } else {
-      conf = this.getLocalConfigFromLocalStorage();
-    }
-    return conf;
+    return this.settings.useSharedConfig ? this.getLocalConfigFromMemory() : this.getLocalConfigFromLocalStorage();
   }
 
   public getLocalConfigFromMemory(): IConfig {
-    const localConfig: IConfig = {
-      "app": this.settings.getAppConfig(),
-      "dashboards": this.settings.getDashboardConfig(),
-      "theme": this.settings.getThemeConfig(),
+    return {
+      app: this.settings.getAppConfig(),
+      dashboards: this.settings.getDashboardConfig(),
+      theme: this.settings.getThemeConfig()
     };
-    return localConfig;
   }
 
   public getLocalConfigFromLocalStorage(): IConfig {
-    const localConfig: IConfig = {
-      "app": this.settings.loadConfigFromLocalStorage('appConfig'),
-      "dashboards": this.settings.loadConfigFromLocalStorage('dashboardsConfig'),
-      "theme": this.settings.loadConfigFromLocalStorage('themeConfig'),
+    return {
+      app: this.settings.loadConfigFromLocalStorage('appConfig'),
+      dashboards: this.settings.loadConfigFromLocalStorage('dashboardsConfig'),
+      theme: this.settings.loadConfigFromLocalStorage('themeConfig')
     };
-    return localConfig;
   }
 
   public downloadJsonConfig(): void {
-    const jsonData = this.getActiveConfig();
-    const jsonString = JSON.stringify(jsonData, null, 2);
+    const jsonString = JSON.stringify(this.getActiveConfig(), null, 2);
     const blob = new Blob([jsonString], { type: 'application/json' });
-
-    const downloadURL = window.URL.createObjectURL(blob); // Generate a temporary download URL
-
-    // Create an invisible <a> element and trigger the download
+    const downloadURL = window.URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = downloadURL;
-    a.download = 'KipConfig.json'; // File name
+    a.download = 'KipConfig.json';
     document.body.appendChild(a);
     a.click();
     document.body.removeChild(a);
-
-    window.URL.revokeObjectURL(downloadURL); // Cleanup memory
+    window.URL.revokeObjectURL(downloadURL);
   }
 
-  public uploadJsonConfig(event: Event) {
+  /** Import a config file as a NEW profile (never overwrites the active one). */
+  public uploadJsonConfig(event: Event): void {
     const input = event.target as HTMLInputElement;
     const file = input.files?.[0];
-    if (file && file.type === "application/json") {
-      const reader = new FileReader();
-      reader.onload = (e) => {
-        try {
-          this.jsonData = JSON.parse(e.target?.result as string); // Parse JSON
-          if (this.hasToken) {
-            this.saveConfig(this.jsonData, 'user', 'default', false, true);
-          } else {
-            this.saveToLocalstorage(this.jsonData);
-          }
-          this.settings.reloadApp();
-        } catch (error) {
-          this.toast.show("File does not contain valid JSON.", 0, false, 'error');
-          console.error("Invalid JSON file format:", error);
-        }
-      };
-      reader.readAsText(file); // Read the file as text
-    } else {
-      this.toast.show("Please select a valid JSON file", 0, false, 'error');
+    if (!file || file.type !== 'application/json') {
+      this.toast.show('Please select a valid JSON file', 0, false, 'error');
+      return;
     }
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(e.target?.result as string);
+      } catch (err) {
+        this.toast.show('File does not contain valid JSON.', 0, false, 'error');
+        console.error('Invalid JSON file format:', err);
+        return;
+      }
+      this.dialog
+        .openNameDialog({ title: 'Import as new profile', name: '', confirmBtnText: 'Import', cancelBtnText: 'Cancel' })
+        .afterClosed()
+        .subscribe(async (result) => {
+          if (!result?.name) {
+            return;
+          }
+          try {
+            await this.profileService.importProfile(result.name, parsed);
+            this.toast.show(`Profile "${result.name}" imported`, 1000, true, 'success');
+          } catch (err) {
+            this.reportError(err);
+          }
+        });
+    };
+    reader.readAsText(file);
+    input.value = '';
   }
 
+  public loadDemoConfig(): void {
+    this.settings.loadDemoConfig();
+  }
+
+  public resetConfigToDefault(): void {
+    this.settings.resetSettings();
+  }
+
+  public resetConnectionToDefault(): void {
+    this.settings.resetConnection();
+  }
+
+  private reportError(err: unknown): void {
+    const message = err instanceof Error ? err.message : String(err);
+    this.toast.show(message, 0, false, 'error');
+  }
 }

--- a/src/app/core/components/options/configuration/config.component.ts
+++ b/src/app/core/components/options/configuration/config.component.ts
@@ -29,28 +29,20 @@ export class SettingsConfigComponent {
   private profileService = inject(ProfileService);
   private dialog = inject(DialogService);
 
-  private authToken = toSignal(this.auth.authToken$, { initialValue: null });
-  private hasTokenSignal = computed(() => Boolean(this.authToken()?.token));
-  private isTokenTypeDeviceSignal = computed(() => Boolean(this.authToken()?.isDeviceAccessToken));
+  private isUserSession = toSignal(this.auth.isUserSession$, { initialValue: false });
 
   protected readonly pageTitle = 'Profiles';
   public supportApplicationData = this.storageSvc.isAppDataSupported;
 
-  // Profiles are user-scope: available only when logged in with a Signal K user account
-  // (a device token resolves to the shared 'global' scope, so profiles do not apply).
+  // Profiles are user-scope: available with a real Signal K user session — a cookie-mode SSO session
+  // or a non-device token. Keying off isUserSession$ (not raw token presence) is what makes profiles
+  // appear in cookie mode, where the httpOnly session cookie carries auth and there is no JWT. A device
+  // token resolves to the shared 'global' scope, and an anonymous visitor has no user scope.
   protected profilesAvailable = computed(() =>
-    this.supportApplicationData && this.hasTokenSignal() && !this.isTokenTypeDeviceSignal()
+    this.supportApplicationData && this.isUserSession()
   );
   protected profiles = this.profileService.profiles;
   protected jsonData: IConfig = null;
-
-  public get hasToken(): boolean {
-    return this.hasTokenSignal();
-  }
-
-  public get isTokenTypeDevice(): boolean {
-    return this.isTokenTypeDeviceSignal();
-  }
 
   private readonly profileLoadEffect = effect(() => {
     if (this.profilesAvailable()) {

--- a/src/app/core/components/options/signalk/signalk.component.html
+++ b/src/app/core/components/options/signalk/signalk.component.html
@@ -19,18 +19,38 @@
     </tr>
     <tr class="connect-table">
       <td colspan="2">
-        <mat-slide-toggle #useSharedConfigToggle
-          name="useSharedConfigToggle"
-          matTooltip="Activating authentication enables Signal K's user storage feature to save KIP configuration on the server. When authentication is not activated, KIP stores it's configuration locally in the Browser."
-          [(ngModel)]="connectionConfig.useSharedConfig"
-          [ngModelOptions]="{standalone: true}"
-          [disabled]="!connectionConfig.signalKUrl"
-          (change)="useSharedConfigToggleClick($event)">
-            Login to server
-        </mat-slide-toggle>
-        <button mat-flat-button type="button" class="credentials-btn" matTooltip="Configure Signal K user authentication credentials. The user must be a valid pre existing Signal K server user. It is strongly recommended not to use the default Signal K Admin user." [disabled]="!connectionConfig.useSharedConfig" (click)="openUserCredentialModal(null)">
-          Set Credential
-        </button>
+        @if (cookieMode) {
+          <div class="sso-identity" aria-live="polite">
+            @if (isUserSession()) {
+              <span>Signed in@if (loginStatus()?.oidcProviderName) { via {{ loginStatus()?.oidcProviderName }}}@if (loginStatus()?.username) { as {{ loginStatus()?.username }}}.</span>
+              @if (!canWriteUserData()) {
+                <span class="sso-readonly"> Read-only access — configuration changes are disabled on the server.</span>
+              }
+            } @else if (loginStatus(); as status) {
+              @if (status.authenticationRequired === false) {
+                <span>Connected (no sign-in required).</span>
+              } @else {
+                <span>Not signed in. </span>
+                <button mat-flat-button type="button" (click)="signIn()">Sign in</button>
+              }
+            } @else {
+              <span>Checking sign-in status…</span>
+            }
+          </div>
+        } @else {
+          <mat-slide-toggle #useSharedConfigToggle
+            name="useSharedConfigToggle"
+            matTooltip="Activating authentication enables Signal K's user storage feature to save KIP configuration on the server. When authentication is not activated, KIP stores it's configuration locally in the Browser."
+            [(ngModel)]="connectionConfig.useSharedConfig"
+            [ngModelOptions]="{standalone: true}"
+            [disabled]="!connectionConfig.signalKUrl"
+            (change)="useSharedConfigToggleClick($event)">
+              Login to server
+          </mat-slide-toggle>
+          <button mat-flat-button type="button" class="credentials-btn" matTooltip="Configure Signal K user authentication credentials. The user must be a valid pre existing Signal K server user. It is strongly recommended not to use the default Signal K Admin user." [disabled]="!connectionConfig.useSharedConfig" (click)="openUserCredentialModal(null)">
+            Set Credential
+          </button>
+        }
         <br />
         <mat-checkbox [(ngModel)]="connectionConfig.signalKSubscribeAll" [ngModelOptions]="{standalone: false}" name="signalKSubscribeAll">Subscribe to remote sources messages such as AIS and DSC targets. <i>Warning: this maybe generate heavy traffic.</i></mat-checkbox>
       </td>
@@ -51,7 +71,7 @@
       <pre>KIP: {{ app.appVersion() }}
 {{ app.browserVersion() }}, {{ app.osVersion() }}<br />
 {{ endpointServiceStatus.serverDescription }}
-{{ streamStatus.message }}, {{ streamStatus.hasToken ? 'Logged In' : 'Readonly'}}
+{{ streamStatus.message }}, {{ cookieMode ? (isUserSession() ? 'Signed in' : 'Not signed in') : (streamStatus.hasToken ? 'Logged In' : 'Readonly') }}
 Internet: {{ internetAvailabilityLabel() }}</pre>
     </div>
   </div>

--- a/src/app/core/components/options/signalk/signalk.component.ts
+++ b/src/app/core/components/options/signalk/signalk.component.ts
@@ -203,11 +203,9 @@ export class SettingsSignalkComponent implements OnInit, AfterViewInit, OnDestro
 
       console.log('[Settings-SignalK] Validation successful - proceeding with connection');
 
-      // Step 2: Save the new configuration to localStorage
-      this.settings.setConnectionConfig(this.connectionConfig);
-
-      // Step 3: Token mode only — establish the session in-memory so the session JWT (the plaintext
-      // password is no longer persisted) survives the reload that bootstraps the new config.
+      // Step 2: Token mode only — establish the session in-memory FIRST (using the explicit newUrl) so
+      // a failed credential login does not persist a rejected config. The session JWT (the plaintext
+      // password is no longer persisted) then survives the reload that bootstraps the new config.
       if (!newConfigIsCookieMode && this.connectionConfig.useSharedConfig) {
         await this.auth.login({
           usr: this.connectionConfig.loginName,
@@ -215,6 +213,9 @@ export class SettingsSignalkComponent implements OnInit, AfterViewInit, OnDestro
           newUrl: this.connectionConfig.signalKUrl
         });
       }
+
+      // Step 3: Persist the now-validated configuration to localStorage.
+      this.settings.setConnectionConfig(this.connectionConfig);
 
       // Step 4: Properly close WebSocket and HTTP connections
       this.connectionStateMachine.shutdown('Configuration changed - restarting app');

--- a/src/app/core/components/options/signalk/signalk.component.ts
+++ b/src/app/core/components/options/signalk/signalk.component.ts
@@ -1,5 +1,5 @@
 import { ElementRef, Component, OnInit, OnDestroy, AfterViewInit, viewChild, inject, DestroyRef, computed } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { AppService } from '../../../services/app-service';
 import { ToastService } from '../../../services/toast.service';
 import { SettingsService } from '../../../services/settings.service';
@@ -8,6 +8,7 @@ import { SignalKConnectionService, IEndpointStatus } from '../../../services/sig
 import { IDeltaUpdate, DataService } from '../../../services/data.service';
 import { SignalKDeltaService, IStreamStatus } from '../../../services/signalk-delta.service';
 import { AuthenticationService, IAuthorizationToken } from '../../../services/authentication.service';
+import { SsoRedirectService } from '../../../services/sso-redirect.service';
 import { ConnectionStateMachine } from '../../../services/connection-state-machine.service';
 import { ModalUserCredentialComponent } from '../../../components/modal-user-credential/modal-user-credential.component';
 import { compare } from 'compare-versions';
@@ -59,6 +60,7 @@ export class SettingsSignalkComponent implements OnInit, AfterViewInit, OnDestro
   private readonly connectionStateMachine = inject(ConnectionStateMachine);
   private readonly internetReachability = inject(InternetReachabilityService);
   protected readonly auth = inject(AuthenticationService);
+  private readonly ssoRedirect = inject(SsoRedirectService);
   private readonly destroyRef = inject(DestroyRef);
   private readonly canvasService = inject(CanvasService);
 
@@ -67,6 +69,17 @@ export class SettingsSignalkComponent implements OnInit, AfterViewInit, OnDestro
 
   public connectionConfig: IConnectionConfig;
   public isConnecting = false; // Loading state for connect button
+
+  // Cookie mode (same-origin): the Connectivity tab shows session identity instead of the credential
+  // controls. These drive that identity block.
+  protected cookieMode = false;
+  protected readonly loginStatus = toSignal(this.auth.loginStatus$, { initialValue: null });
+  protected readonly isUserSession = toSignal(this.auth.isUserSession$, { initialValue: false });
+  protected readonly canWriteUserData = toSignal(this.auth.canWriteUserData$, { initialValue: false });
+
+  protected signIn(): void {
+    this.ssoRedirect.manualSignIn();
+  }
 
   public authToken: IAuthorizationToken;
 
@@ -96,6 +109,7 @@ export class SettingsSignalkComponent implements OnInit, AfterViewInit, OnDestro
   ngOnInit() {
     // get Signal K connection configuration
     this.connectionConfig = this.settings.getConnectionConfig();
+    this.cookieMode = this.auth.authMode === 'cookie';
 
     // get authentication token status
     this.auth.authToken$.pipe(
@@ -169,7 +183,11 @@ export class SettingsSignalkComponent implements OnInit, AfterViewInit, OnDestro
    * configuration saving, connection cleanup, and app reload.
    */
   public async connectToServer() {
-    if (this.connectionConfig.useSharedConfig && (!this.connectionConfig.loginName || !this.connectionConfig.loginPassword)) {
+    // Cookie mode (same-origin): the session cookie authenticates after reload — no KIP credential
+    // dialog, no in-app login.
+    const newConfigIsCookieMode = this.auth.authModeForConfig(this.connectionConfig) === 'cookie';
+
+    if (!newConfigIsCookieMode && this.connectionConfig.useSharedConfig && (!this.connectionConfig.loginName || !this.connectionConfig.loginPassword)) {
       this.openUserCredentialModal("Credentials required");
       return;
     }
@@ -188,9 +206,9 @@ export class SettingsSignalkComponent implements OnInit, AfterViewInit, OnDestro
       // Step 2: Save the new configuration to localStorage
       this.settings.setConnectionConfig(this.connectionConfig);
 
-      // Step 3: Establish the session in-memory so the session JWT (not the plaintext password,
-      // which is no longer persisted) survives the reload that bootstraps the new config.
-      if (this.connectionConfig.useSharedConfig) {
+      // Step 3: Token mode only — establish the session in-memory so the session JWT (the plaintext
+      // password is no longer persisted) survives the reload that bootstraps the new config.
+      if (!newConfigIsCookieMode && this.connectionConfig.useSharedConfig) {
         await this.auth.login({
           usr: this.connectionConfig.loginName,
           pwd: this.connectionConfig.loginPassword ?? '',
@@ -201,8 +219,9 @@ export class SettingsSignalkComponent implements OnInit, AfterViewInit, OnDestro
       // Step 4: Properly close WebSocket and HTTP connections
       this.connectionStateMachine.shutdown('Configuration changed - restarting app');
 
-      // Step 5: Clean up authentication token if switching from shared to individual config
-      if (this.authToken && !this.connectionConfig.useSharedConfig && !this.authToken.isDeviceAccessToken) {
+      // Step 5: Clear a stored user token when the new config resolves to cookie mode (the session
+      // cookie is authoritative) or when switching from shared to individual config.
+      if (this.authToken && !this.authToken.isDeviceAccessToken && (newConfigIsCookieMode || !this.connectionConfig.useSharedConfig)) {
         this.auth.deleteToken();
       }
 

--- a/src/app/core/components/options/signalk/signalk.component.ts
+++ b/src/app/core/components/options/signalk/signalk.component.ts
@@ -188,15 +188,25 @@ export class SettingsSignalkComponent implements OnInit, AfterViewInit, OnDestro
       // Step 2: Save the new configuration to localStorage
       this.settings.setConnectionConfig(this.connectionConfig);
 
-      // Step 3: Properly close WebSocket and HTTP connections
+      // Step 3: Establish the session in-memory so the session JWT (not the plaintext password,
+      // which is no longer persisted) survives the reload that bootstraps the new config.
+      if (this.connectionConfig.useSharedConfig) {
+        await this.auth.login({
+          usr: this.connectionConfig.loginName,
+          pwd: this.connectionConfig.loginPassword ?? '',
+          newUrl: this.connectionConfig.signalKUrl
+        });
+      }
+
+      // Step 4: Properly close WebSocket and HTTP connections
       this.connectionStateMachine.shutdown('Configuration changed - restarting app');
 
-      // Step 4: Clean up authentication token if switching from shared to individual config
+      // Step 5: Clean up authentication token if switching from shared to individual config
       if (this.authToken && !this.connectionConfig.useSharedConfig && !this.authToken.isDeviceAccessToken) {
         this.auth.deleteToken();
       }
 
-      // Step 5: Reload immediately - APP_INITIALIZER will handle connection and authentication with new URL
+      // Step 6: Reload immediately - APP_INITIALIZER will handle connection and authentication with new URL
       // Skip during unit tests to avoid breaking Karma connection
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       if (!(window as any).__KIP_TEST__) {

--- a/src/app/core/interceptors/authentication-interceptor.spec.ts
+++ b/src/app/core/interceptors/authentication-interceptor.spec.ts
@@ -53,6 +53,15 @@ describe('AuthenticationInterceptor', () => {
     req.flush({ ok: true });
   });
 
+  it('cookie mode: a cross-origin request gets neither credentials nor a token header', () => {
+    auth.authMode = 'cookie';
+    http.get('https://boat.example:3443/signalk/').subscribe();
+    const req = httpMock.expectOne('https://boat.example:3443/signalk/');
+    expect(req.request.withCredentials).toBe(false);
+    expect(req.request.headers.has('authorization')).toBe(false);
+    req.flush({ ok: true });
+  });
+
   it('token mode without a token: no header and no credentials', () => {
     auth.authMode = 'token';
     auth.setToken(null);

--- a/src/app/core/interceptors/authentication-interceptor.spec.ts
+++ b/src/app/core/interceptors/authentication-interceptor.spec.ts
@@ -4,22 +4,26 @@ import { beforeEach, describe, expect, it, afterEach } from 'vitest';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { BehaviorSubject } from 'rxjs';
 import { AuthenticationInterceptor } from './authentication-interceptor';
-import { AuthenticationService, IAuthorizationToken } from '../services/authentication.service';
+import { AuthenticationService, AuthMode, IAuthorizationToken } from '../services/authentication.service';
 
 class AuthServiceStub {
-  private _token$ = new BehaviorSubject<IAuthorizationToken>({ token: 'stub-token' } as IAuthorizationToken);
+  private _token$ = new BehaviorSubject<IAuthorizationToken | null>({ token: 'stub-token' } as IAuthorizationToken);
   public authToken$ = this._token$.asObservable();
+  public authMode: AuthMode = 'token';
+  setToken(token: IAuthorizationToken | null): void { this._token$.next(token); }
 }
 
 describe('AuthenticationInterceptor', () => {
   let http: HttpClient;
   let httpMock: HttpTestingController;
+  let auth: AuthServiceStub;
 
   beforeEach(() => {
+    auth = new AuthServiceStub();
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
       providers: [
-        { provide: AuthenticationService, useClass: AuthServiceStub },
+        { provide: AuthenticationService, useValue: auth },
         { provide: HTTP_INTERCEPTORS, useClass: AuthenticationInterceptor, multi: true }
       ]
     });
@@ -31,10 +35,31 @@ describe('AuthenticationInterceptor', () => {
     httpMock.verify();
   });
 
-  it('should attach JWT Authorization header when token is available', () => {
+  it('token mode: attaches the JWT Authorization header and does not send credentials', () => {
+    auth.authMode = 'token';
     http.get('/api/test').subscribe();
     const req = httpMock.expectOne('/api/test');
     expect(req.request.headers.get('authorization')).toBe('JWT stub-token');
+    expect(req.request.withCredentials).toBe(false);
+    req.flush({ ok: true });
+  });
+
+  it('cookie mode: sends credentials and no Authorization header, even with a stored token', () => {
+    auth.authMode = 'cookie';
+    http.get('/api/test').subscribe();
+    const req = httpMock.expectOne('/api/test');
+    expect(req.request.withCredentials).toBe(true);
+    expect(req.request.headers.has('authorization')).toBe(false);
+    req.flush({ ok: true });
+  });
+
+  it('token mode without a token: no header and no credentials', () => {
+    auth.authMode = 'token';
+    auth.setToken(null);
+    http.get('/api/test').subscribe();
+    const req = httpMock.expectOne('/api/test');
+    expect(req.request.headers.has('authorization')).toBe(false);
+    expect(req.request.withCredentials).toBe(false);
     req.flush({ ok: true });
   });
 });

--- a/src/app/core/interceptors/authentication-interceptor.ts
+++ b/src/app/core/interceptors/authentication-interceptor.ts
@@ -19,16 +19,19 @@ export class AuthenticationInterceptor implements HttpInterceptor, OnDestroy {
   }
 
   intercept(req: HttpRequest<unknown>, next: HttpHandler) {
-    let authReq = req.clone();
+    // Branch on mode first. In cookie mode the same-origin httpOnly session cookie carries auth, so
+    // send credentials and never attach a JWT header — even if a stale token is still in storage.
+    if (this.auth.authMode === 'cookie') {
+      return next.handle(req.clone({ withCredentials: true }));
+    }
 
+    // Token mode (cross-origin): the cookie cannot flow, so attach the JWT header when present.
+    let authReq = req.clone();
     if (this.authToken) {
-      // Clone the request and replace the original headers with
-      // with the authorization token.
       authReq = req.clone({
         headers: req.headers.set('authorization', "JWT " + this.authToken.token)
       });
     }
-    // send cloned request with header to the next handler.
     return next.handle(authReq);
   }
 

--- a/src/app/core/interceptors/authentication-interceptor.ts
+++ b/src/app/core/interceptors/authentication-interceptor.ts
@@ -21,8 +21,11 @@ export class AuthenticationInterceptor implements HttpInterceptor, OnDestroy {
   intercept(req: HttpRequest<unknown>, next: HttpHandler) {
     // Branch on mode first. In cookie mode the same-origin httpOnly session cookie carries auth, so
     // send credentials and never attach a JWT header — even if a stale token is still in storage.
+    // Scope withCredentials to same-origin requests: a cross-origin request in cookie mode (e.g. the
+    // discovery GET under proxy + cross-origin URL) gets neither — the cookie cannot flow cross-origin
+    // and a stale token stays suppressed.
     if (this.auth.authMode === 'cookie') {
-      return next.handle(req.clone({ withCredentials: true }));
+      return next.handle(this.isSameOrigin(req.url) ? req.clone({ withCredentials: true }) : req.clone());
     }
 
     // Token mode (cross-origin): the cookie cannot flow, so attach the JWT header when present.
@@ -33,6 +36,15 @@ export class AuthenticationInterceptor implements HttpInterceptor, OnDestroy {
       });
     }
     return next.handle(authReq);
+  }
+
+  private isSameOrigin(url: string): boolean {
+    try {
+      // Relative URLs resolve against the app origin.
+      return new URL(url, window.location.origin).origin === window.location.origin;
+    } catch {
+      return false;
+    }
   }
 
   ngOnDestroy(): void {

--- a/src/app/core/interfaces/app-settings.interfaces.ts
+++ b/src/app/core/interfaces/app-settings.interfaces.ts
@@ -10,7 +10,9 @@ export interface IConnectionConfig {
   signalKSubscribeAll: boolean;
   useDeviceToken: boolean;
   loginName: string;
-  loginPassword: string;
+  // Transient only: collected by the login dialog and passed to login() in memory.
+  // Never persisted to localStorage (the session JWT is the cross-reload credential).
+  loginPassword?: string;
   useSharedConfig: boolean;
   sharedConfigName: string;
 }

--- a/src/app/core/interfaces/app-settings.interfaces.ts
+++ b/src/app/core/interfaces/app-settings.interfaces.ts
@@ -15,11 +15,21 @@ export interface IConnectionConfig {
   loginPassword?: string;
   useSharedConfig: boolean;
   sharedConfigName: string;
-  // Remote-control identity is per-device (Unit 5 / R8): a profile switch must not change whether
-  // this display participates in remote control or the name it advertises.
+  // Remote-control identity is per-device: a profile switch must not change whether this display
+  // participates in remote control or the name it advertises.
   isRemoteControl: boolean;
   instanceName: string;
 }
+
+/**
+ * Per-device connectionConfig schema version (its own version space, decoupled from the app config
+ * version). Only the one-time migration in AppNetworkInitService advances a stored config to this —
+ * nothing else may stamp it, or a write would prematurely mark the migration done and lose the lifted
+ * remote-control identity.
+ */
+export const CONNECTION_CONFIG_VERSION = 13;
+/** connectionConfig versions this build can load without forcing defaults. */
+export const SUPPORTED_CONNECTION_CONFIG_VERSIONS = [11, 12, 13];
 export interface IConfig {
   app: IAppConfig | null;
   theme: IThemeConfig | null;

--- a/src/app/core/interfaces/app-settings.interfaces.ts
+++ b/src/app/core/interfaces/app-settings.interfaces.ts
@@ -15,6 +15,10 @@ export interface IConnectionConfig {
   loginPassword?: string;
   useSharedConfig: boolean;
   sharedConfigName: string;
+  // Remote-control identity is per-device (Unit 5 / R8): a profile switch must not change whether
+  // this display participates in remote control or the name it advertises.
+  isRemoteControl: boolean;
+  instanceName: string;
 }
 export interface IConfig {
   app: IAppConfig | null;
@@ -27,8 +31,6 @@ export interface IAppConfig {
   autoNightMode: boolean;
   redNightMode: boolean;
   nightModeBrightness: number;
-  isRemoteControl: boolean;
-  instanceName: string;
   dataSets: IDatasetServiceDatasetConfig[];
   unitDefaults: IUnitDefaults;
   notificationConfig: INotificationConfig;

--- a/src/app/core/services/app-initNetwork.service.spec.ts
+++ b/src/app/core/services/app-initNetwork.service.spec.ts
@@ -4,6 +4,7 @@ import { BehaviorSubject } from 'rxjs';
 import { Router } from '@angular/router';
 
 import { AppNetworkInitService, IBootstrapIssue } from './app-initNetwork.service';
+import { IConfig, IConnectionConfig } from '../interfaces/app-settings.interfaces';
 import { SignalKConnectionService } from './signalk-connection.service';
 import { AuthenticationService, ILoginStatus } from './authentication.service';
 import { SsoRedirectService } from './sso-redirect.service';
@@ -132,6 +133,55 @@ describe('AppNetworkInitService', () => {
         service.bootstrapIssue$.subscribe(i => (issue = i)).unsubscribe();
         return issue;
     }
+
+    function setConnConfig(cfg: Partial<IConnectionConfig>): void {
+        (service as unknown as { config: Partial<IConnectionConfig> }).config = cfg;
+    }
+    function migrate(remoteConfig: IConfig | null): void {
+        (service as unknown as { migrateRemoteControlToDevice: (r: IConfig | null) => void }).migrateRemoteControlToDevice(remoteConfig);
+    }
+    function storedConn(): IConnectionConfig | null {
+        const raw = localStorage.getItem('connectionConfig');
+        return raw ? JSON.parse(raw) : null;
+    }
+
+    describe('migrateRemoteControlToDevice (connectionConfig v12 -> v13)', () => {
+        const baseV12: Partial<IConnectionConfig> = { configVersion: 12, useSharedConfig: true, isRemoteControl: false, instanceName: '' };
+
+        it('shared boot lifts the profile identity and stamps v13 once', () => {
+            localStorage.removeItem('connectionConfig');
+            setConnConfig({ ...baseV12 });
+            migrate({ app: { isRemoteControl: true, instanceName: 'Helm' } } as unknown as IConfig);
+            expect(storedConn()?.isRemoteControl).toBe(true);
+            expect(storedConn()?.instanceName).toBe('Helm');
+            expect(storedConn()?.configVersion).toBe(13);
+        });
+
+        it('local boot lifts the identity from the local appConfig', () => {
+            localStorage.removeItem('connectionConfig');
+            localStorage.setItem('appConfig', JSON.stringify({ isRemoteControl: true, instanceName: 'Mast' }));
+            setConnConfig({ ...baseV12, useSharedConfig: false });
+            migrate(null);
+            expect(storedConn()?.isRemoteControl).toBe(true);
+            expect(storedConn()?.instanceName).toBe('Mast');
+            expect(storedConn()?.configVersion).toBe(13);
+        });
+
+        it('degraded shared boot (no profile) defers: version stays 12, nothing persisted', () => {
+            localStorage.removeItem('connectionConfig');
+            setConnConfig({ ...baseV12, useSharedConfig: true });
+            migrate(null);
+            expect(storedConn()).toBeNull();
+            expect((service as unknown as { config: IConnectionConfig }).config.configVersion).toBe(12);
+        });
+
+        it('is a no-op when already migrated (version >= 13)', () => {
+            localStorage.removeItem('connectionConfig');
+            setConnConfig({ ...baseV12, configVersion: 13 });
+            migrate({ app: { isRemoteControl: true, instanceName: 'X' } } as unknown as IConfig);
+            expect(storedConn()).toBeNull();
+        });
+    });
 
     describe('cookie-mode bootstrap auth (Unit 6)', () => {
         it('logged-in: proceeds without resetting the budget here (reset deferred to a clean bootstrap)', () => {

--- a/src/app/core/services/app-initNetwork.service.spec.ts
+++ b/src/app/core/services/app-initNetwork.service.spec.ts
@@ -3,9 +3,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { BehaviorSubject } from 'rxjs';
 import { Router } from '@angular/router';
 
-import { AppNetworkInitService } from './app-initNetwork.service';
+import { AppNetworkInitService, IBootstrapIssue } from './app-initNetwork.service';
 import { SignalKConnectionService } from './signalk-connection.service';
-import { AuthenticationService } from './authentication.service';
+import { AuthenticationService, ILoginStatus } from './authentication.service';
+import { SsoRedirectService } from './sso-redirect.service';
 import { ConnectionState, ConnectionStateMachine } from './connection-state-machine.service';
 import { SignalKDeltaService } from './signalk-delta.service';
 import { DataService } from './data.service';
@@ -13,6 +14,14 @@ import { StorageService } from './storage.service';
 import { InternetReachabilityService } from './internet-reachability.service';
 import { DatasetStreamService } from './dataset-stream.service';
 import { Injector } from '@angular/core';
+import { ensureLocalStorage } from '../../../test-helpers/local-storage.test-helper';
+
+// jsdom has no FontFace; preloadFonts() constructs one during the end-to-end initNetworkServices runs.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+if (typeof (globalThis as any).FontFace === 'undefined') {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).FontFace = class { load() { return Promise.resolve(this); } };
+}
 
 describe('AppNetworkInitService', () => {
     let service: AppNetworkInitService;
@@ -26,7 +35,17 @@ describe('AppNetworkInitService', () => {
 
     const mockAuth = {
         isLoggedIn$,
+        authMode: 'token' as 'cookie' | 'token',
+        loginStatusValue: null as ILoginStatus | null,
+        refreshLoginStatus: vi.fn().mockResolvedValue(null),
         login: vi.fn().mockResolvedValue(undefined)
+    };
+
+    const mockSsoRedirect = {
+        attemptAutoRedirect: vi.fn().mockReturnValue('redirected'),
+        resetBudget: vi.fn(),
+        isBudgetExhausted: vi.fn().mockReturnValue(false),
+        manualSignIn: vi.fn()
     };
 
     const mockConnectionStateMachine = {
@@ -66,6 +85,7 @@ describe('AppNetworkInitService', () => {
     };
 
     beforeEach(() => {
+        ensureLocalStorage();
         isLoggedIn$.next(false);
         state$.next(ConnectionState.Disconnected);
         mockConnectionStateMachine.currentState = ConnectionState.Disconnected;
@@ -73,12 +93,20 @@ describe('AppNetworkInitService', () => {
         mockConnectionStateMachine.isHTTPConnected.mockClear();
         mockConnectionStateMachine.enableWebSocketMode.mockClear();
         mockConnectionStateMachine.startWebSocketConnection.mockClear();
+        mockAuth.authMode = 'token';
+        mockAuth.loginStatusValue = null;
+        mockAuth.refreshLoginStatus.mockClear();
+        mockRouter.navigate.mockClear();
+        mockSsoRedirect.attemptAutoRedirect.mockClear().mockReturnValue('redirected');
+        mockSsoRedirect.resetBudget.mockClear();
+        mockSsoRedirect.isBudgetExhausted.mockClear().mockReturnValue(false);
 
         TestBed.configureTestingModule({
             providers: [
                 AppNetworkInitService,
                 { provide: SignalKConnectionService, useValue: mockConnection },
                 { provide: AuthenticationService, useValue: mockAuth },
+                { provide: SsoRedirectService, useValue: mockSsoRedirect },
                 { provide: ConnectionStateMachine, useValue: mockConnectionStateMachine },
                 { provide: Router, useValue: mockRouter },
                 { provide: SignalKDeltaService, useValue: {} },
@@ -89,6 +117,109 @@ describe('AppNetworkInitService', () => {
             ]
         });
         service = TestBed.inject(AppNetworkInitService);
+    });
+
+    function handleCookieAuth(status: ILoginStatus | null): 'redirecting' | 'proceed' | 'auth-blocked' {
+        return (service as unknown as { handleCookieAuth: (s: ILoginStatus | null) => 'redirecting' | 'proceed' | 'auth-blocked' }).handleCookieAuth(status);
+    }
+
+    function routeToReauth(): void {
+        (service as unknown as { routeToReauth: () => void }).routeToReauth();
+    }
+
+    function latestIssue(): IBootstrapIssue {
+        let issue: IBootstrapIssue = { reason: 'none' };
+        service.bootstrapIssue$.subscribe(i => (issue = i)).unsubscribe();
+        return issue;
+    }
+
+    describe('cookie-mode bootstrap auth (Unit 6)', () => {
+        it('logged-in: proceeds without resetting the budget here (reset deferred to a clean bootstrap)', () => {
+            expect(handleCookieAuth({ status: 'loggedIn' })).toBe('proceed');
+            expect(mockSsoRedirect.resetBudget).not.toHaveBeenCalled();
+            expect(mockSsoRedirect.attemptAutoRedirect).not.toHaveBeenCalled();
+        });
+
+        it('null/unreachable loginStatus: fails closed to auth-blocked, not anonymous-open', () => {
+            expect(handleCookieAuth(null)).toBe('auth-blocked');
+            expect(mockSsoRedirect.attemptAutoRedirect).not.toHaveBeenCalled();
+            expect(latestIssue()).toEqual({ reason: 'auth-blocked', cause: 'sign-in-required' });
+        });
+    });
+
+    describe('mid-bootstrap 401 re-auth routing (Unit 6)', () => {
+        it('token mode routes to /login', () => {
+            mockAuth.authMode = 'token';
+            routeToReauth();
+            expect(mockRouter.navigate).toHaveBeenCalledWith(['/login']);
+            expect(mockSsoRedirect.attemptAutoRedirect).not.toHaveBeenCalled();
+        });
+
+        it('cookie mode with oidcAutoLogin auto-redirects (budget-guarded)', () => {
+            mockAuth.authMode = 'cookie';
+            mockAuth.loginStatusValue = { status: 'loggedIn', oidcAutoLogin: true };
+            mockSsoRedirect.attemptAutoRedirect.mockReturnValue('redirected');
+
+            routeToReauth();
+
+            expect(mockSsoRedirect.attemptAutoRedirect).toHaveBeenCalledWith(mockAuth.loginStatusValue);
+            expect(mockRouter.navigate).not.toHaveBeenCalled();
+        });
+
+        it('cookie mode honors oidcAutoLogin:false (no auto-redirect on a 401)', () => {
+            mockAuth.authMode = 'cookie';
+            mockAuth.loginStatusValue = { status: 'loggedIn', oidcAutoLogin: false };
+
+            routeToReauth();
+
+            expect(mockSsoRedirect.attemptAutoRedirect).not.toHaveBeenCalled();
+            expect(latestIssue()).toEqual({ reason: 'auth-blocked', cause: 'sign-in-required' });
+        });
+
+        it('cookie mode surfaces auth-blocked when the budget is exhausted (no infinite 401 loop)', () => {
+            mockAuth.authMode = 'cookie';
+            mockAuth.loginStatusValue = { status: 'loggedIn', oidcAutoLogin: true };
+            mockSsoRedirect.attemptAutoRedirect.mockReturnValue('budget-exhausted');
+            mockSsoRedirect.isBudgetExhausted.mockReturnValue(true);
+
+            routeToReauth();
+
+            expect(latestIssue()).toEqual({ reason: 'auth-blocked', cause: 'budget-exhausted' });
+        });
+
+        it('not-logged-in + authRequired + oidcAutoLogin: auto-redirects to SSO', () => {
+            mockSsoRedirect.attemptAutoRedirect.mockReturnValue('redirected');
+            const status: ILoginStatus = { status: 'notLoggedIn', authenticationRequired: true, oidcAutoLogin: true, oidcEnabled: true };
+
+            expect(handleCookieAuth(status)).toBe('redirecting');
+
+            expect(mockSsoRedirect.attemptAutoRedirect).toHaveBeenCalledWith(status);
+        });
+
+        it('budget exhausted: proceeds with an auth-blocked/budget-exhausted issue, no loop', () => {
+            mockSsoRedirect.attemptAutoRedirect.mockReturnValue('budget-exhausted');
+            mockSsoRedirect.isBudgetExhausted.mockReturnValue(true);
+
+            expect(handleCookieAuth({ status: 'notLoggedIn', authenticationRequired: true, oidcAutoLogin: true })).toBe('auth-blocked');
+
+            expect(latestIssue()).toEqual({ reason: 'auth-blocked', cause: 'budget-exhausted' });
+        });
+
+        it('oidcAutoLogin disabled: does not auto-redirect, surfaces sign-in-required', () => {
+            const status: ILoginStatus = { status: 'notLoggedIn', authenticationRequired: true, oidcAutoLogin: false, oidcEnabled: true };
+
+            expect(handleCookieAuth(status)).toBe('auth-blocked');
+
+            expect(mockSsoRedirect.attemptAutoRedirect).not.toHaveBeenCalled();
+            expect(latestIssue()).toEqual({ reason: 'auth-blocked', cause: 'sign-in-required' });
+        });
+
+        it('authentication not required: anonymous read, no redirect, no auth-blocked issue', () => {
+            expect(handleCookieAuth({ status: 'notLoggedIn', authenticationRequired: false })).toBe('proceed');
+
+            expect(mockSsoRedirect.attemptAutoRedirect).not.toHaveBeenCalled();
+            expect(latestIssue().reason).not.toBe('auth-blocked');
+        });
     });
 
     it('should be created', () => {
@@ -115,5 +246,59 @@ describe('AppNetworkInitService', () => {
 
         expect(mockConnectionStateMachine.getHttpRetryWindowMs).not.toHaveBeenCalled();
         expect(result).toBe(ConnectionState.PermanentFailure);
+    });
+
+    // End-to-end initNetworkServices() runs — these pin the seam between handleCookieAuth and the
+    // finally that an isolated handleCookieAuth test cannot see (the original P0 loop-guard hole).
+    describe('cookie-mode bootstrap end-to-end (Unit 6 loop-guard seam)', () => {
+        it('budget-exhausted: keeps the auth-blocked recovery state and does NOT reset the budget', async () => {
+            mockAuth.authMode = 'cookie';
+            mockAuth.refreshLoginStatus.mockResolvedValue({ status: 'notLoggedIn', authenticationRequired: true, oidcAutoLogin: true });
+            mockSsoRedirect.attemptAutoRedirect.mockReturnValue('budget-exhausted');
+            mockSsoRedirect.isBudgetExhausted.mockReturnValue(true);
+
+            await service.initNetworkServices();
+
+            expect(latestIssue()).toEqual({ reason: 'auth-blocked', cause: 'budget-exhausted' });
+            expect(mockSsoRedirect.resetBudget).not.toHaveBeenCalled();
+        });
+
+        it('null loginStatus: keeps the auth-blocked recovery state and does NOT reset the budget', async () => {
+            mockAuth.authMode = 'cookie';
+            mockAuth.refreshLoginStatus.mockResolvedValue(null);
+
+            await service.initNetworkServices();
+
+            expect(latestIssue()).toEqual({ reason: 'auth-blocked', cause: 'sign-in-required' });
+            expect(mockSsoRedirect.resetBudget).not.toHaveBeenCalled();
+        });
+
+        it('logged-in clean bootstrap resets the budget', async () => {
+            mockAuth.authMode = 'cookie';
+            mockAuth.refreshLoginStatus.mockImplementation(async () => { isLoggedIn$.next(true); return { status: 'loggedIn' }; });
+
+            await service.initNetworkServices();
+
+            expect(mockSsoRedirect.resetBudget).toHaveBeenCalled();
+        });
+
+        it('does not double-start the WebSocket when a connect is already in flight at the finally', async () => {
+            mockAuth.authMode = 'cookie';
+            mockAuth.refreshLoginStatus.mockImplementation(async () => { isLoggedIn$.next(true); return { status: 'loggedIn' }; });
+            mockConnectionStateMachine.currentState = ConnectionState.WebSocketConnecting;
+
+            await service.initNetworkServices();
+
+            expect(mockConnectionStateMachine.startWebSocketConnection).not.toHaveBeenCalled();
+        });
+
+        it('starts the WebSocket once from a fresh HTTPConnected state', async () => {
+            mockAuth.authMode = 'token';
+            mockConnectionStateMachine.currentState = ConnectionState.HTTPConnected;
+
+            await service.initNetworkServices();
+
+            expect(mockConnectionStateMachine.startWebSocketConnection).toHaveBeenCalledTimes(1);
+        });
     });
 });

--- a/src/app/core/services/app-initNetwork.service.ts
+++ b/src/app/core/services/app-initNetwork.service.ts
@@ -10,7 +10,8 @@ import { inject, Injectable, Injector, OnDestroy } from '@angular/core';
 import { Router } from '@angular/router';
 import { IConfig, IConnectionConfig } from "../interfaces/app-settings.interfaces";
 import { SignalKConnectionService } from "./signalk-connection.service";
-import { AuthenticationService } from './authentication.service';
+import { AuthenticationService, ILoginStatus } from './authentication.service';
+import { SsoRedirectService } from './sso-redirect.service';
 import { DefaultConnectionConfig } from '../../../default-config/config.blank.const';
 import { BehaviorSubject, Observable, Subscription } from 'rxjs';
 import { DataService } from './data.service';
@@ -23,13 +24,15 @@ import { DatasetStreamService } from './dataset-stream.service';
 const configFileVersion = 11; // used to change the Signal K configuration storage file name (ie. 9.0.0.json) that contains the configuration definitions. Applies only to remote storage.
 const CONNECTION_CONFIG_KEY = 'connectionConfig';
 export type TBootstrapStatus = 'starting' | 'ready' | 'degraded';
-export type TBootstrapIssueReason = 'none' | 'missing-shared-config' | 'network-unreachable' | 'unauthorized' | 'unknown';
+export type TBootstrapIssueReason = 'none' | 'missing-shared-config' | 'network-unreachable' | 'unauthorized' | 'unknown' | 'auth-blocked';
+export type TAuthBlockedCause = 'budget-exhausted' | 'sign-in-required';
 
 export interface IBootstrapIssue {
   reason: TBootstrapIssueReason;
   statusCode?: number;
   sharedConfigName?: string;
   legacyUpgradeAvailable?: boolean;
+  cause?: TAuthBlockedCause;
 }
 
 @Injectable()
@@ -40,6 +43,7 @@ export class AppNetworkInitService implements OnDestroy {
 
   private readonly connection = inject(SignalKConnectionService);
   private readonly auth = inject(AuthenticationService);
+  private readonly ssoRedirect = inject(SsoRedirectService);
   private readonly connectionStateMachine = inject(ConnectionStateMachine);
   private readonly router = inject(Router);
   private readonly delta = inject(SignalKDeltaService); // Init to get data before app starts
@@ -66,8 +70,64 @@ export class AppNetworkInitService implements OnDestroy {
     return this.auth.authMode === 'cookie' || !!this.config?.useSharedConfig;
   }
 
+  /**
+   * Cookie-mode bootstrap decision from loginStatus. Returns 'redirecting' when the browser is being
+   * sent to the SK/SSO login (caller should stop), or 'proceed' otherwise:
+   * - loggedIn   → reset the redirect budget; the storage bootstrap then runs (isLoggedIn is true).
+   * - notLoggedIn + authRequired → auto-redirect when allowed by oidcAutoLogin and the budget; else
+   *   surface the auth-blocked recovery state (budget exhausted, or a manual sign-in is required).
+   * - auth not required → anonymous read; proceed with no redirect.
+   */
+  private handleCookieAuth(status: ILoginStatus | null): 'redirecting' | 'proceed' | 'auth-blocked' {
+    if (status?.status === 'loggedIn') {
+      // The budget reset is deferred to a genuinely completed bootstrap (see initNetworkServices'
+      // finally), so a loggedIn -> applicationData-401 -> reauth path cannot reset-then-loop.
+      return 'proceed';
+    }
+    if (!status) {
+      // loginStatus unreachable/unparseable: fail closed — do not assume anonymous-open access.
+      this._bootstrapIssue$.next({ reason: 'auth-blocked', cause: 'sign-in-required' });
+      return 'auth-blocked';
+    }
+    if (status.authenticationRequired) {
+      return this.attemptCookieRedirect(status) === 'redirecting' ? 'redirecting' : 'auth-blocked';
+    }
+    // authentication explicitly not required: anonymous read access, no redirect.
+    return 'proceed';
+  }
+
+  /**
+   * Cookie-mode redirect-or-block decision shared by the bootstrap path and the mid-bootstrap 401
+   * path. Auto-redirects when oidcAutoLogin allows and the budget permits; otherwise surfaces the
+   * auth-blocked recovery state (budget exhausted, or a manual sign-in is required).
+   */
+  private attemptCookieRedirect(status: ILoginStatus | null): 'redirecting' | 'blocked' {
+    if (status?.oidcAutoLogin !== false && this.ssoRedirect.attemptAutoRedirect(status) === 'redirected') {
+      return 'redirecting';
+    }
+    this._bootstrapIssue$.next({
+      reason: 'auth-blocked',
+      cause: this.ssoRedirect.isBudgetExhausted() ? 'budget-exhausted' : 'sign-in-required'
+    });
+    return 'blocked';
+  }
+
+  /**
+   * Mode-aware re-authentication routing for a mid-bootstrap 401. Cookie mode reuses the same
+   * oidcAutoLogin/budget-guarded decision as the bootstrap path (so a 401 cannot loop past the
+   * budget, and honors oidcAutoLogin:false); token mode routes to /login.
+   */
+  private routeToReauth(): void {
+    if (this.auth.authMode === 'cookie') {
+      this.attemptCookieRedirect(this.auth.loginStatusValue);
+      return;
+    }
+    this.router.navigate(['/login']);
+  }
+
   public async initNetworkServices() {
     let startupDegraded = false;
+    let redirecting = false;
     this.loadLocalStorageConfig();
     this.preloadFonts();
     this.internetReachability.start();
@@ -82,7 +142,26 @@ export class AppNetworkInitService implements OnDestroy {
         );
       }
 
-      if (!this.isLoggedIn && this.config?.signalKUrl && this.config?.useSharedConfig && this.config?.loginName && this.config?.loginPassword) {
+      // Cookie mode (same-origin): session state comes from loginStatus, not a credential login.
+      if (this.auth.authMode === 'cookie') {
+        const status = await this.auth.refreshLoginStatus();
+        const outcome = this.handleCookieAuth(status);
+        if (outcome === 'redirecting') {
+          redirecting = true;
+          return; // browser is navigating to the SK/SSO login
+        }
+        if (outcome === 'auth-blocked') {
+          // Not authorized and not auto-redirecting: keep the auth-blocked recovery state (set by
+          // handleCookieAuth), do not reset the loop budget, and finish degraded (not 'ready') so the
+          // recovery UI shows. Returning here also avoids the 'reason: none' overwrite below.
+          startupDegraded = true;
+          this._bootstrapStatus$.next('degraded');
+          return;
+        }
+      }
+
+      // Token mode (cross-origin) credential login. Never runs in cookie mode (no stored password).
+      if (this.auth.authMode !== 'cookie' && !this.isLoggedIn && this.config?.signalKUrl && this.config?.useSharedConfig && this.config?.loginName && this.config?.loginPassword) {
         await this.login();
       }
 
@@ -108,7 +187,8 @@ export class AppNetworkInitService implements OnDestroy {
       // This ensures all chart data is ready before any widget components are created.
       await this.getDatasetService().waitUntilReady();
 
-      if (!this.isLoggedIn && this.config?.signalKUrl && this.config?.useSharedConfig) {
+      // Cookie mode handled its own redirect/auth-blocked state above; only token mode falls to /login.
+      if (this.auth.authMode !== 'cookie' && !this.isLoggedIn && this.config?.signalKUrl && this.config?.useSharedConfig) {
         this.router.navigate(['/login']); // need to set credentials
       }
 
@@ -139,8 +219,8 @@ export class AppNetworkInitService implements OnDestroy {
           await this.router.navigate(['/options']);
         }
       } else if (error.status === 401) {
-        console.warn("[AppInit Network Service] Initialization failed. Unauthorized access. Redirecting to login page.");
-        await this.router.navigate(['/login']);
+        console.warn("[AppInit Network Service] Initialization failed. Unauthorized access. Routing to re-authentication.");
+        this.routeToReauth();
       } else {
         console.warn("[AppInit Network Service] Initialization failed. Error: ", JSON.stringify(error));
         await this.router.navigate(['/options']);
@@ -149,6 +229,12 @@ export class AppNetworkInitService implements OnDestroy {
       this._bootstrapStatus$.next('degraded');
       return;
     } finally {
+      if (!startupDegraded && !redirecting) {
+        // A clean, non-redirecting bootstrap is a stable state: clear the SSO redirect loop budget so
+        // a future genuine logout gets a fresh set of attempts. Not reset on the redirect/degraded
+        // paths, so a loggedIn -> 401 -> reauth loop stays bounded.
+        this.ssoRedirect.resetBudget();
+      }
       if (!startupDegraded) {
         this._bootstrapStatus$.next('ready');
       }
@@ -156,8 +242,10 @@ export class AppNetworkInitService implements OnDestroy {
       // Enable WebSocket functionality now that initialization is complete
       this.connectionStateMachine.enableWebSocketMode();
 
-      // Start WebSocket connection if HTTP discovery was successful
-      if (this.connectionStateMachine.isHTTPConnected()) {
+      // Start the WebSocket only from a fresh HTTPConnected state. In cookie mode the loginStatus
+      // result may already have driven the delta service's isLoggedIn$ reconnect (state ->
+      // WebSocketConnecting); starting again here would close and reopen the in-flight socket.
+      if (this.connectionStateMachine.currentState === ConnectionState.HTTPConnected) {
         console.log("[AppInit Network Service] Starting WebSocket connection after initialization");
         this.connectionStateMachine.startWebSocketConnection();
       }

--- a/src/app/core/services/app-initNetwork.service.ts
+++ b/src/app/core/services/app-initNetwork.service.ts
@@ -242,10 +242,12 @@ export class AppNetworkInitService implements OnDestroy {
       // Enable WebSocket functionality now that initialization is complete
       this.connectionStateMachine.enableWebSocketMode();
 
-      // Start the WebSocket only from a fresh HTTPConnected state. In cookie mode the loginStatus
-      // result may already have driven the delta service's isLoggedIn$ reconnect (state ->
-      // WebSocketConnecting); starting again here would close and reopen the in-flight socket.
-      if (this.connectionStateMachine.currentState === ConnectionState.HTTPConnected) {
+      // Start the WebSocket only on a clean bootstrap from a fresh HTTPConnected state. Skip it when
+      // degraded/redirecting (e.g. the cookie auth-blocked path, where HTTP is connected but there is
+      // no session — an anonymous WS would just churn behind the recovery toast), and when the delta
+      // service's isLoggedIn$ reconnect has already driven the state to WebSocketConnecting (starting
+      // again would close and reopen the in-flight socket).
+      if (this.connectionStateMachine.currentState === ConnectionState.HTTPConnected && !startupDegraded && !redirecting) {
         console.log("[AppInit Network Service] Starting WebSocket connection after initialization");
         this.connectionStateMachine.startWebSocketConnection();
       }

--- a/src/app/core/services/app-initNetwork.service.ts
+++ b/src/app/core/services/app-initNetwork.service.ts
@@ -165,13 +165,14 @@ export class AppNetworkInitService implements OnDestroy {
         await this.login();
       }
 
+      let remoteConfig: IConfig | null = null;
       if (this.isLoggedIn && this.useServerStorage()) {
         // Wait for storage to be fully ready before accessing it
         const storageReady = await this.storage.waitUntilReady();
         if (!storageReady) {
           throw new Error('[AppInit Network Service] StorageService did not become ready in time. Cannot bootstrap remote configuration.');
         } else {
-          const remoteConfig = await this.storage.getConfig('user', this.config.sharedConfigName, configFileVersion);
+          remoteConfig = await this.storage.getConfig('user', this.config.sharedConfigName, configFileVersion);
           const bootstrapContext: IStorageRemoteBootstrapContext = {
             sharedConfigName: this.config.sharedConfigName,
             configFileVersion,
@@ -180,6 +181,10 @@ export class AppNetworkInitService implements OnDestroy {
           this.storage.bootstrapRemoteContext(bootstrapContext);
         }
       }
+
+      // Lift remote-control identity to the per-device connectionConfig (once). Runs after the
+      // profile is loaded; skipped on a degraded shared boot (remoteConfig null) so it retries later.
+      this.migrateRemoteControlToDevice(remoteConfig);
 
       this._bootstrapIssue$.next({ reason: 'none' });
 
@@ -348,6 +353,39 @@ export class AppNetworkInitService implements OnDestroy {
 
   private setLocalStorageConfig(): void {
     localStorage.setItem(CONNECTION_CONFIG_KEY, JSON.stringify(this.config));
+  }
+
+  /**
+   * One-time migration (connectionConfig version < 13 → 13): the remote-control identity
+   * (isRemoteControl, instanceName) moved from the profile (IAppConfig) to the per-device
+   * connectionConfig. Lift the existing values from the active profile (shared mode) or the local
+   * appConfig (local mode). On a degraded shared boot the profile is unavailable, so the lift is
+   * deferred (version stays < 13) and retried on a later successful boot.
+   *
+   * @param {IConfig | null} remoteConfig The profile loaded this boot, or null when unavailable.
+   */
+  private migrateRemoteControlToDevice(remoteConfig: IConfig | null): void {
+    if (!this.config || this.config.configVersion >= 13) {
+      return;
+    }
+    // The fields still exist at runtime in pre-migration stored configs, but were removed from IAppConfig.
+    let app: { isRemoteControl?: boolean; instanceName?: string } | null =
+      (remoteConfig?.app as unknown as { isRemoteControl?: boolean; instanceName?: string }) ?? null;
+    if (!app && !this.config.useSharedConfig) {
+      try {
+        app = JSON.parse(localStorage.getItem('appConfig') ?? 'null');
+      } catch {
+        app = null;
+      }
+    }
+    if (!app && this.config.useSharedConfig) {
+      return; // shared mode but the profile is not loaded (degraded) — retry on a later boot
+    }
+    this.config.isRemoteControl = app?.isRemoteControl ?? false;
+    this.config.instanceName = app?.instanceName ?? '';
+    this.config.configVersion = 13;
+    this.setLocalStorageConfig();
+    console.log('[AppInit Network Service] Migrated remote-control identity to per-device connectionConfig (v13)');
   }
 
   private loadLocalStorageConfig(): void {

--- a/src/app/core/services/app-initNetwork.service.ts
+++ b/src/app/core/services/app-initNetwork.service.ts
@@ -8,7 +8,7 @@
 **/
 import { inject, Injectable, Injector, OnDestroy } from '@angular/core';
 import { Router } from '@angular/router';
-import { IConfig, IConnectionConfig } from "../interfaces/app-settings.interfaces";
+import { IConfig, IConnectionConfig, CONNECTION_CONFIG_VERSION } from "../interfaces/app-settings.interfaces";
 import { SignalKConnectionService } from "./signalk-connection.service";
 import { AuthenticationService, ILoginStatus } from './authentication.service';
 import { SsoRedirectService } from './sso-redirect.service';
@@ -365,7 +365,7 @@ export class AppNetworkInitService implements OnDestroy {
    * @param {IConfig | null} remoteConfig The profile loaded this boot, or null when unavailable.
    */
   private migrateRemoteControlToDevice(remoteConfig: IConfig | null): void {
-    if (!this.config || this.config.configVersion >= 13) {
+    if (!this.config || this.config.configVersion >= CONNECTION_CONFIG_VERSION) {
       return;
     }
     // The fields still exist at runtime in pre-migration stored configs, but were removed from IAppConfig.
@@ -383,7 +383,7 @@ export class AppNetworkInitService implements OnDestroy {
     }
     this.config.isRemoteControl = app?.isRemoteControl ?? false;
     this.config.instanceName = app?.instanceName ?? '';
-    this.config.configVersion = 13;
+    this.config.configVersion = CONNECTION_CONFIG_VERSION;
     this.setLocalStorageConfig();
     console.log('[AppInit Network Service] Migrated remote-control identity to per-device connectionConfig (v13)');
   }

--- a/src/app/core/services/app-initNetwork.service.ts
+++ b/src/app/core/services/app-initNetwork.service.ts
@@ -57,6 +57,15 @@ export class AppNetworkInitService implements OnDestroy {
     })
   }
 
+  /**
+   * Whether remote (server applicationData) config should be bootstrapped: cookie mode regardless of
+   * the stored useSharedConfig flag, or cross-origin shared config. Mirrors SettingsService storage
+   * routing so the two never disagree (avoids the cookie-mode localStorage split-brain).
+   */
+  private useServerStorage(): boolean {
+    return this.auth.authMode === 'cookie' || !!this.config?.useSharedConfig;
+  }
+
   public async initNetworkServices() {
     let startupDegraded = false;
     this.loadLocalStorageConfig();
@@ -77,7 +86,7 @@ export class AppNetworkInitService implements OnDestroy {
         await this.login();
       }
 
-      if (this.isLoggedIn && this.config?.useSharedConfig) {
+      if (this.isLoggedIn && this.useServerStorage()) {
         // Wait for storage to be fully ready before accessing it
         const storageReady = await this.storage.waitUntilReady();
         if (!storageReady) {

--- a/src/app/core/services/authentication.service.spec.ts
+++ b/src/app/core/services/authentication.service.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import { HttpTestingController } from '@angular/common/http/testing';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { firstValueFrom } from 'rxjs';
 import { AuthenticationService, IAuthorizationToken } from './authentication.service';
@@ -164,6 +165,205 @@ describe('AuthenticationService', () => {
       const service = createService();
       expect(await firstValueFrom(service.authToken$)).not.toBeNull();
       expect(await firstValueFrom(service.isLoggedIn$)).toBe(true);
+    });
+  });
+
+  describe('loginStatus session state (Unit 3)', () => {
+    function seedConn(overrides: Record<string, unknown>): void {
+      localStorage.setItem(
+        'connectionConfig',
+        JSON.stringify({
+          configVersion: 12,
+          kipUUID: 'u',
+          signalKUrl: '',
+          proxyEnabled: true,
+          signalKSubscribeAll: false,
+          useDeviceToken: false,
+          loginName: '',
+          useSharedConfig: true,
+          sharedConfigName: 'default',
+          ...overrides
+        })
+      );
+    }
+
+    function expectLoginStatusRequest(httpTesting: HttpTestingController) {
+      return httpTesting.expectOne(
+        req => req.url.endsWith('/skServer/loginStatus') && !req.url.includes('/signalk/v1')
+      );
+    }
+
+    it('logged-in writable session: isLoggedIn/isUserSession/canWriteUserData true, no token', async () => {
+      seedConn({ proxyEnabled: true });
+      const service = createService();
+      const httpTesting = TestBed.inject(HttpTestingController);
+
+      const pending = service.refreshLoginStatus();
+      const req = expectLoginStatusRequest(httpTesting);
+      expect(req.request.method).toBe('GET');
+      expect(req.request.withCredentials).toBe(true);
+      req.flush({ status: 'loggedIn', readOnlyAccess: false, userLevel: 'admin' });
+      await pending;
+
+      expect(await firstValueFrom(service.isLoggedIn$)).toBe(true);
+      expect(await firstValueFrom(service.isUserSession$)).toBe(true);
+      expect(await firstValueFrom(service.canWriteUserData$)).toBe(true);
+      expect(await firstValueFrom(service.authToken$)).toBeNull();
+      httpTesting.verify();
+    });
+
+    it('logged-in read-only session: isUserSession true, canWriteUserData false', async () => {
+      seedConn({ proxyEnabled: true });
+      const service = createService();
+      const httpTesting = TestBed.inject(HttpTestingController);
+
+      const pending = service.refreshLoginStatus();
+      expectLoginStatusRequest(httpTesting).flush({ status: 'loggedIn', readOnlyAccess: true });
+      await pending;
+
+      expect(await firstValueFrom(service.isLoggedIn$)).toBe(true);
+      expect(await firstValueFrom(service.isUserSession$)).toBe(true);
+      expect(await firstValueFrom(service.canWriteUserData$)).toBe(false);
+      httpTesting.verify();
+    });
+
+    it('not-logged-in: all session flags false; OIDC descriptors captured', async () => {
+      seedConn({ proxyEnabled: true });
+      const service = createService();
+      const httpTesting = TestBed.inject(HttpTestingController);
+
+      const pending = service.refreshLoginStatus();
+      expectLoginStatusRequest(httpTesting).flush({
+        status: 'notLoggedIn',
+        authenticationRequired: true,
+        oidcEnabled: true,
+        oidcAutoLogin: true,
+        oidcLoginUrl: '/signalk/v1/auth/oidc/login',
+        oidcProviderName: 'HaLOS SSO'
+      });
+      await pending;
+
+      expect(await firstValueFrom(service.isLoggedIn$)).toBe(false);
+      expect(await firstValueFrom(service.isUserSession$)).toBe(false);
+      expect(await firstValueFrom(service.canWriteUserData$)).toBe(false);
+      const status = await firstValueFrom(service.loginStatus$);
+      expect(status?.authenticationRequired).toBe(true);
+      expect(status?.oidcEnabled).toBe(true);
+      expect(status?.oidcAutoLogin).toBe(true);
+      expect(status?.oidcLoginUrl).toBe('/signalk/v1/auth/oidc/login');
+      httpTesting.verify();
+    });
+
+    it('unreachable server: fails closed (not logged in), returns null, no throw', async () => {
+      seedConn({ proxyEnabled: true });
+      const service = createService();
+      const httpTesting = TestBed.inject(HttpTestingController);
+
+      const pending = service.refreshLoginStatus();
+      expectLoginStatusRequest(httpTesting).flush('down', { status: 503, statusText: 'Service Unavailable' });
+      const result = await pending;
+
+      expect(result).toBeNull();
+      expect(await firstValueFrom(service.isLoggedIn$)).toBe(false);
+      expect(await firstValueFrom(service.isUserSession$)).toBe(false);
+      expect(await firstValueFrom(service.canWriteUserData$)).toBe(false);
+      httpTesting.verify();
+    });
+
+    it('unexpected response shape: not logged in, no throw', async () => {
+      seedConn({ proxyEnabled: true });
+      const service = createService();
+      const httpTesting = TestBed.inject(HttpTestingController);
+
+      const pending = service.refreshLoginStatus();
+      expectLoginStatusRequest(httpTesting).flush({ unexpected: 'shape' });
+      await pending;
+
+      expect(await firstValueFrom(service.isLoggedIn$)).toBe(false);
+      expect(await firstValueFrom(service.isUserSession$)).toBe(false);
+      httpTesting.verify();
+    });
+
+    it('non-object 200 body (e.g. an HTML login page): not logged in, no throw', async () => {
+      seedConn({ proxyEnabled: true });
+      const service = createService();
+      const httpTesting = TestBed.inject(HttpTestingController);
+
+      const pending = service.refreshLoginStatus();
+      expectLoginStatusRequest(httpTesting).flush('<!doctype html><html>login</html>');
+      const result = await pending;
+
+      expect(result).toBeNull();
+      expect(await firstValueFrom(service.isLoggedIn$)).toBe(false);
+      expect(await firstValueFrom(service.isUserSession$)).toBe(false);
+      expect(await firstValueFrom(service.canWriteUserData$)).toBe(false);
+      httpTesting.verify();
+    });
+
+    it('mid-session transition: logged-in -> not-logged-in -> failure flips all signals false and clears descriptors', async () => {
+      seedConn({ proxyEnabled: true });
+      const service = createService();
+      const httpTesting = TestBed.inject(HttpTestingController);
+
+      // 1. Logged in, OIDC descriptors present.
+      const first = service.refreshLoginStatus();
+      expectLoginStatusRequest(httpTesting).flush({
+        status: 'loggedIn',
+        readOnlyAccess: false,
+        oidcEnabled: true,
+        oidcLoginUrl: '/signalk/v1/auth/oidc/login'
+      });
+      await first;
+      expect(await firstValueFrom(service.isLoggedIn$)).toBe(true);
+      expect(await firstValueFrom(service.isUserSession$)).toBe(true);
+      expect(await firstValueFrom(service.canWriteUserData$)).toBe(true);
+      expect((await firstValueFrom(service.loginStatus$))?.oidcLoginUrl).toBe('/signalk/v1/auth/oidc/login');
+
+      // 2. Session ends server-side: re-check returns notLoggedIn; stale OIDC descriptor cleared.
+      const second = service.refreshLoginStatus();
+      expectLoginStatusRequest(httpTesting).flush({ status: 'notLoggedIn' });
+      await second;
+      expect(await firstValueFrom(service.isLoggedIn$)).toBe(false);
+      expect(await firstValueFrom(service.isUserSession$)).toBe(false);
+      expect(await firstValueFrom(service.canWriteUserData$)).toBe(false);
+      expect((await firstValueFrom(service.loginStatus$))?.oidcLoginUrl).toBeUndefined();
+
+      // 3. A later failure re-emits null status (fail-closed) on the already-used instance.
+      const third = service.refreshLoginStatus();
+      expectLoginStatusRequest(httpTesting).flush('down', { status: 503, statusText: 'Service Unavailable' });
+      await third;
+      expect(await firstValueFrom(service.isLoggedIn$)).toBe(false);
+      expect(await firstValueFrom(service.loginStatus$)).toBeNull();
+      httpTesting.verify();
+    });
+
+    it('token mode does not query loginStatus', async () => {
+      seedConn({ proxyEnabled: false, signalKUrl: 'https://boat.example:3443' });
+      const service = createService();
+      const httpTesting = TestBed.inject(HttpTestingController);
+
+      const result = await service.refreshLoginStatus();
+
+      expect(result).toBeNull();
+      httpTesting.verify(); // asserts no loginStatus request was issued
+    });
+
+    it('token-mode user token yields a user session via the derived signals', async () => {
+      seedConn({ proxyEnabled: false, signalKUrl: 'https://boat.example:3443' });
+      seedToken({ expiry: nowSec() + 3600, isDeviceAccessToken: false });
+      const service = createService();
+
+      expect(await firstValueFrom(service.isUserSession$)).toBe(true);
+      expect(await firstValueFrom(service.canWriteUserData$)).toBe(true);
+    });
+
+    it('token-mode device token is not a user session', async () => {
+      seedConn({ proxyEnabled: false, signalKUrl: 'https://boat.example:3443' });
+      seedToken({ expiry: nowSec() + 3600, isDeviceAccessToken: true });
+      const service = createService();
+
+      expect(await firstValueFrom(service.isUserSession$)).toBe(false);
+      expect(await firstValueFrom(service.canWriteUserData$)).toBe(false);
     });
   });
 });

--- a/src/app/core/services/authentication.service.spec.ts
+++ b/src/app/core/services/authentication.service.spec.ts
@@ -212,18 +212,33 @@ describe('AuthenticationService', () => {
       httpTesting.verify();
     });
 
-    it('logged-in read-only session: isUserSession true, canWriteUserData false', async () => {
+    it('logged-in read-only user (userLevel readonly): isUserSession true, canWriteUserData false', async () => {
       seedConn({ proxyEnabled: true });
       const service = createService();
       const httpTesting = TestBed.inject(HttpTestingController);
 
       const pending = service.refreshLoginStatus();
-      expectLoginStatusRequest(httpTesting).flush({ status: 'loggedIn', readOnlyAccess: true });
+      expectLoginStatusRequest(httpTesting).flush({ status: 'loggedIn', userLevel: 'readonly' });
       await pending;
 
       expect(await firstValueFrom(service.isLoggedIn$)).toBe(true);
       expect(await firstValueFrom(service.isUserSession$)).toBe(true);
       expect(await firstValueFrom(service.canWriteUserData$)).toBe(false);
+      httpTesting.verify();
+    });
+
+    it('admin user stays write-capable even when the server allows anonymous read (readOnlyAccess true)', async () => {
+      // readOnlyAccess is the server allow_readonly flag, NOT the user's permission. A signed-in
+      // admin (userLevel admin) must remain write-capable regardless of it.
+      seedConn({ proxyEnabled: true });
+      const service = createService();
+      const httpTesting = TestBed.inject(HttpTestingController);
+
+      const pending = service.refreshLoginStatus();
+      expectLoginStatusRequest(httpTesting).flush({ status: 'loggedIn', userLevel: 'admin', readOnlyAccess: true });
+      await pending;
+
+      expect(await firstValueFrom(service.canWriteUserData$)).toBe(true);
       httpTesting.verify();
     });
 
@@ -309,7 +324,7 @@ describe('AuthenticationService', () => {
       const first = service.refreshLoginStatus();
       expectLoginStatusRequest(httpTesting).flush({
         status: 'loggedIn',
-        readOnlyAccess: false,
+        userLevel: 'admin',
         oidcEnabled: true,
         oidcLoginUrl: '/signalk/v1/auth/oidc/login'
       });

--- a/src/app/core/services/authentication.service.spec.ts
+++ b/src/app/core/services/authentication.service.spec.ts
@@ -242,6 +242,53 @@ describe('AuthenticationService', () => {
       httpTesting.verify();
     });
 
+    it('logged-in readwrite user: canWriteUserData true', async () => {
+      seedConn({ proxyEnabled: true });
+      const service = createService();
+      const httpTesting = TestBed.inject(HttpTestingController);
+
+      const pending = service.refreshLoginStatus();
+      expectLoginStatusRequest(httpTesting).flush({ status: 'loggedIn', userLevel: 'readwrite' });
+      await pending;
+
+      expect(await firstValueFrom(service.canWriteUserData$)).toBe(true);
+      httpTesting.verify();
+    });
+
+    it('logged-in with no userLevel: isUserSession true but canWriteUserData false (fail closed)', async () => {
+      seedConn({ proxyEnabled: true });
+      const service = createService();
+      const httpTesting = TestBed.inject(HttpTestingController);
+
+      const pending = service.refreshLoginStatus();
+      expectLoginStatusRequest(httpTesting).flush({ status: 'loggedIn' });
+      await pending;
+
+      expect(await firstValueFrom(service.isUserSession$)).toBe(true);
+      expect(await firstValueFrom(service.canWriteUserData$)).toBe(false);
+      httpTesting.verify();
+    });
+
+    it('fails closed when loginStatus does not respond within the timeout', async () => {
+      vi.useFakeTimers();
+      try {
+        seedConn({ proxyEnabled: true });
+        const service = createService();
+        const httpTesting = TestBed.inject(HttpTestingController);
+
+        const pending = service.refreshLoginStatus();
+        expectLoginStatusRequest(httpTesting); // request opened, never flushed
+        await vi.advanceTimersByTimeAsync(5001);
+        const result = await pending;
+
+        expect(result).toBeNull();
+        expect(await firstValueFrom(service.isLoggedIn$)).toBe(false);
+        httpTesting.verify();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it('not-logged-in: all session flags false; OIDC descriptors captured', async () => {
       seedConn({ proxyEnabled: true });
       const service = createService();

--- a/src/app/core/services/authentication.service.spec.ts
+++ b/src/app/core/services/authentication.service.spec.ts
@@ -83,4 +83,87 @@ describe('AuthenticationService', () => {
       expect(localStorage.getItem('authorization_token')).toBeNull();
     });
   });
+
+  describe('auth mode detection (Unit 2)', () => {
+    function seedConn(overrides: Record<string, unknown>): void {
+      localStorage.setItem(
+        'connectionConfig',
+        JSON.stringify({
+          configVersion: 12,
+          kipUUID: 'u',
+          signalKUrl: 'http://localhost',
+          proxyEnabled: false,
+          signalKSubscribeAll: false,
+          useDeviceToken: false,
+          loginName: '',
+          useSharedConfig: true,
+          sharedConfigName: 'default',
+          ...overrides
+        })
+      );
+    }
+
+    it("returns 'cookie' when proxy mode is enabled (effective origin is the app)", () => {
+      seedConn({ proxyEnabled: true, signalKUrl: 'https://elsewhere.example:9999' });
+      expect(createService().authMode).toBe('cookie');
+    });
+
+    it("returns 'cookie' when the server URL is empty (defaults to the app origin)", () => {
+      seedConn({ signalKUrl: '' });
+      expect(createService().authMode).toBe('cookie');
+    });
+
+    it("returns 'cookie' when the server URL matches the app origin", () => {
+      seedConn({ signalKUrl: window.location.origin });
+      expect(createService().authMode).toBe('cookie');
+    });
+
+    it("returns 'token' for a cross-origin server URL", () => {
+      seedConn({ signalKUrl: 'https://boat.example:3443' });
+      expect(createService().authMode).toBe('token');
+    });
+  });
+
+  describe('startup token suppression by mode (Unit 2)', () => {
+    function seedConn(overrides: Record<string, unknown>): void {
+      localStorage.setItem(
+        'connectionConfig',
+        JSON.stringify({
+          configVersion: 12,
+          kipUUID: 'u',
+          signalKUrl: 'http://localhost',
+          proxyEnabled: false,
+          signalKSubscribeAll: false,
+          useDeviceToken: false,
+          loginName: '',
+          useSharedConfig: true,
+          sharedConfigName: 'default',
+          ...overrides
+        })
+      );
+    }
+
+    it('ignores a stored user token in cookie mode (cookie/SSO is authoritative)', async () => {
+      seedConn({ proxyEnabled: true });
+      seedToken({ expiry: nowSec() + 3600, isDeviceAccessToken: false });
+      const service = createService();
+      expect(await firstValueFrom(service.authToken$)).toBeNull();
+      expect(await firstValueFrom(service.isLoggedIn$)).toBe(false);
+    });
+
+    it('keeps a stored device token in cookie mode (unattended fallback, not stranded)', async () => {
+      seedConn({ proxyEnabled: true });
+      seedToken({ expiry: nowSec() + 3600, isDeviceAccessToken: true });
+      const service = createService();
+      expect(await firstValueFrom(service.authToken$)).not.toBeNull();
+    });
+
+    it('keeps a stored user token in token mode (cross-origin)', async () => {
+      seedConn({ signalKUrl: 'https://boat.example:3443' });
+      seedToken({ expiry: nowSec() + 3600, isDeviceAccessToken: false });
+      const service = createService();
+      expect(await firstValueFrom(service.authToken$)).not.toBeNull();
+      expect(await firstValueFrom(service.isLoggedIn$)).toBe(true);
+    });
+  });
 });

--- a/src/app/core/services/authentication.service.spec.ts
+++ b/src/app/core/services/authentication.service.spec.ts
@@ -1,16 +1,86 @@
 import { TestBed } from '@angular/core/testing';
-import { beforeEach, describe, expect, it } from 'vitest';
-import { AuthenticationService } from './authentication.service';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { firstValueFrom } from 'rxjs';
+import { AuthenticationService, IAuthorizationToken } from './authentication.service';
+import { ensureLocalStorage } from '../../../test-helpers/local-storage.test-helper';
+
+const nowSec = (): number => Math.floor(Date.now() / 1000);
+
+// The constructor/renewal paths read token.expiry from the stored IAuthorizationToken
+// object, so a decodable JWT is not required for these tests.
+function seedToken(token: Partial<IAuthorizationToken>): void {
+  localStorage.setItem(
+    'authorization_token',
+    JSON.stringify({ token: 'jwt', expiry: null, isDeviceAccessToken: false, ...token })
+  );
+}
+
+function seedConnectionConfig(loginPassword: string): void {
+  localStorage.setItem(
+    'connectionConfig',
+    JSON.stringify({
+      configVersion: 12,
+      kipUUID: 'u',
+      signalKUrl: 'http://localhost',
+      proxyEnabled: false,
+      signalKSubscribeAll: false,
+      useDeviceToken: false,
+      loginName: 'pi',
+      loginPassword,
+      useSharedConfig: true,
+      sharedConfigName: 'default'
+    })
+  );
+}
+
+function createService(): AuthenticationService {
+  // Real AuthenticationService; HttpClient + SignalKConnectionService come from the
+  // global test stubs (src/test.ts).
+  TestBed.configureTestingModule({ providers: [AuthenticationService] });
+  return TestBed.inject(AuthenticationService);
+}
 
 describe('AuthenticationService', () => {
-  let service: AuthenticationService;
-
-  beforeEach(() => {
-    TestBed.configureTestingModule({});
-    service = TestBed.inject(AuthenticationService);
-  });
+  beforeEach(() => ensureLocalStorage());
 
   it('should be created', () => {
-    expect(service).toBeTruthy();
+    expect(createService()).toBeTruthy();
+  });
+
+  describe('startup token handling (Option A: the JWT is the persisted credential)', () => {
+    it('keeps an unexpired user-session token and reports logged in', async () => {
+      seedToken({ expiry: nowSec() + 3600, isDeviceAccessToken: false });
+      const service = createService();
+      expect(await firstValueFrom(service.authToken$)).not.toBeNull();
+      expect(await firstValueFrom(service.isLoggedIn$)).toBe(true);
+      expect(localStorage.getItem('authorization_token')).not.toBeNull();
+    });
+
+    it('deletes an expired user-session token on startup', async () => {
+      seedToken({ expiry: nowSec() - 10, isDeviceAccessToken: false });
+      const service = createService();
+      expect(await firstValueFrom(service.authToken$)).toBeNull();
+      expect(await firstValueFrom(service.isLoggedIn$)).toBe(false);
+      expect(localStorage.getItem('authorization_token')).toBeNull();
+    });
+  });
+
+  describe('token renewal without a stored password', () => {
+    it('deletes the token to surface re-login instead of re-POSTing stored credentials', async () => {
+      // Construct with a far-future token so the constructor does not auto-trigger renewal.
+      seedToken({ expiry: nowSec() + 3600, isDeviceAccessToken: false });
+      const service = createService();
+      const loginSpy = vi.spyOn(service, 'login').mockResolvedValue(undefined);
+
+      // Move the stored token into the renewal window (still valid, < buffer remaining).
+      seedToken({ expiry: nowSec() + 30, isDeviceAccessToken: false });
+      seedConnectionConfig('plaintext-secret-must-not-be-used');
+
+      (service as unknown as { handleTokenRenewal: () => void }).handleTokenRenewal();
+
+      expect(loginSpy).not.toHaveBeenCalled();
+      expect(await firstValueFrom(service.authToken$)).toBeNull();
+      expect(localStorage.getItem('authorization_token')).toBeNull();
+    });
   });
 });

--- a/src/app/core/services/authentication.service.ts
+++ b/src/app/core/services/authentication.service.ts
@@ -1,8 +1,8 @@
 import { SignalKConnectionService, IEndpointStatus } from './signalk-connection.service';
 import { HttpClient, HttpResponse, HttpErrorResponse } from '@angular/common/http';
 import { Injectable, OnDestroy, inject } from '@angular/core';
-import { BehaviorSubject, lastValueFrom, Subscription } from 'rxjs';
-import { distinctUntilChanged } from "rxjs/operators";
+import { BehaviorSubject, combineLatest, lastValueFrom, Subscription } from 'rxjs';
+import { distinctUntilChanged, map } from "rxjs/operators";
 
 export interface IAuthorizationToken {
   expiry: number;
@@ -18,10 +18,29 @@ export interface IAuthorizationToken {
  */
 export type AuthMode = 'cookie' | 'token';
 
+/**
+ * Parsed subset of the Signal K server's `GET /skServer/loginStatus` response. Drives cookie-mode
+ * session state and carries the login/OIDC descriptors the bootstrap redirect needs. All fields are
+ * optional because the response shape is owned by the server and is treated defensively (fail-closed:
+ * a session is only "logged in" when {@link status} is exactly `'loggedIn'`).
+ */
+export interface ILoginStatus {
+  status?: string;
+  authenticationRequired?: boolean;
+  readOnlyAccess?: boolean;
+  userLevel?: string;
+  username?: string;
+  oidcEnabled?: boolean;
+  oidcAutoLogin?: boolean;
+  oidcLoginUrl?: string;
+  oidcProviderName?: string;
+}
+
 const defaultApiPath = '/signalk/v1/'; // Use as default for new server URL changes. We do a Login before ConnectionService has time to send the new endpoitn url
 const loginEndpoint = 'auth/login';
 const logoutEndpoint = 'auth/logout';
 const validateTokenEndpoint = 'auth/validate';
+const loginStatusPath = '/skServer/loginStatus'; // server-origin, not the /signalk/v1 API base
 const tokenRenewalBuffer = 60; // nb of seconds before token expiration
 const MAX_TIMEOUT_MS = 2147483647; // Maximum safe delay for setTimeout (~24.8 days)
 
@@ -36,6 +55,30 @@ export class AuthenticationService implements OnDestroy {
   public isLoggedIn$ = this._IsLoggedIn$.asObservable();
   private _authToken$ = new BehaviorSubject<IAuthorizationToken>(null);
   public authToken$ = this._authToken$.asObservable();
+
+  // Latest parsed loginStatus (cookie mode only; null until refreshed or on any failure).
+  private _loginStatus$ = new BehaviorSubject<ILoginStatus | null>(null);
+  public loginStatus$ = this._loginStatus$.asObservable();
+
+  /**
+   * A real per-user identity is present: cookie-mode logged-in session, or a non-device token in
+   * token mode. Profiles availability and user-scope applicationData key off this, not token presence.
+   */
+  public isUserSession$ = combineLatest([this._authToken$, this._loginStatus$]).pipe(
+    map(([token, status]) => this.deriveIsUserSession(token, status)),
+    distinctUntilChanged()
+  );
+
+  /**
+   * The current session can write user-scope data: a user session that is not server-side read-only.
+   * Write affordances (config save, profile create/rename/delete/switch) gate on this so a read-only
+   * session does not present controls that silently fail server-side.
+   */
+  public canWriteUserData$ = combineLatest([this._authToken$, this._loginStatus$]).pipe(
+    map(([token, status]) => this.deriveCanWriteUserData(token, status)),
+    distinctUntilChanged()
+  );
+
   private connectionEndpointSubscription: Subscription = null;
   private authTokenSubscription: Subscription = null;
   private renewalTimerId: ReturnType<typeof setTimeout> | null = null; // Node & browser compatible handle
@@ -148,6 +191,50 @@ export class AuthenticationService implements OnDestroy {
     } catch {
       return false;
     }
+  }
+
+  /**
+   * Cookie mode: query `GET /skServer/loginStatus` with credentials so the httpOnly session cookie
+   * authenticates the probe, and derive session state from it (fail-closed). Returns the parsed
+   * status (including OIDC descriptors for the bootstrap redirect), or null on any failure or in
+   * token mode (where loginStatus is not consulted). The request targets the served origin — in
+   * cookie mode the effective Signal K origin equals `window.location.origin` by definition — not the
+   * post-discovery `/signalk/v1` base.
+   */
+  public async refreshLoginStatus(): Promise<ILoginStatus | null> {
+    if (this.authMode !== 'cookie') {
+      return null;
+    }
+    const url = window.location.origin + loginStatusPath;
+    try {
+      const raw = await lastValueFrom(this.http.get<ILoginStatus>(url, { withCredentials: true }));
+      return this.applyLoginStatus(raw);
+    } catch {
+      // Unreachable, non-2xx, or unparseable response: treat as not logged in.
+      return this.applyLoginStatus(null);
+    }
+  }
+
+  private applyLoginStatus(raw: unknown): ILoginStatus | null {
+    const status: ILoginStatus | null = raw && typeof raw === 'object' ? (raw as ILoginStatus) : null;
+    this._loginStatus$.next(status);
+    this._IsLoggedIn$.next(status?.status === 'loggedIn');
+    return status;
+  }
+
+  private deriveIsUserSession(token: IAuthorizationToken | null, status: ILoginStatus | null): boolean {
+    if (this.authMode === 'cookie') {
+      return status?.status === 'loggedIn';
+    }
+    return !!token && !token.isDeviceAccessToken;
+  }
+
+  private deriveCanWriteUserData(token: IAuthorizationToken | null, status: ILoginStatus | null): boolean {
+    if (this.authMode === 'cookie') {
+      return status?.status === 'loggedIn' && !status.readOnlyAccess;
+    }
+    // Token mode has no readOnly signal; a user token has always been treated as write-capable.
+    return !!token && !token.isDeviceAccessToken;
   }
 
   private scheduleRenewalChunk(token: IAuthorizationToken) {

--- a/src/app/core/services/authentication.service.ts
+++ b/src/app/core/services/authentication.service.ts
@@ -60,6 +60,11 @@ export class AuthenticationService implements OnDestroy {
   private _loginStatus$ = new BehaviorSubject<ILoginStatus | null>(null);
   public loginStatus$ = this._loginStatus$.asObservable();
 
+  /** Latest parsed loginStatus, read synchronously (e.g. by the SSO redirect). Null until refreshed. */
+  public get loginStatusValue(): ILoginStatus | null {
+    return this._loginStatus$.getValue();
+  }
+
   /**
    * A real per-user identity is present: cookie-mode logged-in session, or a non-device token in
    * token mode. Profiles availability and user-scope applicationData key off this, not token presence.

--- a/src/app/core/services/authentication.service.ts
+++ b/src/app/core/services/authentication.service.ts
@@ -237,10 +237,20 @@ export class AuthenticationService implements OnDestroy {
 
   private deriveCanWriteUserData(token: IAuthorizationToken | null, status: ILoginStatus | null): boolean {
     if (this.authMode === 'cookie') {
-      return status?.status === 'loggedIn' && !status.readOnlyAccess;
+      return status?.status === 'loggedIn' && this.isWriteUserLevel(status.userLevel);
     }
-    // Token mode has no readOnly signal; a user token has always been treated as write-capable.
+    // Token mode has no loginStatus; a user token has always been treated as write-capable.
     return !!token && !token.isDeviceAccessToken;
+  }
+
+  /**
+   * Whether a Signal K userLevel (skPrincipal.permissions) can write user-scope data. SK treats
+   * 'admin' and 'readwrite' as write-capable; 'readonly' (or an absent level) cannot. Note this is
+   * NOT loginStatus.readOnlyAccess — that field is the server's allow_readonly (anonymous read)
+   * config and is independent of the signed-in user's permission.
+   */
+  private isWriteUserLevel(userLevel?: string): boolean {
+    return userLevel === 'admin' || userLevel === 'readwrite';
   }
 
   private scheduleRenewalChunk(token: IAuthorizationToken) {

--- a/src/app/core/services/authentication.service.ts
+++ b/src/app/core/services/authentication.service.ts
@@ -10,6 +10,14 @@ export interface IAuthorizationToken {
   isDeviceAccessToken: boolean;
 }
 
+/**
+ * Auth carriage mode, derived synchronously from the connection config:
+ * - 'cookie': KIP is served same-origin as the Signal K server; the httpOnly session cookie
+ *   carries auth (no token header / WS token param).
+ * - 'token': cross-origin; auth is carried by the stored JWT (header + WS query param).
+ */
+export type AuthMode = 'cookie' | 'token';
+
 const defaultApiPath = '/signalk/v1/'; // Use as default for new server URL changes. We do a Login before ConnectionService has time to send the new endpoitn url
 const loginEndpoint = 'auth/login';
 const logoutEndpoint = 'auth/logout';
@@ -55,10 +63,14 @@ export class AuthenticationService implements OnDestroy {
           console.log('[Authentication Service] Device Access Token found in Local Storage');
           this._authToken$.next(token);
         }
+      } else if (this.authMode === 'cookie') {
+        // Cookie mode (same-origin): the SSO/session cookie is authoritative, so a stored user
+        // token is ignored for carriage (authToken$ stays null). Device tokens are still kept
+        // (above) as the unattended same-origin fallback.
+        console.log('[Authentication Service] User session token ignored in cookie mode (session cookie is authoritative)');
       } else {
-        // User session token: keep it across reloads (Option A — the session JWT is the
-        // persisted credential now that the plaintext password is no longer stored). Delete
-        // only when expired; mirrors the device-token handling above.
+        // Token mode (cross-origin): keep the unexpired user JWT across reloads (Option A — the
+        // session JWT is the persisted credential now that the plaintext password is not stored).
         if (token.expiry === null) {
           console.log('[Authentication Service] User session token found with expiry: NEVER');
           this._IsLoggedIn$.next(true);
@@ -98,6 +110,44 @@ export class AuthenticationService implements OnDestroy {
         this.validateTokenUrl = httpApiUrl + validateTokenEndpoint;
       }
     });
+  }
+
+  /**
+   * Synchronous auth carriage mode (no async / no connection discovery), so the HTTP interceptor
+   * and bootstrap can branch on it from the very first request. See {@link AuthMode}.
+   */
+  public get authMode(): AuthMode {
+    return this.effectiveOriginIsSameAsApp() ? 'cookie' : 'token';
+  }
+
+  /**
+   * Whether the effective Signal K request origin equals the origin KIP is served from. True when
+   * proxy mode is enabled (endpoints are rewritten to the app origin) or the configured server URL
+   * resolves to the app origin (an empty URL defaults to the app origin). Conservative on any gap:
+   * an unreadable config or unparseable URL is treated as cross-origin (token mode), preserving
+   * existing behavior.
+   */
+  private effectiveOriginIsSameAsApp(): boolean {
+    let config: { proxyEnabled?: boolean; signalKUrl?: string } | null = null;
+    try {
+      config = JSON.parse(localStorage.getItem('connectionConfig'));
+    } catch {
+      config = null;
+    }
+    if (!config) {
+      return false;
+    }
+    if (config.proxyEnabled) {
+      return true;
+    }
+    if (!config.signalKUrl) {
+      return true;
+    }
+    try {
+      return new URL(config.signalKUrl).origin === window.location.origin;
+    } catch {
+      return false;
+    }
   }
 
   private scheduleRenewalChunk(token: IAuthorizationToken) {

--- a/src/app/core/services/authentication.service.ts
+++ b/src/app/core/services/authentication.service.ts
@@ -165,36 +165,37 @@ export class AuthenticationService implements OnDestroy {
    * and bootstrap can branch on it from the very first request. See {@link AuthMode}.
    */
   public get authMode(): AuthMode {
-    return this.effectiveOriginIsSameAsApp() ? 'cookie' : 'token';
+    return this.authModeForConfig(this.readConnectionConfig());
   }
 
   /**
-   * Whether the effective Signal K request origin equals the origin KIP is served from. True when
-   * proxy mode is enabled (endpoints are rewritten to the app origin) or the configured server URL
-   * resolves to the app origin (an empty URL defaults to the app origin). Conservative on any gap:
-   * an unreadable config or unparseable URL is treated as cross-origin (token mode), preserving
-   * existing behavior.
+   * Resolves the carriage mode for a given connection config (not necessarily the stored one — the
+   * Connectivity tab uses this to pre-check a config being edited). Cookie mode when proxy is enabled
+   * (endpoints rewrite to the app origin) or the server URL resolves to the app origin (an empty URL
+   * defaults to it). Conservative on any gap: an unreadable config or unparseable URL is token mode.
    */
-  private effectiveOriginIsSameAsApp(): boolean {
-    let config: { proxyEnabled?: boolean; signalKUrl?: string } | null = null;
-    try {
-      config = JSON.parse(localStorage.getItem('connectionConfig'));
-    } catch {
-      config = null;
-    }
+  public authModeForConfig(config: { proxyEnabled?: boolean; signalKUrl?: string } | null): AuthMode {
     if (!config) {
-      return false;
+      return 'token';
     }
     if (config.proxyEnabled) {
-      return true;
+      return 'cookie';
     }
     if (!config.signalKUrl) {
-      return true;
+      return 'cookie';
     }
     try {
-      return new URL(config.signalKUrl).origin === window.location.origin;
+      return new URL(config.signalKUrl).origin === window.location.origin ? 'cookie' : 'token';
     } catch {
-      return false;
+      return 'token';
+    }
+  }
+
+  private readConnectionConfig(): { proxyEnabled?: boolean; signalKUrl?: string } | null {
+    try {
+      return JSON.parse(localStorage.getItem('connectionConfig'));
+    } catch {
+      return null;
     }
   }
 

--- a/src/app/core/services/authentication.service.ts
+++ b/src/app/core/services/authentication.service.ts
@@ -1,7 +1,7 @@
 import { SignalKConnectionService, IEndpointStatus } from './signalk-connection.service';
 import { HttpClient, HttpResponse, HttpErrorResponse } from '@angular/common/http';
 import { Injectable, OnDestroy, inject } from '@angular/core';
-import { BehaviorSubject, combineLatest, lastValueFrom, Subscription } from 'rxjs';
+import { BehaviorSubject, combineLatest, lastValueFrom, Subscription, timeout } from 'rxjs';
 import { distinctUntilChanged, map } from "rxjs/operators";
 
 export interface IAuthorizationToken {
@@ -27,7 +27,6 @@ export type AuthMode = 'cookie' | 'token';
 export interface ILoginStatus {
   status?: string;
   authenticationRequired?: boolean;
-  readOnlyAccess?: boolean;
   userLevel?: string;
   username?: string;
   oidcEnabled?: boolean;
@@ -39,8 +38,8 @@ export interface ILoginStatus {
 const defaultApiPath = '/signalk/v1/'; // Use as default for new server URL changes. We do a Login before ConnectionService has time to send the new endpoitn url
 const loginEndpoint = 'auth/login';
 const logoutEndpoint = 'auth/logout';
-const validateTokenEndpoint = 'auth/validate';
 const loginStatusPath = '/skServer/loginStatus'; // server-origin, not the /signalk/v1 API base
+const loginStatusTimeoutMs = 5000; // bounded so a hung endpoint cannot block the APP_INITIALIZER
 const tokenRenewalBuffer = 60; // nb of seconds before token expiration
 const MAX_TIMEOUT_MS = 2147483647; // Maximum safe delay for setTimeout (~24.8 days)
 
@@ -92,7 +91,6 @@ export class AuthenticationService implements OnDestroy {
   // Network connection
   private loginUrl = null;
   private logoutUrl = null;
-  private validateTokenUrl = null;
 
   constructor()
   {
@@ -155,7 +153,6 @@ export class AuthenticationService implements OnDestroy {
         const httpApiUrl: string = endpoint.httpServiceUrl.substring(0, endpoint.httpServiceUrl.length - 4); // this removes 'api/' from the end
         this.loginUrl = httpApiUrl + loginEndpoint;
         this.logoutUrl = httpApiUrl + logoutEndpoint;
-        this.validateTokenUrl = httpApiUrl + validateTokenEndpoint;
       }
     });
   }
@@ -213,7 +210,7 @@ export class AuthenticationService implements OnDestroy {
     }
     const url = window.location.origin + loginStatusPath;
     try {
-      const raw = await lastValueFrom(this.http.get<ILoginStatus>(url, { withCredentials: true }));
+      const raw = await lastValueFrom(this.http.get<ILoginStatus>(url, { withCredentials: true }).pipe(timeout(loginStatusTimeoutMs)));
       return this.applyLoginStatus(raw);
     } catch {
       // Unreachable, non-2xx, or unparseable response: treat as not logged in.
@@ -444,11 +441,6 @@ export class AuthenticationService implements OnDestroy {
       date.setUTCSeconds(dateAsSeconds);
     }
     return date;
-  }
-
-  // not yet implemented by Signal K but part of the specs. Using contained token string expiration value instead for now
-  private renewToken() {
-    return this.http.post<HttpResponse<Response>>(this.validateTokenUrl, null, {observe: 'response'});
   }
 
   /**

--- a/src/app/core/services/authentication.service.ts
+++ b/src/app/core/services/authentication.service.ts
@@ -56,9 +56,21 @@ export class AuthenticationService implements OnDestroy {
           this._authToken$.next(token);
         }
       } else {
-        console.log('[Authentication Service] User session token found in Local Storage');
-        console.log('[Authentication Service] Deleting user session token');
-        localStorage.removeItem('authorization_token');
+        // User session token: keep it across reloads (Option A — the session JWT is the
+        // persisted credential now that the plaintext password is no longer stored). Delete
+        // only when expired; mirrors the device-token handling above.
+        if (token.expiry === null) {
+          console.log('[Authentication Service] User session token found with expiry: NEVER');
+          this._IsLoggedIn$.next(true);
+          this._authToken$.next(token);
+        } else if (this.isTokenExpired(token.expiry)) {
+          console.log('[Authentication Service] User session token expired. Deleting token');
+          localStorage.removeItem('authorization_token');
+        } else {
+          console.log('[Authentication Service] User session token found in Local Storage');
+          this._IsLoggedIn$.next(true);
+          this._authToken$.next(token);
+        }
       }
     }
 
@@ -148,18 +160,12 @@ export class AuthenticationService implements OnDestroy {
         this.isRenewingToken = false;
         this.scheduleRenewalChunk(token);
       } else {
-        console.log(`[Authentication Service] User session Token within renewal window (${remainingSec}s remaining). Renewing token...`);
-        const connectionConfig = JSON.parse(localStorage.getItem('connectionConfig'));
-        this.login({ usr: connectionConfig.loginName, pwd: connectionConfig.loginPassword })
-          .then(() => {
-            console.log('[Authentication Service] Token successfully renewed.');
-          })
-          .catch((error: HttpErrorResponse) => {
-            console.error('[Authentication Service] Token renewal failed. Server returned:', error.error);
-          })
-          .finally(() => {
-            this.isRenewingToken = false;
-          });
+        // No silent refresh available: auth/validate is unimplemented on the server and the
+        // plaintext password is no longer stored. Surface re-login by dropping the token rather
+        // than re-POSTing stored credentials.
+        console.log(`[Authentication Service] User session token within renewal window (${remainingSec}s remaining); no refresh available. Signing out to surface re-login.`);
+        this.deleteToken();
+        this.isRenewingToken = false;
       }
     }
   }

--- a/src/app/core/services/profile.service.spec.ts
+++ b/src/app/core/services/profile.service.spec.ts
@@ -187,6 +187,13 @@ describe('ProfileService', () => {
       await service.deleteProfile('old');
       expect(storage.removeItem).toHaveBeenCalledWith('user', 'old');
     });
+
+    it('surfaces a delete that did not persist (drain reports failure)', async () => {
+      setup(makeStorageMock(['default', 'profileA', 'old']), makeSettingsMock('profileA'));
+      storage.awaitQueueDrain.mockResolvedValueOnce(false);
+      await service.refresh();
+      await expect(service.deleteProfile('old')).rejects.toThrow(/retry/i);
+    });
   });
 
   describe('rename', () => {
@@ -225,6 +232,17 @@ describe('ProfileService', () => {
       await expect(service.renameProfile('other', 'renamed')).rejects.toThrow(/no usable configuration/i);
       expect(storage.setConfig).not.toHaveBeenCalled();
       expect(storage.removeItem).not.toHaveBeenCalled();
+    });
+
+    it('waits for the old-slot delete to drain before switching to the renamed active slot', async () => {
+      let resolveDrain: (v: boolean) => void = () => undefined;
+      storage.awaitQueueDrain.mockReturnValueOnce(new Promise<boolean>((r) => { resolveDrain = r; }));
+      const p = service.renameProfile('profileA', 'newName'); // active = profileA
+      await new Promise((r) => setTimeout(r, 0)); // flush the resolved awaits up to the hanging drain
+      expect(settings.setActiveProfile).not.toHaveBeenCalled();
+      resolveDrain(true);
+      await p;
+      expect(settings.setActiveProfile).toHaveBeenCalledWith('newName');
     });
   });
 

--- a/src/app/core/services/profile.service.spec.ts
+++ b/src/app/core/services/profile.service.spec.ts
@@ -1,0 +1,189 @@
+import { TestBed } from '@angular/core/testing';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ProfileService } from './profile.service';
+import { StorageService } from './storage.service';
+import { SettingsService } from './settings.service';
+import { IConfig } from '../interfaces/app-settings.interfaces';
+
+const cfg = (theme = 'x'): IConfig => ({
+  app: { configVersion: 12 } as IConfig['app'],
+  theme: { themeName: theme },
+  dashboards: [{ id: 'd' }]
+});
+
+function makeStorageMock(userNames: string[] = ['default', 'profileA']) {
+  return {
+    sharedConfigName: 'profileA',
+    listConfigs: vi.fn<() => Promise<{ scope: string; name: string }[]>>(() =>
+      Promise.resolve([
+        ...userNames.map((name) => ({ scope: 'user', name })),
+        { scope: 'global', name: 'sharedThing' }
+      ])
+    ),
+    getConfig: vi.fn<(scope: string, name: string) => Promise<IConfig>>(() => Promise.resolve(cfg('fromGet'))),
+    setConfig: vi.fn<(scope: string, name: string, config: IConfig) => Promise<null>>(() => Promise.resolve(null)),
+    removeItem: vi.fn<(scope: string, name: string) => void>(() => undefined),
+    awaitQueueDrain: vi.fn<() => Promise<boolean>>(() => Promise.resolve(true))
+  };
+}
+
+function makeSettingsMock(active = 'profileA') {
+  return {
+    getActiveProfileName: vi.fn(() => active),
+    setActiveProfile: vi.fn(),
+    getActiveConfigSnapshot: vi.fn(() => cfg('current'))
+  };
+}
+
+describe('ProfileService', () => {
+  let service: ProfileService;
+  let storage: ReturnType<typeof makeStorageMock>;
+  let settings: ReturnType<typeof makeSettingsMock>;
+
+  function setup(storageMock = makeStorageMock(), settingsMock = makeSettingsMock()) {
+    storage = storageMock;
+    settings = settingsMock;
+    TestBed.resetTestingModule(); // allow tests to reconfigure with different mocks
+    TestBed.configureTestingModule({
+      providers: [
+        ProfileService,
+        { provide: StorageService, useValue: storage },
+        { provide: SettingsService, useValue: settings }
+      ]
+    });
+    service = TestBed.inject(ProfileService);
+  }
+
+  beforeEach(() => setup());
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('refresh / list', () => {
+    it('lists user-scope profiles (incl default), flags the active one, drops global scope', async () => {
+      await service.refresh();
+      expect(service.profiles().map((p) => p.name)).toEqual(['default', 'profileA']);
+      expect(service.profiles().find((p) => p.name === 'profileA')?.isActive).toBe(true);
+      expect(service.profiles().find((p) => p.name === 'default')?.isActive).toBe(false);
+    });
+  });
+
+  describe('switch', () => {
+    it('drains the queue then delegates to SettingsService.setActiveProfile', async () => {
+      await service.switchProfile('cockpit');
+      expect(storage.awaitQueueDrain).toHaveBeenCalled();
+      expect(settings.setActiveProfile).toHaveBeenCalledWith('cockpit');
+    });
+  });
+
+  describe('create', () => {
+    it('blank seed writes a default config under the new name', async () => {
+      await service.refresh();
+      await service.createProfile('cockpit', 'blank');
+      expect(storage.setConfig).toHaveBeenCalledTimes(1);
+      const [scope, name, config] = storage.setConfig.mock.calls[0];
+      expect(scope).toBe('user');
+      expect(name).toBe('cockpit');
+      expect(config.app).toBeTruthy();
+      expect(Array.isArray(config.dashboards)).toBe(true);
+      expect(config.dashboards.length).toBeGreaterThan(0);
+    });
+
+    it('current seed clones the live snapshot', async () => {
+      await service.refresh();
+      await service.createProfile('cockpit', 'current');
+      const config = storage.setConfig.mock.calls[0][2] as IConfig;
+      expect(config.theme?.themeName).toBe('current');
+    });
+
+    it('does not auto-switch into the created profile', async () => {
+      await service.refresh();
+      await service.createProfile('cockpit', 'blank');
+      expect(settings.setActiveProfile).not.toHaveBeenCalled();
+    });
+
+    it.each(['', '   ', 'default', 'profileA', 'bad/name', 'bad.name', 'a~b', 'a::b'])(
+      'rejects invalid/duplicate/reserved name "%s" without writing',
+      async (bad) => {
+        await service.refresh();
+        await expect(service.createProfile(bad, 'blank')).rejects.toThrow();
+        expect(storage.setConfig).not.toHaveBeenCalled();
+      }
+    );
+
+    it('surfaces a storage failure and never switches', async () => {
+      await service.refresh();
+      storage.setConfig.mockRejectedValueOnce(new Error('500'));
+      await expect(service.createProfile('cockpit', 'blank')).rejects.toThrow();
+      expect(settings.setActiveProfile).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('duplicate', () => {
+    it('copies the source config under a new name', async () => {
+      await service.refresh();
+      await service.duplicateProfile('profileA', 'profileB');
+      expect(storage.getConfig).toHaveBeenCalledWith('user', 'profileA');
+      expect(storage.setConfig).toHaveBeenCalledWith('user', 'profileB', expect.anything());
+    });
+  });
+
+  describe('delete (guard rails)', () => {
+    it('blocks deleting the active profile', async () => {
+      await service.refresh();
+      await expect(service.deleteProfile('profileA')).rejects.toThrow(/active/i);
+      expect(storage.removeItem).not.toHaveBeenCalled();
+    });
+
+    it('blocks deleting the reserved default profile', async () => {
+      await service.refresh();
+      await expect(service.deleteProfile('default')).rejects.toThrow(/default/i);
+      expect(storage.removeItem).not.toHaveBeenCalled();
+    });
+
+    it('blocks deleting the last remaining profile', async () => {
+      setup(makeStorageMock(['solo']), makeSettingsMock('other'));
+      await service.refresh();
+      await expect(service.deleteProfile('solo')).rejects.toThrow(/last/i);
+      expect(storage.removeItem).not.toHaveBeenCalled();
+    });
+
+    it('deletes a non-active, non-default profile', async () => {
+      setup(makeStorageMock(['default', 'profileA', 'old']), makeSettingsMock('profileA'));
+      await service.refresh();
+      await service.deleteProfile('old');
+      expect(storage.removeItem).toHaveBeenCalledWith('user', 'old');
+    });
+  });
+
+  describe('rename', () => {
+    it('renaming the active profile creates new, deletes old, then switches (reload)', async () => {
+      await service.refresh(); // active = profileA
+      await service.renameProfile('profileA', 'newName');
+      expect(storage.setConfig).toHaveBeenCalledWith('user', 'newName', expect.anything());
+      expect(storage.removeItem).toHaveBeenCalledWith('user', 'profileA');
+      expect(settings.setActiveProfile).toHaveBeenCalledWith('newName');
+      // ordering: create new slot before deleting old before switching
+      const setOrder = storage.setConfig.mock.invocationCallOrder[0];
+      const rmOrder = storage.removeItem.mock.invocationCallOrder[0];
+      const switchOrder = settings.setActiveProfile.mock.invocationCallOrder[0];
+      expect(setOrder).toBeLessThan(rmOrder);
+      expect(rmOrder).toBeLessThan(switchOrder);
+    });
+
+    it('renaming a non-active profile does not reload', async () => {
+      setup(makeStorageMock(['default', 'profileA', 'other']), makeSettingsMock('profileA'));
+      await service.refresh();
+      await service.renameProfile('other', 'renamed');
+      expect(storage.setConfig).toHaveBeenCalledWith('user', 'renamed', expect.anything());
+      expect(storage.removeItem).toHaveBeenCalledWith('user', 'other');
+      expect(settings.setActiveProfile).not.toHaveBeenCalled();
+    });
+
+    it('blocks renaming the reserved default profile', async () => {
+      await service.refresh();
+      await expect(service.renameProfile('default', 'x')).rejects.toThrow(/default/i);
+    });
+  });
+});

--- a/src/app/core/services/profile.service.spec.ts
+++ b/src/app/core/services/profile.service.spec.ts
@@ -69,10 +69,15 @@ describe('ProfileService', () => {
   });
 
   describe('switch', () => {
-    it('drains the queue then delegates to SettingsService.setActiveProfile', async () => {
-      await service.switchProfile('cockpit');
+    it('verifies the slot exists, drains the queue, then delegates to setActiveProfile', async () => {
+      await service.switchProfile('default'); // present in the listed user slots
       expect(storage.awaitQueueDrain).toHaveBeenCalled();
-      expect(settings.setActiveProfile).toHaveBeenCalledWith('cockpit');
+      expect(settings.setActiveProfile).toHaveBeenCalledWith('default');
+    });
+
+    it('refuses to switch to a slot that no longer exists (deleted on another device)', async () => {
+      await expect(service.switchProfile('ghost')).rejects.toThrow(/no longer exists/i);
+      expect(settings.setActiveProfile).not.toHaveBeenCalled();
     });
   });
 
@@ -119,6 +124,13 @@ describe('ProfileService', () => {
       expect(storage.getConfig).toHaveBeenCalledWith('user', 'profileA');
       expect(storage.setConfig).toHaveBeenCalledWith('user', 'profileB', expect.anything());
     });
+
+    it('refuses to copy an empty/unbootable source slot (server returns {})', async () => {
+      storage.getConfig.mockResolvedValueOnce({} as IConfig);
+      await service.refresh();
+      await expect(service.duplicateProfile('profileA', 'profileB')).rejects.toThrow(/no usable configuration/i);
+      expect(storage.setConfig).not.toHaveBeenCalled();
+    });
   });
 
   describe('import', () => {
@@ -132,6 +144,13 @@ describe('ProfileService', () => {
     it('rejects a structurally invalid config without writing', async () => {
       await service.refresh();
       await expect(service.importProfile('imported', { not: 'a config' })).rejects.toThrow(/valid/i);
+      expect(storage.setConfig).not.toHaveBeenCalled();
+    });
+
+    it('rejects a shape-valid config with an unsupported version without writing', async () => {
+      await service.refresh();
+      const stale = { app: { configVersion: 9 }, theme: { themeName: 'old' }, dashboards: [] };
+      await expect(service.importProfile('imported', stale)).rejects.toThrow(/version/i);
       expect(storage.setConfig).not.toHaveBeenCalled();
     });
 
@@ -197,6 +216,27 @@ describe('ProfileService', () => {
     it('blocks renaming the reserved default profile', async () => {
       await service.refresh();
       await expect(service.renameProfile('default', 'x')).rejects.toThrow(/default/i);
+    });
+
+    it('refuses to rename when the source slot is empty/unbootable', async () => {
+      setup(makeStorageMock(['default', 'profileA', 'other']), makeSettingsMock('profileA'));
+      storage.getConfig.mockResolvedValueOnce({} as IConfig);
+      await service.refresh();
+      await expect(service.renameProfile('other', 'renamed')).rejects.toThrow(/no usable configuration/i);
+      expect(storage.setConfig).not.toHaveBeenCalled();
+      expect(storage.removeItem).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('re-entrancy', () => {
+    it('rejects a second mutation while one is still in flight', async () => {
+      let release: () => void = () => undefined;
+      storage.setConfig.mockReturnValueOnce(new Promise((r) => { release = () => r(null); }));
+      const first = service.createProfile('one');
+      const second = service.createProfile('two');
+      await expect(second).rejects.toThrow(/in progress/i);
+      release();
+      await first;
     });
   });
 });

--- a/src/app/core/services/profile.service.spec.ts
+++ b/src/app/core/services/profile.service.spec.ts
@@ -30,8 +30,7 @@ function makeStorageMock(userNames: string[] = ['default', 'profileA']) {
 function makeSettingsMock(active = 'profileA') {
   return {
     getActiveProfileName: vi.fn(() => active),
-    setActiveProfile: vi.fn(),
-    getActiveConfigSnapshot: vi.fn(() => cfg('current'))
+    setActiveProfile: vi.fn()
   };
 }
 
@@ -78,9 +77,9 @@ describe('ProfileService', () => {
   });
 
   describe('create', () => {
-    it('blank seed writes a default config under the new name', async () => {
+    it('writes a default config under the new name', async () => {
       await service.refresh();
-      await service.createProfile('cockpit', 'blank');
+      await service.createProfile('cockpit');
       expect(storage.setConfig).toHaveBeenCalledTimes(1);
       const [scope, name, config] = storage.setConfig.mock.calls[0];
       expect(scope).toBe('user');
@@ -90,16 +89,9 @@ describe('ProfileService', () => {
       expect(config.dashboards.length).toBeGreaterThan(0);
     });
 
-    it('current seed clones the live snapshot', async () => {
-      await service.refresh();
-      await service.createProfile('cockpit', 'current');
-      const config = storage.setConfig.mock.calls[0][2] as IConfig;
-      expect(config.theme?.themeName).toBe('current');
-    });
-
     it('does not auto-switch into the created profile', async () => {
       await service.refresh();
-      await service.createProfile('cockpit', 'blank');
+      await service.createProfile('cockpit');
       expect(settings.setActiveProfile).not.toHaveBeenCalled();
     });
 
@@ -107,7 +99,7 @@ describe('ProfileService', () => {
       'rejects invalid/duplicate/reserved name "%s" without writing',
       async (bad) => {
         await service.refresh();
-        await expect(service.createProfile(bad, 'blank')).rejects.toThrow();
+        await expect(service.createProfile(bad)).rejects.toThrow();
         expect(storage.setConfig).not.toHaveBeenCalled();
       }
     );
@@ -115,7 +107,7 @@ describe('ProfileService', () => {
     it('surfaces a storage failure and never switches', async () => {
       await service.refresh();
       storage.setConfig.mockRejectedValueOnce(new Error('500'));
-      await expect(service.createProfile('cockpit', 'blank')).rejects.toThrow();
+      await expect(service.createProfile('cockpit')).rejects.toThrow();
       expect(settings.setActiveProfile).not.toHaveBeenCalled();
     });
   });

--- a/src/app/core/services/profile.service.spec.ts
+++ b/src/app/core/services/profile.service.spec.ts
@@ -129,6 +129,27 @@ describe('ProfileService', () => {
     });
   });
 
+  describe('import', () => {
+    it('imports a valid config as a new profile (no auto-switch)', async () => {
+      await service.refresh();
+      await service.importProfile('imported', cfg('imp'));
+      expect(storage.setConfig).toHaveBeenCalledWith('user', 'imported', expect.objectContaining({ theme: { themeName: 'imp' } }));
+      expect(settings.setActiveProfile).not.toHaveBeenCalled();
+    });
+
+    it('rejects a structurally invalid config without writing', async () => {
+      await service.refresh();
+      await expect(service.importProfile('imported', { not: 'a config' })).rejects.toThrow(/valid/i);
+      expect(storage.setConfig).not.toHaveBeenCalled();
+    });
+
+    it('rejects an invalid name without writing', async () => {
+      await service.refresh();
+      await expect(service.importProfile('bad/name', cfg())).rejects.toThrow();
+      expect(storage.setConfig).not.toHaveBeenCalled();
+    });
+  });
+
   describe('delete (guard rails)', () => {
     it('blocks deleting the active profile', async () => {
       await service.refresh();

--- a/src/app/core/services/profile.service.ts
+++ b/src/app/core/services/profile.service.ts
@@ -57,7 +57,10 @@ export class ProfileService {
       if (!this.existingNames().includes(name)) {
         throw new Error(`Profile "${name}" no longer exists — it may have been deleted on another device.`);
       }
-      await this.storage.awaitQueueDrain();
+      const drained = await this.storage.awaitQueueDrain();
+      if (!drained) {
+        console.warn('[ProfileService] Pending changes to the previous profile may not have been saved before switching.');
+      }
       this.settings.setActiveProfile(name);
     });
   }
@@ -127,7 +130,10 @@ export class ProfileService {
       await this.storage.setConfig(PROFILE_SCOPE, normalized, sourceConfig);
 
       this.storage.removeItem(PROFILE_SCOPE, oldName);
-      await this.storage.awaitQueueDrain();
+      const drained = await this.storage.awaitQueueDrain();
+      if (!drained) {
+        console.warn(`[ProfileService] Old profile slot "${oldName}" may not have been removed; an orphan copy could remain until the next refresh.`);
+      }
 
       if (oldName === this.settings.getActiveProfileName()) {
         this.settings.setActiveProfile(normalized); // persist + reload onto the renamed slot
@@ -151,8 +157,11 @@ export class ProfileService {
         throw new Error('The last remaining profile cannot be deleted.');
       }
       this.storage.removeItem(PROFILE_SCOPE, name);
-      await this.storage.awaitQueueDrain();
+      const drained = await this.storage.awaitQueueDrain();
       await this.refresh();
+      if (!drained) {
+        throw new Error(`Could not confirm "${name}" was deleted on the server — it may still exist. Please retry.`);
+      }
     });
   }
 

--- a/src/app/core/services/profile.service.ts
+++ b/src/app/core/services/profile.service.ts
@@ -1,0 +1,155 @@
+import { Injectable, computed, inject, signal } from '@angular/core';
+import { cloneDeep } from 'lodash-es';
+import { IConfig } from '../interfaces/app-settings.interfaces';
+import { StorageService } from './storage.service';
+import { SettingsService } from './settings.service';
+import { defaultConfig } from '../../../default-config/config.blank.const';
+import { DefaultDashboard } from '../../../default-config/config.blank.dashboard';
+import { UUID } from '../utils/uuid.util';
+
+export interface IProfileSummary {
+  name: string;
+  isActive: boolean;
+}
+
+/** Reserved fallback profile name: a fresh device boots into it and it must always be available. */
+const RESERVED_DEFAULT = 'default';
+/** Profile names are URL path segments AND JSON-Patch keys; '.' truncates and '/' splits on the
+ * Signal K server (confirmed by the Unit 1 probe), so only an allow-list charset is safe. */
+const PROFILE_NAME_PATTERN = /^[A-Za-z0-9 _-]+$/;
+const MAX_NAME_LENGTH = 64;
+const PROFILE_SCOPE = 'user';
+
+export type ProfileSeed = 'current' | 'blank';
+
+/**
+ * Owns profile (named config slot) lifecycle: list / switch / create / rename / duplicate / delete.
+ * Orchestrates StorageService (slot CRUD, all hardcoded to the 'user' scope) and SettingsService
+ * (active-profile name + reload + clone snapshot). Mutations reject on storage failure; callers
+ * surface the error. The active name is never changed on a failed mutation.
+ */
+@Injectable({ providedIn: 'root' })
+export class ProfileService {
+  private readonly storage = inject(StorageService);
+  private readonly settings = inject(SettingsService);
+
+  private readonly _profiles = signal<IProfileSummary[]>([]);
+  public readonly profiles = this._profiles.asReadonly();
+  public readonly activeProfileName = computed(() => this._profiles().find((p) => p.isActive)?.name ?? null);
+
+  /** Refresh the user-scope profile list and flag the active one. */
+  public async refresh(): Promise<void> {
+    const all = (await this.storage.listConfigs()) ?? [];
+    const active = this.settings.getActiveProfileName();
+    this._profiles.set(
+      all
+        .filter((c) => c.scope === PROFILE_SCOPE)
+        .map((c) => ({ name: c.name, isActive: c.name === active }))
+    );
+  }
+
+  /** Make a profile active on this device. Drains pending writes, then persists + reloads. */
+  public async switchProfile(name: string): Promise<void> {
+    await this.storage.awaitQueueDrain();
+    this.settings.setActiveProfile(name);
+  }
+
+  /** Create a new profile seeded from the current config (clone) or a blank default. Does not switch. */
+  public async createProfile(name: string, seed: ProfileSeed): Promise<void> {
+    await this.refresh();
+    const normalized = this.validateNewName(name);
+    const config = seed === 'current' ? this.requireSnapshot() : this.buildBlankConfig();
+    await this.storage.setConfig(PROFILE_SCOPE, normalized, cloneDeep(config));
+    await this.refresh();
+  }
+
+  /** Copy an existing profile's config under a new name. */
+  public async duplicateProfile(sourceName: string, newName: string): Promise<void> {
+    await this.refresh();
+    const normalized = this.validateNewName(newName);
+    const sourceConfig = await this.storage.getConfig(PROFILE_SCOPE, sourceName);
+    await this.storage.setConfig(PROFILE_SCOPE, normalized, sourceConfig);
+    await this.refresh();
+  }
+
+  /**
+   * Rename a profile: create the new slot, then delete the old one. When the active profile is
+   * renamed, the old slot is deleted (awaited via the queue drain) before switching to the new
+   * name so the device never reloads into a missing slot and no orphan is left behind.
+   */
+  public async renameProfile(oldName: string, newName: string): Promise<void> {
+    await this.refresh();
+    const normalized = this.validateNewName(newName);
+    if (oldName === RESERVED_DEFAULT) {
+      throw new Error(`The "${RESERVED_DEFAULT}" profile cannot be renamed.`);
+    }
+    const sourceConfig = await this.storage.getConfig(PROFILE_SCOPE, oldName);
+    await this.storage.setConfig(PROFILE_SCOPE, normalized, sourceConfig);
+
+    this.storage.removeItem(PROFILE_SCOPE, oldName);
+    await this.storage.awaitQueueDrain();
+
+    if (oldName === this.settings.getActiveProfileName()) {
+      this.settings.setActiveProfile(normalized); // persist + reload onto the renamed slot
+    } else {
+      await this.refresh();
+    }
+  }
+
+  /** Delete a profile. Refuses the active, the reserved default, and the last remaining profile. */
+  public async deleteProfile(name: string): Promise<void> {
+    await this.refresh();
+    if (name === RESERVED_DEFAULT) {
+      throw new Error(`The "${RESERVED_DEFAULT}" profile cannot be deleted.`);
+    }
+    if (name === this.settings.getActiveProfileName()) {
+      throw new Error('The active profile cannot be deleted. Switch to another profile first.');
+    }
+    if (this.existingNames().length <= 1) {
+      throw new Error('The last remaining profile cannot be deleted.');
+    }
+    this.storage.removeItem(PROFILE_SCOPE, name);
+    await this.storage.awaitQueueDrain();
+    await this.refresh();
+  }
+
+  private existingNames(): string[] {
+    return this._profiles().map((p) => p.name);
+  }
+
+  private requireSnapshot(): IConfig {
+    const snapshot = this.settings.getActiveConfigSnapshot();
+    if (!snapshot) {
+      throw new Error('Cannot clone the current profile: its configuration is not loaded.');
+    }
+    return snapshot;
+  }
+
+  private buildBlankConfig(): IConfig {
+    const config = cloneDeep(defaultConfig);
+    const dashboards = cloneDeep(DefaultDashboard);
+    dashboards[0].id = UUID.create();
+    config.dashboards = dashboards;
+    return config;
+  }
+
+  private validateNewName(name: string): string {
+    const trimmed = (name ?? '').trim();
+    if (!trimmed) {
+      throw new Error('Profile name cannot be empty.');
+    }
+    if (trimmed === RESERVED_DEFAULT) {
+      throw new Error(`"${RESERVED_DEFAULT}" is reserved and cannot be used as a profile name.`);
+    }
+    if (!PROFILE_NAME_PATTERN.test(trimmed)) {
+      throw new Error('Profile name may only contain letters, numbers, spaces, hyphens and underscores.');
+    }
+    if (trimmed.length > MAX_NAME_LENGTH) {
+      throw new Error('Profile name is too long.');
+    }
+    if (this.existingNames().includes(trimmed)) {
+      throw new Error(`A profile named "${trimmed}" already exists.`);
+    }
+    return trimmed;
+  }
+}

--- a/src/app/core/services/profile.service.ts
+++ b/src/app/core/services/profile.service.ts
@@ -20,12 +20,10 @@ const PROFILE_NAME_PATTERN = /^[A-Za-z0-9 _-]+$/;
 const MAX_NAME_LENGTH = 64;
 const PROFILE_SCOPE = 'user';
 
-export type ProfileSeed = 'current' | 'blank';
-
 /**
  * Owns profile (named config slot) lifecycle: list / switch / create / rename / duplicate / delete.
  * Orchestrates StorageService (slot CRUD, all hardcoded to the 'user' scope) and SettingsService
- * (active-profile name + reload + clone snapshot). Mutations reject on storage failure; callers
+ * (active-profile name + reload). Mutations reject on storage failure; callers
  * surface the error. The active name is never changed on a failed mutation.
  */
 @Injectable({ providedIn: 'root' })
@@ -54,12 +52,11 @@ export class ProfileService {
     this.settings.setActiveProfile(name);
   }
 
-  /** Create a new profile seeded from the current config (clone) or a blank default. Does not switch. */
-  public async createProfile(name: string, seed: ProfileSeed): Promise<void> {
+  /** Create a new profile from a blank default config. Does not switch. */
+  public async createProfile(name: string): Promise<void> {
     await this.refresh();
     const normalized = this.validateNewName(name);
-    const config = seed === 'current' ? this.requireSnapshot() : this.buildBlankConfig();
-    await this.storage.setConfig(PROFILE_SCOPE, normalized, cloneDeep(config));
+    await this.storage.setConfig(PROFILE_SCOPE, normalized, cloneDeep(this.buildBlankConfig()));
     await this.refresh();
   }
 
@@ -137,14 +134,6 @@ export class ProfileService {
     }
     const cfg = c as Record<string, unknown>;
     return 'app' in cfg && 'theme' in cfg && Array.isArray(cfg['dashboards']);
-  }
-
-  private requireSnapshot(): IConfig {
-    const snapshot = this.settings.getActiveConfigSnapshot();
-    if (!snapshot) {
-      throw new Error('Cannot clone the current profile: its configuration is not loaded.');
-    }
-    return snapshot;
   }
 
   private buildBlankConfig(): IConfig {

--- a/src/app/core/services/profile.service.ts
+++ b/src/app/core/services/profile.service.ts
@@ -63,6 +63,20 @@ export class ProfileService {
     await this.refresh();
   }
 
+  /**
+   * Import an arbitrary config as a NEW profile (never overwrites an existing one, never
+   * auto-switches). The config is structurally validated before it is written.
+   */
+  public async importProfile(name: string, config: unknown): Promise<void> {
+    await this.refresh();
+    const normalized = this.validateNewName(name);
+    if (!this.isValidConfigShape(config)) {
+      throw new Error('The selected file is not a valid KIP configuration.');
+    }
+    await this.storage.setConfig(PROFILE_SCOPE, normalized, config);
+    await this.refresh();
+  }
+
   /** Copy an existing profile's config under a new name. */
   public async duplicateProfile(sourceName: string, newName: string): Promise<void> {
     await this.refresh();
@@ -115,6 +129,14 @@ export class ProfileService {
 
   private existingNames(): string[] {
     return this._profiles().map((p) => p.name);
+  }
+
+  private isValidConfigShape(c: unknown): c is IConfig {
+    if (!c || typeof c !== 'object') {
+      return false;
+    }
+    const cfg = c as Record<string, unknown>;
+    return 'app' in cfg && 'theme' in cfg && Array.isArray(cfg['dashboards']);
   }
 
   private requireSnapshot(): IConfig {

--- a/src/app/core/services/profile.service.ts
+++ b/src/app/core/services/profile.service.ts
@@ -15,7 +15,7 @@ export interface IProfileSummary {
 /** Reserved fallback profile name: a fresh device boots into it and it must always be available. */
 const RESERVED_DEFAULT = 'default';
 /** Profile names are URL path segments AND JSON-Patch keys; '.' truncates and '/' splits on the
- * Signal K server (confirmed by the Unit 1 probe), so only an allow-list charset is safe. */
+ * Signal K server, so only an allow-list charset is safe. */
 const PROFILE_NAME_PATTERN = /^[A-Za-z0-9 _-]+$/;
 const MAX_NAME_LENGTH = 64;
 const PROFILE_SCOPE = 'user';

--- a/src/app/core/services/profile.service.ts
+++ b/src/app/core/services/profile.service.ts
@@ -35,6 +35,10 @@ export class ProfileService {
   public readonly profiles = this._profiles.asReadonly();
   public readonly activeProfileName = computed(() => this._profiles().find((p) => p.isActive)?.name ?? null);
 
+  // Serializes mutating operations: a second create/rename/delete/switch while one is in flight is
+  // rejected rather than racing (the plan's double-switch / re-entrancy guard).
+  private mutationInFlight = false;
+
   /** Refresh the user-scope profile list and flag the active one. */
   public async refresh(): Promise<void> {
     const all = (await this.storage.listConfigs()) ?? [];
@@ -46,41 +50,62 @@ export class ProfileService {
     );
   }
 
-  /** Make a profile active on this device. Drains pending writes, then persists + reloads. */
+  /** Make a profile active on this device. Verifies the slot still exists, drains pending writes, then persists + reloads. */
   public async switchProfile(name: string): Promise<void> {
-    await this.storage.awaitQueueDrain();
-    this.settings.setActiveProfile(name);
+    return this.exclusive(async () => {
+      await this.refresh();
+      if (!this.existingNames().includes(name)) {
+        throw new Error(`Profile "${name}" no longer exists — it may have been deleted on another device.`);
+      }
+      await this.storage.awaitQueueDrain();
+      this.settings.setActiveProfile(name);
+    });
   }
 
   /** Create a new profile from a blank default config. Does not switch. */
   public async createProfile(name: string): Promise<void> {
-    await this.refresh();
-    const normalized = this.validateNewName(name);
-    await this.storage.setConfig(PROFILE_SCOPE, normalized, cloneDeep(this.buildBlankConfig()));
-    await this.refresh();
+    return this.exclusive(async () => {
+      await this.refresh();
+      const normalized = this.validateNewName(name);
+      await this.storage.setConfig(PROFILE_SCOPE, normalized, cloneDeep(this.buildBlankConfig()));
+      await this.refresh();
+    });
   }
 
   /**
    * Import an arbitrary config as a NEW profile (never overwrites an existing one, never
-   * auto-switches). The config is structurally validated before it is written.
+   * auto-switches). The config is structurally validated AND its version checked before it is written,
+   * so a shape-valid but unsupported-version file cannot become a switchable, unbootable slot.
    */
   public async importProfile(name: string, config: unknown): Promise<void> {
-    await this.refresh();
-    const normalized = this.validateNewName(name);
-    if (!this.isValidConfigShape(config)) {
-      throw new Error('The selected file is not a valid KIP configuration.');
-    }
-    await this.storage.setConfig(PROFILE_SCOPE, normalized, config);
-    await this.refresh();
+    return this.exclusive(async () => {
+      await this.refresh();
+      const normalized = this.validateNewName(name);
+      if (!this.isValidConfigShape(config)) {
+        throw new Error('The selected file is not a valid KIP configuration.');
+      }
+      const supported = defaultConfig.app?.configVersion;
+      const version = config.app?.configVersion;
+      if (version !== supported) {
+        throw new Error(`This configuration is version ${version ?? 'unknown'}, but this version of KIP supports version ${supported}. Re-export it from a current KIP and try again.`);
+      }
+      await this.storage.setConfig(PROFILE_SCOPE, normalized, config);
+      await this.refresh();
+    });
   }
 
   /** Copy an existing profile's config under a new name. */
   public async duplicateProfile(sourceName: string, newName: string): Promise<void> {
-    await this.refresh();
-    const normalized = this.validateNewName(newName);
-    const sourceConfig = await this.storage.getConfig(PROFILE_SCOPE, sourceName);
-    await this.storage.setConfig(PROFILE_SCOPE, normalized, sourceConfig);
-    await this.refresh();
+    return this.exclusive(async () => {
+      await this.refresh();
+      const normalized = this.validateNewName(newName);
+      const sourceConfig = await this.storage.getConfig(PROFILE_SCOPE, sourceName);
+      if (!this.isValidConfigShape(sourceConfig)) {
+        throw new Error(`Profile "${sourceName}" has no usable configuration to copy.`);
+      }
+      await this.storage.setConfig(PROFILE_SCOPE, normalized, sourceConfig);
+      await this.refresh();
+    });
   }
 
   /**
@@ -89,39 +114,58 @@ export class ProfileService {
    * name so the device never reloads into a missing slot and no orphan is left behind.
    */
   public async renameProfile(oldName: string, newName: string): Promise<void> {
-    await this.refresh();
-    const normalized = this.validateNewName(newName);
-    if (oldName === RESERVED_DEFAULT) {
-      throw new Error(`The "${RESERVED_DEFAULT}" profile cannot be renamed.`);
-    }
-    const sourceConfig = await this.storage.getConfig(PROFILE_SCOPE, oldName);
-    await this.storage.setConfig(PROFILE_SCOPE, normalized, sourceConfig);
-
-    this.storage.removeItem(PROFILE_SCOPE, oldName);
-    await this.storage.awaitQueueDrain();
-
-    if (oldName === this.settings.getActiveProfileName()) {
-      this.settings.setActiveProfile(normalized); // persist + reload onto the renamed slot
-    } else {
+    return this.exclusive(async () => {
       await this.refresh();
-    }
+      const normalized = this.validateNewName(newName);
+      if (oldName === RESERVED_DEFAULT) {
+        throw new Error(`The "${RESERVED_DEFAULT}" profile cannot be renamed.`);
+      }
+      const sourceConfig = await this.storage.getConfig(PROFILE_SCOPE, oldName);
+      if (!this.isValidConfigShape(sourceConfig)) {
+        throw new Error(`Profile "${oldName}" has no usable configuration to rename.`);
+      }
+      await this.storage.setConfig(PROFILE_SCOPE, normalized, sourceConfig);
+
+      this.storage.removeItem(PROFILE_SCOPE, oldName);
+      await this.storage.awaitQueueDrain();
+
+      if (oldName === this.settings.getActiveProfileName()) {
+        this.settings.setActiveProfile(normalized); // persist + reload onto the renamed slot
+      } else {
+        await this.refresh();
+      }
+    });
   }
 
   /** Delete a profile. Refuses the active, the reserved default, and the last remaining profile. */
   public async deleteProfile(name: string): Promise<void> {
-    await this.refresh();
-    if (name === RESERVED_DEFAULT) {
-      throw new Error(`The "${RESERVED_DEFAULT}" profile cannot be deleted.`);
+    return this.exclusive(async () => {
+      await this.refresh();
+      if (name === RESERVED_DEFAULT) {
+        throw new Error(`The "${RESERVED_DEFAULT}" profile cannot be deleted.`);
+      }
+      if (name === this.settings.getActiveProfileName()) {
+        throw new Error('The active profile cannot be deleted. Switch to another profile first.');
+      }
+      if (this.existingNames().length <= 1) {
+        throw new Error('The last remaining profile cannot be deleted.');
+      }
+      this.storage.removeItem(PROFILE_SCOPE, name);
+      await this.storage.awaitQueueDrain();
+      await this.refresh();
+    });
+  }
+
+  private async exclusive<T>(op: () => Promise<T>): Promise<T> {
+    if (this.mutationInFlight) {
+      throw new Error('Another profile operation is still in progress. Please wait for it to finish.');
     }
-    if (name === this.settings.getActiveProfileName()) {
-      throw new Error('The active profile cannot be deleted. Switch to another profile first.');
+    this.mutationInFlight = true;
+    try {
+      return await op();
+    } finally {
+      this.mutationInFlight = false;
     }
-    if (this.existingNames().length <= 1) {
-      throw new Error('The last remaining profile cannot be deleted.');
-    }
-    this.storage.removeItem(PROFILE_SCOPE, name);
-    await this.storage.awaitQueueDrain();
-    await this.refresh();
   }
 
   private existingNames(): string[] {

--- a/src/app/core/services/settings.service.spec.ts
+++ b/src/app/core/services/settings.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { SettingsService } from './settings.service';
 import { StorageService } from './storage.service';
 import { ensureLocalStorage } from '../../../test-helpers/local-storage.test-helper';
@@ -53,5 +53,52 @@ describe('SettingsService — connection credential persistence', () => {
     const cfg = createService().getConnectionConfig();
     expect(cfg.loginName).toBe('captain');
     expect(Object.prototype.hasOwnProperty.call(cfg, 'loginPassword')).toBe(false);
+  });
+});
+
+describe('SettingsService — storage routing by mode (Unit 5)', () => {
+  beforeEach(() => ensureLocalStorage());
+
+  // authMode is derived by the real AuthenticationService from the seeded connectionConfig:
+  // proxyEnabled => cookie; a cross-origin signalKUrl => token.
+  const COOKIE = { proxyEnabled: true };
+  const CROSS_ORIGIN = { signalKUrl: 'https://boat.example:3443' };
+
+  function setup(connExtra: Record<string, unknown>) {
+    seedConnectionConfig(connExtra);
+    TestBed.configureTestingModule({ providers: [SettingsService, StorageService] });
+    const storage = TestBed.inject(StorageService);
+    const patchSpy = vi.spyOn(storage, 'patchConfig').mockImplementation(() => undefined);
+    const service = TestBed.inject(SettingsService);
+    return { service, patchSpy };
+  }
+
+  it('cookie mode routes a setting write to server applicationData, not localStorage', () => {
+    const { service, patchSpy } = setup({ ...COOKIE, useSharedConfig: false });
+    localStorage.removeItem('themeConfig');
+
+    service.setThemeName('cookie-theme');
+
+    expect(patchSpy).toHaveBeenCalledWith('IThemeConfig', { themeName: 'cookie-theme' });
+    expect(localStorage.getItem('themeConfig')).toBeNull();
+  });
+
+  it('cross-origin shared config still routes to server applicationData (unchanged)', () => {
+    const { service, patchSpy } = setup({ ...CROSS_ORIGIN, useSharedConfig: true });
+    localStorage.removeItem('themeConfig');
+
+    service.setThemeName('shared-theme');
+
+    expect(patchSpy).toHaveBeenCalledWith('IThemeConfig', { themeName: 'shared-theme' });
+    expect(localStorage.getItem('themeConfig')).toBeNull();
+  });
+
+  it('cross-origin local config still routes to localStorage (unchanged)', () => {
+    const { service, patchSpy } = setup({ ...CROSS_ORIGIN, useSharedConfig: false });
+
+    service.setThemeName('local-theme');
+
+    expect(patchSpy).not.toHaveBeenCalled();
+    expect(JSON.parse(localStorage.getItem('themeConfig') as string)).toEqual({ themeName: 'local-theme' });
   });
 });

--- a/src/app/core/services/settings.service.spec.ts
+++ b/src/app/core/services/settings.service.spec.ts
@@ -1,16 +1,57 @@
 import { TestBed } from '@angular/core/testing';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { SettingsService } from './settings.service';
+import { StorageService } from './storage.service';
+import { ensureLocalStorage } from '../../../test-helpers/local-storage.test-helper';
 
-describe('SettingsService', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [SettingsService]
-    });
+function seedConnectionConfig(extra: Record<string, unknown> = {}): void {
+  localStorage.setItem('authorization_token', JSON.stringify(null));
+  localStorage.setItem(
+    'connectionConfig',
+    JSON.stringify({
+      configVersion: 12,
+      kipUUID: 'test-uuid',
+      signalKUrl: 'http://localhost',
+      proxyEnabled: false,
+      signalKSubscribeAll: false,
+      useDeviceToken: false,
+      loginName: 'pi',
+      useSharedConfig: true,
+      sharedConfigName: 'default',
+      ...extra
+    })
+  );
+}
+
+function createService(): SettingsService {
+  // localStorage is installed+cleared in beforeEach; the test seeds before calling this.
+  // Provide both services so the transitive chain resolves to the global stubs
+  // (AuthenticationService / SignalKConnectionService) rather than the real root services.
+  TestBed.configureTestingModule({ providers: [SettingsService, StorageService] });
+  return TestBed.inject(SettingsService);
+}
+
+describe('SettingsService — connection credential persistence', () => {
+  beforeEach(() => ensureLocalStorage());
+
+  it('getConnectionConfig() does not expose a loginPassword key', () => {
+    seedConnectionConfig();
+    const cfg = createService().getConnectionConfig();
+    expect(Object.prototype.hasOwnProperty.call(cfg, 'loginPassword')).toBe(false);
   });
 
-  it('should be created', () => {
-    const service = TestBed.inject(SettingsService);
-    expect(service).toBeTruthy();
+  it('strips a persisted loginPassword from a legacy connectionConfig on load, without a version bump', () => {
+    seedConnectionConfig({ loginPassword: 'plaintext-secret' });
+    createService();
+    const persisted = JSON.parse(localStorage.getItem('connectionConfig') as string);
+    expect(Object.prototype.hasOwnProperty.call(persisted, 'loginPassword')).toBe(false);
+    expect(persisted.configVersion).toBe(12);
+  });
+
+  it('preserves loginName while dropping the password', () => {
+    seedConnectionConfig({ loginName: 'captain', loginPassword: 'secret' });
+    const cfg = createService().getConnectionConfig();
+    expect(cfg.loginName).toBe('captain');
+    expect(Object.prototype.hasOwnProperty.call(cfg, 'loginPassword')).toBe(false);
   });
 });

--- a/src/app/core/services/settings.service.spec.ts
+++ b/src/app/core/services/settings.service.spec.ts
@@ -227,4 +227,26 @@ describe('SettingsService', () => {
       expect(app['instanceName']).toBeUndefined();
     });
   });
+
+  describe('loadDemoConfig storage-readiness guard (server mode)', () => {
+    beforeEach(() => { (window as unknown as Record<string, unknown>)['__KIP_TEST__'] = true; });
+
+    it('does not write the demo config to the server when storage is not ready', () => {
+      const service = createService({ useSharedConfig: true, sharedConfigName: 'profileA' });
+      const storage = TestBed.inject(StorageService);
+      storage.storageServiceReady$.next(false);
+      const setSpy = vi.spyOn(storage, 'setConfig').mockImplementation(() => undefined);
+      service.loadDemoConfig();
+      expect(setSpy).not.toHaveBeenCalled();
+    });
+
+    it('writes the demo config to the server when storage is ready', () => {
+      const service = createService({ useSharedConfig: true, sharedConfigName: 'profileA' });
+      const storage = TestBed.inject(StorageService);
+      storage.storageServiceReady$.next(true);
+      const setSpy = vi.spyOn(storage, 'setConfig').mockImplementation(() => undefined);
+      service.loadDemoConfig();
+      expect(setSpy).toHaveBeenCalledWith('user', 'profileA', expect.objectContaining({ app: expect.anything() }));
+    });
+  });
 });

--- a/src/app/core/services/settings.service.spec.ts
+++ b/src/app/core/services/settings.service.spec.ts
@@ -66,6 +66,11 @@ describe('SettingsService — storage routing by mode (Unit 5)', () => {
 
   function setup(connExtra: Record<string, unknown>) {
     seedConnectionConfig(connExtra);
+    // Seed the local config keys so the localStorage startup() branch (cross-origin/local routing)
+    // loads cleanly instead of throwing an (unhandled, suite-masking) JSON parse error.
+    localStorage.setItem('appConfig', JSON.stringify({ configVersion: 12, dataSets: [], unitDefaults: {}, notificationConfig: {} }));
+    localStorage.setItem('dashboardsConfig', JSON.stringify([]));
+    localStorage.setItem('themeConfig', JSON.stringify({ themeName: '' }));
     TestBed.configureTestingModule({ providers: [SettingsService, StorageService] });
     const storage = TestBed.inject(StorageService);
     const patchSpy = vi.spyOn(storage, 'patchConfig').mockImplementation(() => undefined);

--- a/src/app/core/services/settings.service.spec.ts
+++ b/src/app/core/services/settings.service.spec.ts
@@ -7,12 +7,14 @@ import { ensureLocalStorage } from '../../../test-helpers/local-storage.test-hel
 interface SeedOpts {
   sharedConfigName?: string;
   useSharedConfig?: boolean;
+  isRemoteControl?: boolean;
+  instanceName?: string;
 }
 
 function seedConfig(opts: SeedOpts = {}): void {
   localStorage.setItem('authorization_token', JSON.stringify(null));
   localStorage.setItem('connectionConfig', JSON.stringify({
-    configVersion: 12,
+    configVersion: 13,
     kipUUID: 'test-uuid',
     // Cross-origin so authMode resolves to token: storage then routes purely on useSharedConfig,
     // keeping "local mode" (useSharedConfig:false) genuinely local under the auth-era routing.
@@ -23,15 +25,15 @@ function seedConfig(opts: SeedOpts = {}): void {
     loginName: '',
     loginPassword: '',
     useSharedConfig: opts.useSharedConfig ?? false,
-    sharedConfigName: opts.sharedConfigName ?? 'profileA'
+    sharedConfigName: opts.sharedConfigName ?? 'profileA',
+    isRemoteControl: opts.isRemoteControl ?? false,
+    instanceName: opts.instanceName ?? ''
   }));
   localStorage.setItem('appConfig', JSON.stringify({
     configVersion: 12,
     autoNightMode: false,
     redNightMode: false,
     nightModeBrightness: 1,
-    isRemoteControl: false,
-    instanceName: '',
     dataSets: [],
     unitDefaults: {},
     notificationConfig: {
@@ -200,6 +202,49 @@ describe('SettingsService', () => {
       // leaving activeConfig.app null. Clone must not seed from a hollow snapshot.
       const service = createService({ useSharedConfig: true, sharedConfigName: 'profileA' });
       expect(service.getActiveConfigSnapshot()).toBeNull();
+    });
+  });
+
+  describe('remote-control identity (per-device, Unit 5)', () => {
+    it('reads isRemoteControl / instanceName from connectionConfig at boot', () => {
+      const service = createService({ isRemoteControl: true, instanceName: 'Helm' });
+      expect(service.getIsRemoteControl()).toBe(true);
+      expect(service.getInstanceName()).toBe('Helm');
+    });
+
+    it('setIsRemoteControl persists to connectionConfig, not the profile/appConfig', () => {
+      const service = createService({ isRemoteControl: false });
+      service.setIsRemoteControl(true);
+      const cc = JSON.parse(localStorage.getItem('connectionConfig') as string);
+      expect(cc.isRemoteControl).toBe(true);
+      const appConf = JSON.parse(localStorage.getItem('appConfig') as string);
+      expect(appConf.isRemoteControl).toBeUndefined();
+    });
+
+    it('setInstanceName persists to connectionConfig', () => {
+      const service = createService({ instanceName: '' });
+      service.setInstanceName('Mast');
+      const cc = JSON.parse(localStorage.getItem('connectionConfig') as string);
+      expect(cc.instanceName).toBe('Mast');
+    });
+
+    it('switching the active profile leaves remote-control identity unchanged', () => {
+      const service = createService({ isRemoteControl: true, instanceName: 'Helm' });
+      service.setActiveProfile('cockpit');
+      expect(service.getIsRemoteControl()).toBe(true);
+      expect(service.getInstanceName()).toBe('Helm');
+      const cc = JSON.parse(localStorage.getItem('connectionConfig') as string);
+      expect(cc.isRemoteControl).toBe(true);
+      expect(cc.instanceName).toBe('Helm');
+    });
+
+    it('getAppConfig no longer carries remote-control fields', () => {
+      const service = createService();
+      const snap = service.getActiveConfigSnapshot();
+      expect(snap?.app).not.toBeNull();
+      const app = snap?.app as unknown as Record<string, unknown>;
+      expect(app['isRemoteControl']).toBeUndefined();
+      expect(app['instanceName']).toBeUndefined();
     });
   });
 });

--- a/src/app/core/services/settings.service.spec.ts
+++ b/src/app/core/services/settings.service.spec.ts
@@ -187,24 +187,6 @@ describe('SettingsService', () => {
     });
   });
 
-  describe('config snapshot', () => {
-    it('returns an assembled IConfig when settings are loaded', () => {
-      const service = createService({ useSharedConfig: false });
-      const snap = service.getActiveConfigSnapshot();
-      expect(snap).not.toBeNull();
-      expect(snap?.app).not.toBeNull();
-      expect(snap?.theme?.themeName).toBe('light');
-      expect(snap?.dashboards).toEqual([{ id: 'dash-1' }]);
-    });
-
-    it('returns null on a degraded shared boot (config not loaded)', () => {
-      // useSharedConfig=true but storage was never bootstrapped → startup() early-returns,
-      // leaving activeConfig.app null. Clone must not seed from a hollow snapshot.
-      const service = createService({ useSharedConfig: true, sharedConfigName: 'profileA' });
-      expect(service.getActiveConfigSnapshot()).toBeNull();
-    });
-  });
-
   describe('remote-control identity (per-device, Unit 5)', () => {
     it('reads isRemoteControl / instanceName from connectionConfig at boot', () => {
       const service = createService({ isRemoteControl: true, instanceName: 'Helm' });
@@ -240,9 +222,7 @@ describe('SettingsService', () => {
 
     it('getAppConfig no longer carries remote-control fields', () => {
       const service = createService();
-      const snap = service.getActiveConfigSnapshot();
-      expect(snap?.app).not.toBeNull();
-      const app = snap?.app as unknown as Record<string, unknown>;
+      const app = service.getAppConfig() as unknown as Record<string, unknown>;
       expect(app['isRemoteControl']).toBeUndefined();
       expect(app['instanceName']).toBeUndefined();
     });

--- a/src/app/core/services/settings.service.spec.ts
+++ b/src/app/core/services/settings.service.spec.ts
@@ -4,6 +4,48 @@ import { SettingsService } from './settings.service';
 import { StorageService } from './storage.service';
 import { ensureLocalStorage } from '../../../test-helpers/local-storage.test-helper';
 
+interface SeedOpts {
+  sharedConfigName?: string;
+  useSharedConfig?: boolean;
+}
+
+function seedConfig(opts: SeedOpts = {}): void {
+  localStorage.setItem('authorization_token', JSON.stringify(null));
+  localStorage.setItem('connectionConfig', JSON.stringify({
+    configVersion: 12,
+    kipUUID: 'test-uuid',
+    // Cross-origin so authMode resolves to token: storage then routes purely on useSharedConfig,
+    // keeping "local mode" (useSharedConfig:false) genuinely local under the auth-era routing.
+    signalKUrl: 'https://boat.example:3443',
+    proxyEnabled: false,
+    signalKSubscribeAll: false,
+    useDeviceToken: false,
+    loginName: '',
+    loginPassword: '',
+    useSharedConfig: opts.useSharedConfig ?? false,
+    sharedConfigName: opts.sharedConfigName ?? 'profileA'
+  }));
+  localStorage.setItem('appConfig', JSON.stringify({
+    configVersion: 12,
+    autoNightMode: false,
+    redNightMode: false,
+    nightModeBrightness: 1,
+    isRemoteControl: false,
+    instanceName: '',
+    dataSets: [],
+    unitDefaults: {},
+    notificationConfig: {
+      disableNotifications: true,
+      menuGrouping: false,
+      security: { disableSecurity: true },
+      devices: { disableDevices: true, showNormalState: false, showNominalState: false },
+      sound: { disableSound: true, muteNormal: true, muteNominal: true, muteWarn: true, muteAlert: true, muteAlarm: true, muteEmergency: true }
+    }
+  }));
+  localStorage.setItem('dashboardsConfig', JSON.stringify([{ id: 'dash-1' }]));
+  localStorage.setItem('themeConfig', JSON.stringify({ themeName: 'light' }));
+}
+
 function seedConnectionConfig(extra: Record<string, unknown> = {}): void {
   localStorage.setItem('authorization_token', JSON.stringify(null));
   localStorage.setItem(
@@ -23,9 +65,14 @@ function seedConnectionConfig(extra: Record<string, unknown> = {}): void {
   );
 }
 
-function createService(): SettingsService {
-  // localStorage is installed+cleared in beforeEach; the test seeds before calling this.
-  // Provide both services so the transitive chain resolves to the global stubs
+function createService(opts?: SeedOpts): SettingsService {
+  // opts provided (profile suite): clear + seed inside. Omitted (credential/routing suites): the
+  // describe's beforeEach already cleared and the test seeds via seedConnectionConfig first.
+  if (opts) {
+    ensureLocalStorage();
+    seedConfig(opts);
+  }
+  // Provide both services in the module so transitive deps resolve to the global stubs
   // (AuthenticationService / SignalKConnectionService) rather than the real root services.
   TestBed.configureTestingModule({ providers: [SettingsService, StorageService] });
   return TestBed.inject(SettingsService);
@@ -105,5 +152,54 @@ describe('SettingsService — storage routing by mode (Unit 5)', () => {
 
     expect(patchSpy).not.toHaveBeenCalled();
     expect(JSON.parse(localStorage.getItem('themeConfig') as string)).toEqual({ themeName: 'local-theme' });
+  });
+});
+
+describe('SettingsService', () => {
+  it('should be created', () => {
+    expect(createService({})).toBeTruthy();
+  });
+
+  describe('active profile (local mode)', () => {
+    let service: SettingsService;
+
+    beforeEach(() => {
+      service = createService({ useSharedConfig: false, sharedConfigName: 'profileA' });
+    });
+
+    it('getActiveProfileName returns the booted slot name', () => {
+      expect(service.getActiveProfileName()).toBe('profileA');
+    });
+
+    it('setActiveProfile updates the name and persists it to connectionConfig', () => {
+      service.setActiveProfile('cockpit');
+      expect(service.getActiveProfileName()).toBe('cockpit');
+      const cc = JSON.parse(localStorage.getItem('connectionConfig') as string);
+      expect(cc.sharedConfigName).toBe('cockpit');
+    });
+
+    it('setActiveProfile keeps StorageService.sharedConfigName coherent', () => {
+      const storage = TestBed.inject(StorageService);
+      service.setActiveProfile('cockpit');
+      expect(storage.sharedConfigName).toBe('cockpit');
+    });
+  });
+
+  describe('config snapshot', () => {
+    it('returns an assembled IConfig when settings are loaded', () => {
+      const service = createService({ useSharedConfig: false });
+      const snap = service.getActiveConfigSnapshot();
+      expect(snap).not.toBeNull();
+      expect(snap?.app).not.toBeNull();
+      expect(snap?.theme?.themeName).toBe('light');
+      expect(snap?.dashboards).toEqual([{ id: 'dash-1' }]);
+    });
+
+    it('returns null on a degraded shared boot (config not loaded)', () => {
+      // useSharedConfig=true but storage was never bootstrapped → startup() early-returns,
+      // leaving activeConfig.app null. Clone must not seed from a hollow snapshot.
+      const service = createService({ useSharedConfig: true, sharedConfigName: 'profileA' });
+      expect(service.getActiveConfigSnapshot()).toBeNull();
+    });
   });
 });

--- a/src/app/core/services/settings.service.ts
+++ b/src/app/core/services/settings.service.ts
@@ -16,6 +16,7 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { StorageService } from './storage.service';
 import { Dashboard } from './dashboard.service';
 import { SignalKConnectionService } from '../services/signalk-connection.service';
+import { AuthenticationService } from './authentication.service';
 import { compare } from 'compare-versions';
 
 
@@ -29,6 +30,7 @@ export class SettingsService {
   private readonly storage = inject(StorageService);
   private readonly snackBar = inject(MatSnackBar);
   private readonly server = inject(SignalKConnectionService);
+  private readonly auth = inject(AuthenticationService);
 
   private unitDefaults: BehaviorSubject<IUnitDefaults> = new BehaviorSubject<IUnitDefaults>({});
   private themeName: BehaviorSubject<string> = new BehaviorSubject<string>(defaultTheme);
@@ -76,8 +78,18 @@ export class SettingsService {
     }
   }
 
+  /**
+   * Whether config persistence should target the server's applicationData rather than localStorage.
+   * True in cookie mode (same-origin SSO session) regardless of the stored useSharedConfig flag, and
+   * in cross-origin mode when shared config is enabled. Decouples storage routing from useSharedConfig
+   * the same way auth carriage is — avoids the cookie-mode localStorage split-brain.
+   */
+  private get useServerStorage(): boolean {
+    return this.auth.authMode === 'cookie' || this.useSharedConfig;
+  }
+
   private async startup(): Promise<void> {
-    if (this.useSharedConfig) {
+    if (this.useServerStorage) {
       if (!this.storage.isRemoteContextBootstrapped() || this.storage.initConfig === null) {
         console.warn('[AppSettings Service] Shared configuration enabled but remote bootstrap handoff is missing. Waiting for explicit recovery action.');
         return;
@@ -282,7 +294,7 @@ export class SettingsService {
   }
   public setDefaultUnits(newDefaults: IUnitDefaults) {
     this.unitDefaults.next(newDefaults);
-    if (this.useSharedConfig) {
+    if (this.useServerStorage) {
       this.storage.patchConfig('Array<IUnitDefaults>', newDefaults);
 
     } else {
@@ -343,7 +355,7 @@ export class SettingsService {
 
   public setThemeName(newTheme: string) {
     this.themeName.next(newTheme);
-    if (this.useSharedConfig) {
+    if (this.useServerStorage) {
       const theme: IThemeConfig = {
         themeName: newTheme
       }
@@ -366,7 +378,7 @@ export class SettingsService {
     this.autoNightMode.next(enabled);
     const appConf = this.buildAppStorageObject();
 
-    if (this.useSharedConfig) {
+    if (this.useServerStorage) {
       this.storage.patchConfig('IAppConfig', appConf);
     } else {
       this.saveAppConfigToLocalStorage();
@@ -390,7 +402,7 @@ export class SettingsService {
     this.redNightMode.next(enabled);
     const appConf = this.buildAppStorageObject();
 
-    if (this.useSharedConfig) {
+    if (this.useServerStorage) {
       this.storage.patchConfig('IAppConfig', appConf);
     } else {
       this.saveAppConfigToLocalStorage();
@@ -410,7 +422,7 @@ export class SettingsService {
     this.isRemoteControl.next(enabled);
     const appConf = this.buildAppStorageObject();
 
-    if (this.useSharedConfig) {
+    if (this.useServerStorage) {
       this.storage.patchConfig('IAppConfig', appConf);
     } else {
       this.saveAppConfigToLocalStorage();
@@ -430,7 +442,7 @@ export class SettingsService {
     this.instanceName.next(name);
     const appConf = this.buildAppStorageObject();
 
-    if (this.useSharedConfig) {
+    if (this.useServerStorage) {
       this.storage.patchConfig('IAppConfig', appConf);
     } else {
       this.saveAppConfigToLocalStorage();
@@ -456,7 +468,7 @@ export class SettingsService {
     this.splitShellEnabled.next(enabled);
     const appConf = this.buildAppStorageObject();
 
-    if (this.useSharedConfig) {
+    if (this.useServerStorage) {
       this.storage.patchConfig('IAppConfig', appConf);
     } else {
       this.saveAppConfigToLocalStorage();
@@ -473,7 +485,7 @@ export class SettingsService {
     this.splitShellSide.next(side);
     const appConf = this.buildAppStorageObject();
 
-    if (this.useSharedConfig) {
+    if (this.useServerStorage) {
       this.storage.patchConfig('IAppConfig', appConf);
     } else {
       this.saveAppConfigToLocalStorage();
@@ -490,7 +502,7 @@ export class SettingsService {
     this.widgetHistoryDisabled.next(disabled);
     const appConf = this.buildAppStorageObject();
 
-    if (this.useSharedConfig) {
+    if (this.useServerStorage) {
       this.storage.patchConfig('IAppConfig', appConf);
     } else {
       this.saveAppConfigToLocalStorage();
@@ -507,7 +519,7 @@ export class SettingsService {
     this.splitShellSwipeDisabled.next(enabled);
     const appConf = this.buildAppStorageObject();
 
-    if (this.useSharedConfig) {
+    if (this.useServerStorage) {
       this.storage.patchConfig('IAppConfig', appConf);
     } else {
       this.saveAppConfigToLocalStorage();
@@ -526,7 +538,7 @@ export class SettingsService {
     this.splitShellWidth.next(ratio);
     const appConf = this.buildAppStorageObject();
 
-    if (this.useSharedConfig) {
+    if (this.useServerStorage) {
       this.storage.patchConfig('IAppConfig', appConf);
     } else {
       this.saveAppConfigToLocalStorage();
@@ -541,7 +553,7 @@ export class SettingsService {
     this.nightModeBrightness.next(brightness);
     const appConf = this.buildAppStorageObject();
 
-    if (this.useSharedConfig) {
+    if (this.useServerStorage) {
       this.storage.patchConfig('IAppConfig', appConf);
     } else {
       this.saveAppConfigToLocalStorage();
@@ -554,7 +566,7 @@ export class SettingsService {
   }
 
   public saveDashboards(dashboards: Dashboard[]) {
-    if (this.useSharedConfig) {
+    if (this.useServerStorage) {
       if (this.storage.storageServiceReady$.getValue()) {
         this.storage.patchConfig('Dashboards', dashboards);
       }
@@ -567,7 +579,7 @@ export class SettingsService {
   // DataSets
   public saveDataSets(dataSets: IDatasetServiceDatasetConfig[]) {
     this.dataSets = dataSets;
-    if (this.useSharedConfig) {
+    if (this.useServerStorage) {
       this.storage.patchConfig('Array<IDatasetDef>', dataSets);
     } else {
       this.saveAppConfigToLocalStorage();
@@ -586,7 +598,7 @@ export class SettingsService {
   }
   public setNotificationConfig(notificationConfig: INotificationConfig) {
     this.kipKNotificationConfig.next(notificationConfig);
-    if (this.useSharedConfig) {
+    if (this.useServerStorage) {
       this.storage.patchConfig('INotificationConfig', notificationConfig);
     } else {
       this.saveAppConfigToLocalStorage();
@@ -601,7 +613,7 @@ export class SettingsService {
     newDefaultConfig.theme = this.getDefaultThemeConfig();
     newDefaultConfig.dashboards = this.getDefaultDashboardsConfig();
 
-      if (this.useSharedConfig) {
+      if (this.useServerStorage) {
         if (this.storage.storageServiceReady$.getValue()) {
           this.storage.setConfig('user', this.sharedConfigName, newDefaultConfig)
             .then(() => {
@@ -644,13 +656,13 @@ export class SettingsService {
   }
 
   public loadDemoConfig() {
-    if (this.useSharedConfig) {
+    if (this.useServerStorage) {
       const demoConfig: IConfig = {
         app: DemoAppConfig,
         dashboards: DemoDashboardsConfig,
         theme: DemoThemeConfig
       };
-      console.log("[AppSettings Service] Loading Demo configuration settings as remote config: " + this.useSharedConfig + " and reloading app.");
+      console.log("[AppSettings Service] Loading Demo configuration settings as remote config: " + this.useServerStorage + " and reloading app.");
       this.storage.setConfig('user', this.sharedConfigName, demoConfig);
       this.reloadApp();
     } else {

--- a/src/app/core/services/settings.service.ts
+++ b/src/app/core/services/settings.service.ts
@@ -357,24 +357,6 @@ export class SettingsService {
     this.reloadApp();
   }
 
-  /**
-   * Assembles the current in-memory config for cloning into a new profile. Returns null when the
-   * active config is not loaded (e.g. a degraded shared boot), so a clone cannot seed from a
-   * hollow snapshot.
-   *
-   * @returns {IConfig | null} The current config, or null when settings are not loaded.
-   */
-  public getActiveConfigSnapshot(): IConfig | null {
-    if (!this.activeConfig?.app) {
-      return null;
-    }
-    return {
-      app: this.getAppConfig(),
-      theme: this.getThemeConfig(),
-      dashboards: this.getDashboardConfig()
-    };
-  }
-
   public get KipUUID(): string {
     return this.kipUUID;
   }

--- a/src/app/core/services/settings.service.ts
+++ b/src/app/core/services/settings.service.ts
@@ -90,8 +90,10 @@ export class SettingsService {
 
   private async startup(): Promise<void> {
     if (this.useServerStorage) {
-      if (!this.storage.isRemoteContextBootstrapped() || this.storage.initConfig === null) {
-        console.warn('[AppSettings Service] Shared configuration enabled but remote bootstrap handoff is missing. Waiting for explicit recovery action.');
+      // A missing server config comes back as {} (not a 404), so guard on the presence of app config —
+      // an empty/appless object must not fall through to pushSettings() and dereference activeConfig.app.
+      if (!this.storage.isRemoteContextBootstrapped() || !this.storage.initConfig?.app) {
+        console.warn('[AppSettings Service] Shared configuration enabled but remote bootstrap handoff is missing or empty. Waiting for explicit recovery action.');
         return;
       }
 
@@ -325,9 +327,9 @@ export class SettingsService {
     if (this.signalkUrl) {
       this.signalkUrl.url = value.signalKUrl;
     }
-    if (!value.useSharedConfig) {
-      this.useDeviceToken = true;
-    } else this.useDeviceToken = false;
+    // useDeviceToken and useSharedConfig are one "cross-origin intent" axis (device token only when
+    // not using shared config).
+    this.useDeviceToken = !value.useSharedConfig;
     this.saveConnectionConfigToLocalStorage();
   }
 

--- a/src/app/core/services/settings.service.ts
+++ b/src/app/core/services/settings.service.ts
@@ -6,7 +6,7 @@ import { IWidget } from '../interfaces/widgets-interface';
 import { IUnitDefaults } from './units.service';
 import { UUID } from '../utils/uuid.util';
 
-import { IConfig, IAppConfig, IConnectionConfig, IThemeConfig, INotificationConfig, ISignalKUrl } from "../interfaces/app-settings.interfaces";
+import { IConfig, IAppConfig, IConnectionConfig, IThemeConfig, INotificationConfig, ISignalKUrl, CONNECTION_CONFIG_VERSION, SUPPORTED_CONNECTION_CONFIG_VERSIONS } from "../interfaces/app-settings.interfaces";
 import { DefaultAppConfig, DefaultConnectionConfig as DefaultConnectionConfig, DefaultThemeConfig } from '../../../default-config/config.blank.const';
 import { DefaultUnitsConfig } from '../../../default-config/config.blank.units.const'
 import { DefaultNotificationConfig } from '../../../default-config/config.blank.notification.const';
@@ -23,7 +23,6 @@ import { compare } from 'compare-versions';
 const defaultTheme = '';
 const configFileVersion = 11; // used to change the Signal K configuration storage file name (ie. 9.0.0.json) that contains the configuration definitions. Applies only to remote storage. Local storage has no file concept.
 const latestConfigVersion = 12; // used to set the configVersion property in the app config. This is used to manage config upgrades.
-const latestConnectionConfigVersion = 13; // per-device connectionConfig schema version; bumped for the remote-control identity hoist (Unit 5). Decoupled from the app configVersion.
 @Injectable({
   providedIn: 'root'
 })
@@ -54,6 +53,10 @@ export class SettingsService {
   private loginPassword = '';
   public useSharedConfig = true;
   private sharedConfigName = 'default';
+  // True once the user explicitly changes the remote-control identity this session; until then a
+  // connection write preserves the stored (possibly migration-written) identity rather than the
+  // in-memory default loaded before the migration ran.
+  private connectionIdentityDirty = false;
   private activeConfig: IConfig = { app: null, theme: null, dashboards: [] };
 
   private kipUUID = '';
@@ -146,7 +149,7 @@ export class SettingsService {
       localStorage.setItem("connectionConfig", JSON.stringify(config));
     }
 
-    // Remote-control identity is per-device (Unit 5): read from connectionConfig, not the profile.
+    // Remote-control identity is per-device: read from connectionConfig, not the profile.
     this.isRemoteControl.next(config.isRemoteControl ?? false);
     this.instanceName.next(config.instanceName ?? '');
   }
@@ -199,7 +202,7 @@ export class SettingsService {
     }
 
     if(type === 'connectionConfig') {
-      if (config.configVersion !== latestConfigVersion && config.configVersion !== latestConnectionConfigVersion) {
+      if (!SUPPORTED_CONNECTION_CONFIG_VERSIONS.includes(config.configVersion)) {
         console.log(`[AppSettings Service] Invalid ${type} version. Force loading defaults`);
 
         switch (type) {
@@ -433,7 +436,8 @@ export class SettingsService {
 
   public setIsRemoteControl(enabled: boolean) {
     this.isRemoteControl.next(enabled);
-    // Per-device (Unit 5): persist to connectionConfig, never the profile.
+    this.connectionIdentityDirty = true;
+    // Remote-control identity is per-device: persist to connectionConfig, never the profile.
     this.saveConnectionConfigToLocalStorage();
   }
 
@@ -448,7 +452,8 @@ export class SettingsService {
 
   public setInstanceName(name: string) {
     this.instanceName.next(name);
-    // Per-device (Unit 5): persist to connectionConfig, never the profile.
+    this.connectionIdentityDirty = true;
+    // Remote-control identity is per-device: persist to connectionConfig, never the profile.
     this.saveConnectionConfigToLocalStorage();
   }
 
@@ -711,8 +716,12 @@ export class SettingsService {
   }
 
   private buildConnectionStorageObject() {
+    const stored = this.readStoredConnectionConfig();
     const storageObject: IConnectionConfig = {
-      configVersion: latestConnectionConfigVersion,
+      // Preserve the stored connectionConfig version; only the one-time migration in
+      // AppNetworkInitService advances it. Stamping the latest here would prematurely mark the
+      // migration done and lose the not-yet-lifted remote-control identity.
+      configVersion: stored?.configVersion ?? CONNECTION_CONFIG_VERSION,
       kipUUID: this.kipUUID,
       signalKUrl: this.signalkUrl?.url ?? '',
       proxyEnabled: this.proxyEnabled,
@@ -722,10 +731,20 @@ export class SettingsService {
       // loginPassword intentionally omitted: never persisted (transient in-memory only).
       useSharedConfig: this.useSharedConfig,
       sharedConfigName: this.sharedConfigName,
-      isRemoteControl: this.isRemoteControl.getValue(),
-      instanceName: this.instanceName.getValue()
+      // Preserve the stored (possibly migration-written) identity unless the user changed it this
+      // session, so a connection write around the migration cannot revert the lifted value.
+      isRemoteControl: this.connectionIdentityDirty ? this.isRemoteControl.getValue() : (stored?.isRemoteControl ?? this.isRemoteControl.getValue()),
+      instanceName: this.connectionIdentityDirty ? this.instanceName.getValue() : (stored?.instanceName ?? this.instanceName.getValue())
     }
     return storageObject;
+  }
+
+  private readStoredConnectionConfig(): Partial<IConnectionConfig> | null {
+    try {
+      return JSON.parse(localStorage.getItem('connectionConfig') ?? 'null');
+    } catch {
+      return null;
+    }
   }
 
   private buildDashboardStorageObject() {

--- a/src/app/core/services/settings.service.ts
+++ b/src/app/core/services/settings.service.ts
@@ -23,6 +23,7 @@ import { compare } from 'compare-versions';
 const defaultTheme = '';
 const configFileVersion = 11; // used to change the Signal K configuration storage file name (ie. 9.0.0.json) that contains the configuration definitions. Applies only to remote storage. Local storage has no file concept.
 const latestConfigVersion = 12; // used to set the configVersion property in the app config. This is used to manage config upgrades.
+const latestConnectionConfigVersion = 13; // per-device connectionConfig schema version; bumped for the remote-control identity hoist (Unit 5). Decoupled from the app configVersion.
 @Injectable({
   providedIn: 'root'
 })
@@ -119,8 +120,8 @@ export class SettingsService {
 
     switch (config.configVersion) {
       case 11:
-        break;
       case 12:
+      case 13:
         break;
       default:
         console.error(`[AppSettings Service] Invalid connectionConfig version ${config.configVersion}. Resetting and loading connection configuration default`);
@@ -144,6 +145,10 @@ export class SettingsService {
       delete config.loginPassword;
       localStorage.setItem("connectionConfig", JSON.stringify(config));
     }
+
+    // Remote-control identity is per-device (Unit 5): read from connectionConfig, not the profile.
+    this.isRemoteControl.next(config.isRemoteControl ?? false);
+    this.instanceName.next(config.instanceName ?? '');
   }
 
   public resetConnection() {
@@ -194,7 +199,7 @@ export class SettingsService {
     }
 
     if(type === 'connectionConfig') {
-      if (config.configVersion !== latestConfigVersion) {
+      if (config.configVersion !== latestConfigVersion && config.configVersion !== latestConnectionConfigVersion) {
         console.log(`[AppSettings Service] Invalid ${type} version. Force loading defaults`);
 
         switch (type) {
@@ -238,18 +243,6 @@ export class SettingsService {
       this._dashboards = [];
     } else {
       this._dashboards = this.activeConfig.dashboards;
-    }
-
-    if (this.activeConfig.app.isRemoteControl === undefined) {
-      this.setIsRemoteControl(false);
-    } else {
-      this.isRemoteControl.next(this.activeConfig.app.isRemoteControl);
-    }
-
-    if (this.activeConfig.app.instanceName === undefined) {
-      this.setInstanceName('');
-    } else {
-      this.instanceName.next(this.activeConfig.app.instanceName);
     }
 
     if (this.activeConfig.app.splitShellEnabled === undefined) {
@@ -458,13 +451,8 @@ export class SettingsService {
 
   public setIsRemoteControl(enabled: boolean) {
     this.isRemoteControl.next(enabled);
-    const appConf = this.buildAppStorageObject();
-
-    if (this.useServerStorage) {
-      this.storage.patchConfig('IAppConfig', appConf);
-    } else {
-      this.saveAppConfigToLocalStorage();
-    }
+    // Per-device (Unit 5): persist to connectionConfig, never the profile.
+    this.saveConnectionConfigToLocalStorage();
   }
 
   // Remote Control Instance Name
@@ -478,13 +466,8 @@ export class SettingsService {
 
   public setInstanceName(name: string) {
     this.instanceName.next(name);
-    const appConf = this.buildAppStorageObject();
-
-    if (this.useServerStorage) {
-      this.storage.patchConfig('IAppConfig', appConf);
-    } else {
-      this.saveAppConfigToLocalStorage();
-    }
+    // Per-device (Unit 5): persist to connectionConfig, never the profile.
+    this.saveConnectionConfigToLocalStorage();
   }
 
   public getDisablePathValidation(): boolean {
@@ -733,8 +716,6 @@ export class SettingsService {
       autoNightMode: this.autoNightMode.getValue(),
       redNightMode: this.redNightMode.getValue(),
       nightModeBrightness: this.nightModeBrightness.getValue(),
-      isRemoteControl: this.isRemoteControl.getValue(),
-      instanceName: this.instanceName.getValue(),
       dataSets: this.dataSets,
       unitDefaults: this.unitDefaults.getValue(),
       notificationConfig: this.kipKNotificationConfig.getValue(),
@@ -749,7 +730,7 @@ export class SettingsService {
 
   private buildConnectionStorageObject() {
     const storageObject: IConnectionConfig = {
-      configVersion: this.configVersion ?? latestConfigVersion,
+      configVersion: latestConnectionConfigVersion,
       kipUUID: this.kipUUID,
       signalKUrl: this.signalkUrl?.url ?? '',
       proxyEnabled: this.proxyEnabled,
@@ -758,7 +739,9 @@ export class SettingsService {
       loginName: this.loginName,
       // loginPassword intentionally omitted: never persisted (transient in-memory only).
       useSharedConfig: this.useSharedConfig,
-      sharedConfigName: this.sharedConfigName
+      sharedConfigName: this.sharedConfigName,
+      isRemoteControl: this.isRemoteControl.getValue(),
+      instanceName: this.instanceName.getValue()
     }
     return storageObject;
   }

--- a/src/app/core/services/settings.service.ts
+++ b/src/app/core/services/settings.service.ts
@@ -346,6 +346,42 @@ export class SettingsService {
     return this.buildThemeStorageObject();
   }
 
+  // --- Active profile (named config slot) ---
+  public getActiveProfileName(): string {
+    return this.sharedConfigName;
+  }
+
+  /**
+   * Points this device at a different profile (named config slot) and reloads so the bootstrap
+   * loads it. The active profile is per-device: persisted in the always-local connectionConfig.
+   *
+   * @param {string} name Profile (config slot) name to make active on this device.
+   */
+  public setActiveProfile(name: string): void {
+    this.sharedConfigName = name;
+    this.storage.sharedConfigName = name; // keep the storage write-path slot name coherent
+    this.saveConnectionConfigToLocalStorage();
+    this.reloadApp();
+  }
+
+  /**
+   * Assembles the current in-memory config for cloning into a new profile. Returns null when the
+   * active config is not loaded (e.g. a degraded shared boot), so a clone cannot seed from a
+   * hollow snapshot.
+   *
+   * @returns {IConfig | null} The current config, or null when settings are not loaded.
+   */
+  public getActiveConfigSnapshot(): IConfig | null {
+    if (!this.activeConfig?.app) {
+      return null;
+    }
+    return {
+      app: this.getAppConfig(),
+      theme: this.getThemeConfig(),
+      dashboards: this.getDashboardConfig()
+    };
+  }
+
   public get KipUUID(): string {
     return this.kipUUID;
   }
@@ -659,6 +695,10 @@ export class SettingsService {
 
   public loadDemoConfig() {
     if (this.useServerStorage) {
+      if (!this.storage.storageServiceReady$.getValue()) {
+        console.warn("[AppSettings Service] Storage not ready; cannot load demo configuration.");
+        return;
+      }
       const demoConfig: IConfig = {
         app: DemoAppConfig,
         dashboards: DemoDashboardsConfig,

--- a/src/app/core/services/settings.service.ts
+++ b/src/app/core/services/settings.service.ts
@@ -119,10 +119,17 @@ export class SettingsService {
     this.signalKSubscribeAll = config.signalKSubscribeAll;
     this.useDeviceToken = config.useDeviceToken;
     this.loginName = config.loginName;
-    this.loginPassword = config.loginPassword;
+    this.loginPassword = ''; // transient only; never loaded from storage
     this.useSharedConfig = config.useSharedConfig;
     this.sharedConfigName = config.sharedConfigName;
     this.kipUUID = config.kipUUID;
+
+    // Idempotent purge: strip any plaintext password persisted by an older version.
+    // Targeted rewrite preserves all other fields (incl. configVersion) exactly.
+    if (Object.prototype.hasOwnProperty.call(config, 'loginPassword')) {
+      delete config.loginPassword;
+      localStorage.setItem("connectionConfig", JSON.stringify(config));
+    }
   }
 
   public resetConnection() {
@@ -299,7 +306,7 @@ export class SettingsService {
 
   public setConnectionConfig(value: IConnectionConfig) {
     this.loginName = value.loginName;
-    this.loginPassword = value.loginPassword;
+    this.loginPassword = value.loginPassword ?? ''; // transient; not persisted
     this.useSharedConfig = value.useSharedConfig;
     this.proxyEnabled = value.proxyEnabled;
     this.signalKSubscribeAll = value.signalKSubscribeAll;
@@ -695,7 +702,7 @@ export class SettingsService {
       signalKSubscribeAll: this.signalKSubscribeAll,
       useDeviceToken: this.useDeviceToken,
       loginName: this.loginName,
-      loginPassword: this.loginPassword,
+      // loginPassword intentionally omitted: never persisted (transient in-memory only).
       useSharedConfig: this.useSharedConfig,
       sharedConfigName: this.sharedConfigName
     }

--- a/src/app/core/services/signalk-delta.service.spec.ts
+++ b/src/app/core/services/signalk-delta.service.spec.ts
@@ -1,15 +1,159 @@
-import { TestBed, inject } from '@angular/core/testing';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { BehaviorSubject } from 'rxjs';
 import { SignalKDeltaService } from './signalk-delta.service';
+import { AuthenticationService } from './authentication.service';
+import { SignalKConnectionService } from './signalk-connection.service';
+import { ConnectionStateMachine } from './connection-state-machine.service';
 
-describe('SignalkDeltaService', () => {
+class AuthStub {
+  isLoggedIn$ = new BehaviorSubject<boolean>(false);
+  authToken$ = new BehaviorSubject<unknown>(null);
+  authMode: 'cookie' | 'token' = 'token';
+  refreshLoginStatus = vi.fn(async () => null);
+}
+
+class ConnStub {
+  serverServiceEndpoint$ = new BehaviorSubject<{ operation: number; WsServiceUrl?: string; subscribeAll?: boolean }>({ operation: 0 });
+  setServerInfo(): void { /* noop */ }
+}
+
+class CsmStub {
+  state$ = new BehaviorSubject<string>('Disconnected');
+  setWebSocketRetryCallback = vi.fn();
+  isFullyConnected = vi.fn(() => false);
+  isHTTPConnected = vi.fn(() => true);
+  startWebSocketConnection = vi.fn();
+  onWebSocketConnected = vi.fn();
+  onWebSocketError = vi.fn();
+  currentState = 'HTTPConnected';
+}
+
+interface DeltaInternals { buildWebSocketUrl(): string }
+
+function setup() {
+  const auth = new AuthStub();
+  const conn = new ConnStub();
+  const csm = new CsmStub();
+  TestBed.configureTestingModule({
+    providers: [
+      SignalKDeltaService,
+      { provide: AuthenticationService, useValue: auth },
+      { provide: SignalKConnectionService, useValue: conn },
+      { provide: ConnectionStateMachine, useValue: csm },
+    ]
+  });
+  const service = TestBed.inject(SignalKDeltaService);
+  return { service, auth, conn, csm };
+}
+
+describe('SignalKDeltaService', () => {
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [SignalKDeltaService]
+    TestBed.resetTestingModule();
+  });
+
+  it('should be created', () => {
+    expect(setup().service).toBeTruthy();
+  });
+
+  describe('WebSocket token carriage by mode (Unit 4)', () => {
+    it('cookie mode omits &token= even when a token is present', () => {
+      const { service, auth, conn } = setup();
+      auth.authMode = 'cookie';
+      conn.serverServiceEndpoint$.next({ operation: 2, WsServiceUrl: 'wss://host/signalk/v1/stream', subscribeAll: false });
+      auth.authToken$.next({ token: 'should-not-appear', expiry: null, isDeviceAccessToken: false });
+
+      const url = (service as unknown as DeltaInternals).buildWebSocketUrl();
+      expect(url).not.toContain('token=');
+      expect(url.startsWith('wss://host/signalk/v1/stream')).toBe(true);
+    });
+
+    it('token mode appends &token= when a token is present', () => {
+      const { service, auth, conn } = setup();
+      auth.authMode = 'token';
+      conn.serverServiceEndpoint$.next({ operation: 2, WsServiceUrl: 'wss://host/signalk/v1/stream', subscribeAll: false });
+      auth.authToken$.next({ token: 'abc123', expiry: 9999999999, isDeviceAccessToken: false });
+
+      const url = (service as unknown as DeltaInternals).buildWebSocketUrl();
+      expect(url).toContain('&token=abc123');
     });
   });
 
-  it('should be created', inject([SignalKDeltaService], (service: SignalKDeltaService) => {
-    expect(service).toBeTruthy();
-  }));
+  describe('cookie-mode session-driven (re)connect (Unit 4)', () => {
+    it('a login transition triggers a WS (re)connect via the isFullyConnected guard', () => {
+      const { auth, csm } = setup();
+      auth.authMode = 'cookie';
+      csm.startWebSocketConnection.mockClear();
+
+      auth.isLoggedIn$.next(true);
+
+      expect(csm.startWebSocketConnection).toHaveBeenCalled();
+    });
+
+    it('does not start a WS connect when already fully connected (no double-connect)', () => {
+      const { auth, csm } = setup();
+      auth.authMode = 'cookie';
+      csm.isFullyConnected.mockReturnValue(true);
+      csm.startWebSocketConnection.mockClear();
+
+      auth.isLoggedIn$.next(true);
+
+      expect(csm.startWebSocketConnection).not.toHaveBeenCalled();
+    });
+
+    it('does not start a second WS connect while one is already in flight (WebSocketConnecting)', () => {
+      const { auth, csm } = setup();
+      auth.authMode = 'cookie';
+      // Bootstrap already opened the socket: not yet Connected, but a connect is in flight.
+      csm.isFullyConnected.mockReturnValue(false);
+      csm.currentState = 'WebSocketConnecting';
+      csm.startWebSocketConnection.mockClear();
+
+      auth.isLoggedIn$.next(true);
+
+      expect(csm.startWebSocketConnection).not.toHaveBeenCalled();
+    });
+
+    it('token mode does not drive the cookie reconnect path on a login transition', () => {
+      const { auth, csm } = setup();
+      auth.authMode = 'token';
+      csm.startWebSocketConnection.mockClear();
+
+      auth.isLoggedIn$.next(true);
+
+      expect(csm.startWebSocketConnection).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('cookie-mode loginStatus re-check on WS drop (Unit 4)', () => {
+    it('re-checks loginStatus on a non-clean close', () => {
+      const { service, auth } = setup();
+      auth.authMode = 'cookie';
+      auth.refreshLoginStatus.mockClear();
+
+      service.socketWSCloseEvent$.next({ wasClean: false } as CloseEvent);
+
+      expect(auth.refreshLoginStatus).toHaveBeenCalled();
+    });
+
+    it('does not re-check loginStatus on a clean close', () => {
+      const { service, auth } = setup();
+      auth.authMode = 'cookie';
+      auth.refreshLoginStatus.mockClear();
+
+      service.socketWSCloseEvent$.next({ wasClean: true } as CloseEvent);
+
+      expect(auth.refreshLoginStatus).not.toHaveBeenCalled();
+    });
+
+    it('token mode does not re-check loginStatus on a non-clean close', () => {
+      const { service, auth } = setup();
+      auth.authMode = 'token';
+      auth.refreshLoginStatus.mockClear();
+
+      service.socketWSCloseEvent$.next({ wasClean: false } as CloseEvent);
+
+      expect(auth.refreshLoginStatus).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/app/core/services/signalk-delta.service.ts
+++ b/src/app/core/services/signalk-delta.service.ts
@@ -1,5 +1,6 @@
 import { DestroyRef, inject, Injectable, OnDestroy } from '@angular/core';
 import { BehaviorSubject, Observable, Subject, fromEvent } from 'rxjs';
+import { distinctUntilChanged } from 'rxjs/operators';
 import { webSocket, WebSocketSubject } from 'rxjs/webSocket';
 
 import { ISignalKDataValueUpdate, ISignalKDeltaMessage, ISignalKMeta, ISignalKUpdateMessage } from '../interfaces/signalk-interfaces';
@@ -136,6 +137,17 @@ export class SignalKDeltaService implements OnDestroy {
         }
       });
 
+    // Cookie mode has no token, so the authToken$ reconnect above never fires. Drive the WS
+    // (re)connect off the session signal instead, reusing checkAndReconnect's isFullyConnected
+    // guard so we do not double-connect with the bootstrap's startWebSocketConnection().
+    this.auth.isLoggedIn$
+      .pipe(distinctUntilChanged(), takeUntilDestroyed(this._destroyRef))
+      .subscribe((loggedIn: boolean) => {
+        if (loggedIn && this.auth.authMode === 'cookie') {
+          this.checkAndReconnect('Cookie session established');
+        }
+      });
+
     // WebSocket Open Event Handling
     this.socketWSOpenEvent$
       .pipe(takeUntilDestroyed(this._destroyRef))
@@ -168,6 +180,12 @@ export class SignalKDeltaService implements OnDestroy {
 
           // Notify ConnectionStateMachine of WebSocket error
           this.connectionStateMachine.onWebSocketError('WebSocket connection lost');
+
+          // In cookie mode a drop may mean the session cookie expired; re-check loginStatus so
+          // session state (and the UI) reflect a server-side logout rather than retrying blindly.
+          if (this.auth.authMode === 'cookie') {
+            void this.auth.refreshLoginStatus();
+          }
         }
         this.streamEndpoint$.next(this.streamEndpoint);
       });
@@ -259,18 +277,27 @@ export class SignalKDeltaService implements OnDestroy {
   }
 
   /**
-   * Handles connection arguments, token and links socket Open/Close Observers
+   * Builds the WebSocket URL including the subscription/meta args and, in token mode only, the
+   * auth token. Mode-first: in cookie mode the same-origin session cookie authenticates the WS
+   * upgrade, so &token= is never appended (even if a stale token is present).
    */
-  private getNewWebSocket(): WebSocketSubject<object> {
+  private buildWebSocketUrl(): string {
     let args = this.WS_CONNECTION_SUBSCRIBE + this.SubscriptionType + this.WS_CONNECTION_META;
-    if (this.authToken != null) {
+    if (this.auth.authMode === 'token' && this.authToken != null) {
       args += "&token=" + this.authToken.token;
       this.streamEndpoint.hasToken = true;
     } else {
       this.streamEndpoint.hasToken = false;
     }
+    return this.endpointWS + args;
+  }
+
+  /**
+   * Handles connection arguments, token and links socket Open/Close Observers
+   */
+  private getNewWebSocket(): WebSocketSubject<object> {
     return webSocket({
-      url: this.endpointWS + args,
+      url: this.buildWebSocketUrl(),
       closeObserver: this.socketWSCloseEvent$,
       openObserver: this.socketWSOpenEvent$
     })
@@ -498,7 +525,12 @@ export class SignalKDeltaService implements OnDestroy {
    */
   private checkAndReconnect(reason: string): void {
     if (!this.connectionStateMachine.isFullyConnected()) {
-      if (this.connectionStateMachine.isHTTPConnected()  && this.connectionStateMachine.currentState !== ConnectionState.WebSocketRetrying) {
+      // Do not start a second connect while one is already in flight (WebSocketConnecting) or being
+      // retried — that would close and reopen the in-flight socket. This matters for the cookie-mode
+      // isLoggedIn$ reconnect, which can race the bootstrap's own startWebSocketConnection().
+      if (this.connectionStateMachine.isHTTPConnected()
+          && this.connectionStateMachine.currentState !== ConnectionState.WebSocketRetrying
+          && this.connectionStateMachine.currentState !== ConnectionState.WebSocketConnecting) {
         console.log(`[Delta Service] ${reason}: WebSocket disconnected, requesting reconnection...`);
         this.connectionStateMachine.startWebSocketConnection();
       } else {

--- a/src/app/core/services/sso-redirect.service.spec.ts
+++ b/src/app/core/services/sso-redirect.service.spec.ts
@@ -1,0 +1,125 @@
+import { TestBed } from '@angular/core/testing';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SsoRedirectService } from './sso-redirect.service';
+import { AuthenticationService, ILoginStatus } from './authentication.service';
+import { ensureLocalStorage, ensureSessionStorage } from '../../../test-helpers/local-storage.test-helper';
+
+class AuthStub {
+  loginStatusValue: ILoginStatus | null = null;
+}
+
+const OIDC_STATUS: ILoginStatus = {
+  status: 'notLoggedIn',
+  authenticationRequired: true,
+  oidcEnabled: true,
+  oidcAutoLogin: true,
+  oidcLoginUrl: '/signalk/v1/auth/oidc/login'
+};
+
+function setup(authStub: AuthStub = new AuthStub()) {
+  ensureLocalStorage();
+  ensureSessionStorage();
+  TestBed.configureTestingModule({
+    providers: [SsoRedirectService, { provide: AuthenticationService, useValue: authStub }]
+  });
+  const service = TestBed.inject(SsoRedirectService);
+  const navSpy = vi
+    .spyOn(service as unknown as { navigate: (u: string) => void }, 'navigate')
+    .mockImplementation(() => undefined);
+  return { service, navSpy, authStub };
+}
+
+describe('SsoRedirectService', () => {
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  it('redirects to the OIDC login and records one budget attempt', () => {
+    const { service, navSpy } = setup();
+
+    expect(service.attemptAutoRedirect(OIDC_STATUS)).toBe('redirected');
+
+    expect(navSpy).toHaveBeenCalledTimes(1);
+    expect(navSpy.mock.calls[0][0]).toContain('/signalk/v1/auth/oidc/login');
+    expect(service.attempts()).toBe(1);
+  });
+
+  it('stops redirecting once the budget is exhausted (kiosk auto-login loop guard)', () => {
+    const { service, navSpy } = setup();
+
+    expect(service.attemptAutoRedirect(OIDC_STATUS)).toBe('redirected');
+    expect(service.attemptAutoRedirect(OIDC_STATUS)).toBe('redirected');
+    expect(service.attemptAutoRedirect(OIDC_STATUS)).toBe('redirected');
+    navSpy.mockClear();
+
+    expect(service.attemptAutoRedirect(OIDC_STATUS)).toBe('budget-exhausted');
+    expect(navSpy).not.toHaveBeenCalled();
+  });
+
+  it('resetBudget clears the attempt count', () => {
+    const { service } = setup();
+    service.attemptAutoRedirect(OIDC_STATUS);
+    expect(service.attempts()).toBe(1);
+
+    service.resetBudget();
+
+    expect(service.attempts()).toBe(0);
+    expect(service.isBudgetExhausted()).toBe(false);
+  });
+
+  it('manualSignIn resets the budget and disables auto-login', () => {
+    const authStub = new AuthStub();
+    authStub.loginStatusValue = OIDC_STATUS;
+    const { service, navSpy } = setup(authStub);
+    service.attemptAutoRedirect(OIDC_STATUS);
+    service.attemptAutoRedirect(OIDC_STATUS);
+    navSpy.mockClear();
+
+    service.manualSignIn();
+
+    expect(service.attempts()).toBe(0);
+    expect(navSpy).toHaveBeenCalledTimes(1);
+    expect(navSpy.mock.calls[0][0]).toContain('/signalk/v1/auth/oidc/login');
+    expect(navSpy.mock.calls[0][0]).toContain('noAutoLogin=true');
+  });
+
+  it('falls back to the admin login when OIDC is not enabled', () => {
+    const { service, navSpy } = setup();
+
+    service.attemptAutoRedirect({ status: 'notLoggedIn', authenticationRequired: true, oidcEnabled: false });
+
+    expect(navSpy.mock.calls[0][0]).toContain('/admin/#/login');
+  });
+
+  it('fails closed (does not auto-redirect) when sessionStorage is unavailable', () => {
+    const { service, navSpy } = setup();
+    const original = window.sessionStorage;
+    Object.defineProperty(window, 'sessionStorage', {
+      configurable: true,
+      get() { throw new Error('storage blocked'); }
+    });
+
+    try {
+      expect(service.attemptAutoRedirect(OIDC_STATUS)).toBe('budget-exhausted');
+      expect(navSpy).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(window, 'sessionStorage', { configurable: true, value: original });
+    }
+  });
+
+  it('fails closed when sessionStorage silently discards writes (probe read-back mismatch)', () => {
+    const { service, navSpy } = setup();
+    const original = window.sessionStorage;
+    Object.defineProperty(window, 'sessionStorage', {
+      configurable: true,
+      value: { setItem() { /* accepted but discarded */ }, getItem() { return null; }, removeItem() { /* noop */ } }
+    });
+
+    try {
+      expect(service.attemptAutoRedirect(OIDC_STATUS)).toBe('budget-exhausted');
+      expect(navSpy).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(window, 'sessionStorage', { configurable: true, value: original });
+    }
+  });
+});

--- a/src/app/core/services/sso-redirect.service.ts
+++ b/src/app/core/services/sso-redirect.service.ts
@@ -1,0 +1,116 @@
+import { inject, Injectable } from '@angular/core';
+import { AuthenticationService, ILoginStatus } from './authentication.service';
+import { buildLoginRedirectUrl, isSafeReturnTo } from '../utils/login-redirect.util';
+
+const REDIRECT_BUDGET_KEY = 'kip.ssoRedirectAttempts';
+const MAX_REDIRECT_ATTEMPTS = 3;
+const ADMIN_LOGIN_URL = '/admin/#/login'; // non-OIDC same-origin fallback login
+
+export type TAutoRedirectOutcome = 'redirected' | 'budget-exhausted';
+
+/**
+ * Owns the cookie-mode SSO redirect: where to send the browser to sign in, and a reload-surviving
+ * attempt budget so a kiosk with oidcAutoLogin cannot loop forever. The budget lives in
+ * sessionStorage (per-tab, cleared on a fresh session), resets on a confirmed login, and is bypassed
+ * by an explicit user sign-in.
+ */
+@Injectable({ providedIn: 'root' })
+export class SsoRedirectService {
+  private readonly auth = inject(AuthenticationService);
+
+  public attempts(): number {
+    try {
+      const raw = window.sessionStorage.getItem(REDIRECT_BUDGET_KEY);
+      const n = raw ? parseInt(raw, 10) : 0;
+      return Number.isFinite(n) && n > 0 ? n : 0;
+    } catch {
+      return 0;
+    }
+  }
+
+  public isBudgetExhausted(): boolean {
+    return this.attempts() >= MAX_REDIRECT_ATTEMPTS;
+  }
+
+  public resetBudget(): void {
+    try {
+      window.sessionStorage.removeItem(REDIRECT_BUDGET_KEY);
+    } catch {
+      /* ignore */
+    }
+  }
+
+  private recordAttempt(): void {
+    try {
+      window.sessionStorage.setItem(REDIRECT_BUDGET_KEY, String(this.attempts() + 1));
+    } catch {
+      /* ignore */
+    }
+  }
+
+  /**
+   * Whether the reload-surviving budget storage actually works. If sessionStorage is blocked (some
+   * kiosk WebViews, private modes), the budget cannot bound a cross-reload loop, so auto-redirect must
+   * fail closed rather than redirect forever.
+   */
+  private budgetStorageWorks(): boolean {
+    try {
+      const probe = `${REDIRECT_BUDGET_KEY}.probe`;
+      window.sessionStorage.setItem(probe, '1');
+      // Read back: a storage that accepts writes but silently discards them (some locked-down kiosk
+      // WebViews) would otherwise leave the budget permanently at 0 and loop. Fail closed on a mismatch.
+      const persisted = window.sessionStorage.getItem(probe) === '1';
+      window.sessionStorage.removeItem(probe);
+      return persisted;
+    } catch {
+      return false;
+    }
+  }
+
+  private resolveLoginUrl(status: ILoginStatus | null): string {
+    if (status?.oidcEnabled && status.oidcLoginUrl) {
+      return status.oidcLoginUrl;
+    }
+    return ADMIN_LOGIN_URL;
+  }
+
+  private currentReturnTo(): string | undefined {
+    const relative = window.location.pathname + window.location.search + window.location.hash;
+    return isSafeReturnTo(relative) ? relative : undefined;
+  }
+
+  /**
+   * Bootstrap auto-redirect to the SK login. Honors the budget, records an attempt and navigates, or
+   * reports the budget is spent so the caller can show the auth-blocked recovery state instead.
+   */
+  public attemptAutoRedirect(status: ILoginStatus | null): TAutoRedirectOutcome {
+    // Fail closed: if the budget cannot be tracked across reloads, do not auto-redirect (an explicit
+    // user Sign in still can). Treating an untrackable budget as "0 attempts" would loop forever.
+    if (!this.budgetStorageWorks() || this.isBudgetExhausted()) {
+      return 'budget-exhausted';
+    }
+    this.recordAttempt();
+    this.navigate(buildLoginRedirectUrl({
+      loginUrl: this.resolveLoginUrl(status),
+      returnTo: this.currentReturnTo()
+    }));
+    return 'redirected';
+  }
+
+  /**
+   * Explicit user sign-in (recovery). Resets the budget and disables SK auto-login (noAutoLogin) so a
+   * manual retry is not immediately bounced back by an auto-login loop.
+   */
+  public manualSignIn(): void {
+    this.resetBudget();
+    this.navigate(buildLoginRedirectUrl({
+      loginUrl: this.resolveLoginUrl(this.auth.loginStatusValue),
+      returnTo: this.currentReturnTo(),
+      noAutoLogin: true
+    }));
+  }
+
+  protected navigate(url: string): void {
+    window.location.replace(url);
+  }
+}

--- a/src/app/core/services/storage.service.spec.ts
+++ b/src/app/core/services/storage.service.spec.ts
@@ -1,16 +1,98 @@
 import { TestBed } from '@angular/core/testing';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { StorageService } from './storage.service';
+import { IConfig } from '../interfaces/app-settings.interfaces';
+import { ensureLocalStorage } from '../../../test-helpers/local-storage.test-helper';
+
+const blankConfig = (): IConfig => ({ app: null, theme: null, dashboards: [] });
 
 describe('StorageService', () => {
   let service: StorageService;
+  let http: HttpTestingController;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    ensureLocalStorage();
+    // Provide StorageService in the module so its deps resolve to the global test stubs
+    // (AuthenticationService / SignalKConnectionService) instead of the real root services.
+    TestBed.configureTestingModule({ providers: [StorageService] });
     service = TestBed.inject(StorageService);
+    http = TestBed.inject(HttpTestingController);
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  describe('write-safety guard', () => {
+    beforeEach(() => {
+      service.storageServiceReady$.next(true);
+      service.activeConfigFileVersion = 11;
+    });
+
+    afterEach(() => http.verify());
+
+    it('setConfig rejects an empty config name', async () => {
+      await expect(service.setConfig('user', '', blankConfig())).rejects.toThrow(/name/i);
+      http.expectNone(() => true);
+    });
+
+    it('removeItem throws on an empty name', () => {
+      expect(() => service.removeItem('user', '')).toThrow(/name/i);
+      http.expectNone(() => true);
+    });
+
+    it('patchConfig does not POST when the active slot name is unset', () => {
+      service.sharedConfigName = undefined as unknown as string;
+      service.patchConfig('Dashboards', []);
+      http.expectNone(() => true);
+    });
+
+    it('patchConfig POSTs a patch targeting the active slot when set', () => {
+      service.sharedConfigName = 'cockpit';
+      service.patchConfig('Dashboards', [{ id: 'd1' }]);
+      const req = http.expectOne((r) => r.method === 'POST');
+      // JSON Patch op path is namespaced by the active slot name
+      expect(req.request.body[0].path).toBe('/cockpit/dashboards');
+      req.flush(null);
+    });
+  });
+
+  describe('awaitQueueDrain', () => {
+    beforeEach(() => {
+      service.storageServiceReady$.next(true);
+      service.activeConfigFileVersion = 11;
+      service.sharedConfigName = 'p';
+    });
+
+    it('resolves true immediately when the queue is empty', async () => {
+      await expect(service.awaitQueueDrain(1000)).resolves.toBe(true);
+    });
+
+    it('resolves true once a queued write completes', async () => {
+      service.patchConfig('Dashboards', []);
+      const drain = service.awaitQueueDrain(2000);
+      http.expectOne(() => true).flush(null);
+      await expect(drain).resolves.toBe(true);
+      http.verify();
+    });
+
+    it('resolves false (best-effort) when a write stalls past the timeout', async () => {
+      service.patchConfig('Dashboards', []);
+      await expect(service.awaitQueueDrain(40)).resolves.toBe(false);
+      // drain the stalled request so the test ends clean
+      http.expectOne(() => true).flush(null);
+      http.verify();
+    });
+
+    it('a failed write does not wedge the queue (later writes still process)', async () => {
+      service.patchConfig('Dashboards', []);
+      http.expectOne(() => true).flush('boom', { status: 500, statusText: 'err' });
+      service.patchConfig('Dashboards', []);
+      const drain = service.awaitQueueDrain(2000);
+      http.expectOne(() => true).flush(null);
+      await expect(drain).resolves.toBe(true);
+      http.verify();
+    });
   });
 });

--- a/src/app/core/services/storage.service.ts
+++ b/src/app/core/services/storage.service.ts
@@ -51,6 +51,7 @@ export class StorageService {
 
   private patchQueue$ = new Subject();  // REST call queue to force sequential calls
   private _pendingPatches$ = new BehaviorSubject<number>(0); // in-flight + queued patch count, for awaitQueueDrain
+  private _patchFailures = 0; // monotonic count of failed patches, so awaitQueueDrain can report failure (not just emptiness)
   private patch = function (arg: IPatchAction) { // http JSON Patch function
     //console.log(`[Storage Service] Send patch request:\n${JSON.stringify(arg.document)}`);
     return this.http.post(arg.url, arg.document)
@@ -94,6 +95,7 @@ export class StorageService {
           this.patch(arg).pipe(
             catchError((err) => {
               console.error('[Storage Service] Config patch failed; keeping the queue alive:', err);
+              this._patchFailures++;
               return of(null);
             }),
             finalize(() => this._pendingPatches$.next(Math.max(0, this._pendingPatches$.value - 1)))
@@ -192,9 +194,15 @@ export class StorageService {
    * @param {number} timeoutMs Maximum time to wait before resolving false. Defaults to 5000.
    * @returns {Promise<boolean>} True if the queue drained, false on timeout.
    */
+  /**
+   * Resolves true only when the queue empties with no patch failure in the meantime; false if a
+   * patch failed while draining or the wait times out. Callers that treat a drain as a save/delete
+   * guarantee (e.g. profile switch/rename/delete) must check the result rather than assume success.
+   */
   public awaitQueueDrain(timeoutMs = 5000): Promise<boolean> {
+    const failuresAtStart = this._patchFailures;
     if (this._pendingPatches$.value === 0) {
-      return Promise.resolve(true);
+      return Promise.resolve(this._patchFailures === failuresAtStart);
     }
     return new Promise<boolean>((resolve) => {
       let settled = false;
@@ -206,7 +214,7 @@ export class StorageService {
         resolve(result);
       };
       const sub = this._pendingPatches$.subscribe((count) => {
-        if (count === 0) finish(true);
+        if (count === 0) finish(this._patchFailures === failuresAtStart);
       });
       const timer = window.setTimeout(() => finish(false), timeoutMs);
     });

--- a/src/app/core/services/storage.service.ts
+++ b/src/app/core/services/storage.service.ts
@@ -6,7 +6,7 @@ import { IConfig } from "../interfaces/app-settings.interfaces";
 import { compare } from 'compare-versions';
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { Subject } from 'rxjs/internal/Subject';
-import { tap, concatMap, catchError, lastValueFrom, BehaviorSubject, EMPTY, timeout } from 'rxjs';
+import { tap, concatMap, catchError, finalize, lastValueFrom, of, BehaviorSubject, timeout } from 'rxjs';
 import { AuthenticationService } from './authentication.service';
 
 const REMOTE_CONFIG_TIMEOUT_MS = 5000; // bounded so a hung applicationData fetch cannot stall the bootstrap
@@ -50,6 +50,7 @@ export class StorageService {
 
 
   private patchQueue$ = new Subject();  // REST call queue to force sequential calls
+  private _pendingPatches$ = new BehaviorSubject<number>(0); // in-flight + queued patch count, for awaitQueueDrain
   private patch = function (arg: IPatchAction) { // http JSON Patch function
     //console.log(`[Storage Service] Send patch request:\n${JSON.stringify(arg.document)}`);
     return this.http.post(arg.url, arg.document)
@@ -89,10 +90,15 @@ export class StorageService {
       .pipe(
         // Keep the queue alive when one patch fails (e.g. a read-only session's 401): without this,
         // a thrown inner error terminates the subscription and silently drops every later save.
-        concatMap((arg: IPatchAction) => this.patch(arg).pipe(catchError((err) => {
-          console.error('[Storage Service] Config patch failed; keeping the queue alive:', err);
-          return EMPTY;
-        }))),
+        concatMap((arg: IPatchAction) =>
+          this.patch(arg).pipe(
+            catchError((err) => {
+              console.error('[Storage Service] Config patch failed; keeping the queue alive:', err);
+              return of(null);
+            }),
+            finalize(() => this._pendingPatches$.next(Math.max(0, this._pendingPatches$.value - 1)))
+          )
+        ),
         takeUntilDestroyed()
       )
       .subscribe(() => { /* queue item processed */ });
@@ -160,6 +166,50 @@ export class StorageService {
     if (!this.storageServiceReady$.getValue()) {
       throw new Error('[StorageService] Not ready: storageServiceReady is false');
     }
+  }
+
+  /**
+   * Boundary guard: a config slot name reaches the server both as a URL path segment and as a
+   * JSON Patch path key. An empty/undefined name would target the wrong location (e.g. POST to
+   * `/undefined/...`), silently corrupting storage. Refuse it.
+   */
+  private assertSlotName(name: string, op: string): void {
+    if (!name) {
+      throw new Error(`[StorageService] Refusing ${op}: empty or undefined config slot name.`);
+    }
+  }
+
+  private enqueuePatch(patch: IPatchAction): void {
+    this._pendingPatches$.next(this._pendingPatches$.value + 1);
+    this.patchQueue$.next(patch);
+  }
+
+  /**
+   * Resolves once the sequential patch queue has drained, or `false` if it has not settled within
+   * `timeoutMs`. Used before a profile switch/reload so queued writes to the leaving profile are
+   * not abandoned, while a stalled write degrades to best-effort rather than hanging the UI.
+   *
+   * @param {number} timeoutMs Maximum time to wait before resolving false. Defaults to 5000.
+   * @returns {Promise<boolean>} True if the queue drained, false on timeout.
+   */
+  public awaitQueueDrain(timeoutMs = 5000): Promise<boolean> {
+    if (this._pendingPatches$.value === 0) {
+      return Promise.resolve(true);
+    }
+    return new Promise<boolean>((resolve) => {
+      let settled = false;
+      const finish = (result: boolean) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        sub.unsubscribe();
+        resolve(result);
+      };
+      const sub = this._pendingPatches$.subscribe((count) => {
+        if (count === 0) finish(true);
+      });
+      const timer = window.setTimeout(() => finish(false), timeoutMs);
+    });
   }
 
   /**
@@ -265,6 +315,7 @@ export class StorageService {
    */
   public async setConfig(scope: string, configName: string, config: IConfig, forceConfigFileVersion?: number | string): Promise<null> {
     this.ensureReady();
+    this.assertSlotName(configName, 'setConfig');
 
     const base = this.serverEndpoint + scope + "/kip/";
     const ver = forceConfigFileVersion ?? this.configFileVersion;
@@ -299,6 +350,10 @@ export class StorageService {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public patchConfig(ObjType: string, value: any, forceConfigFileVersion?: number) {
     this.ensureReady();
+    if (!this.sharedConfigName) {
+      console.error('[StorageService] Refusing patchConfig: active config slot name is unset.');
+      return;
+    }
     const ver = forceConfigFileVersion ?? this.configFileVersion;
     const url = this.serverEndpoint + "user/kip/" + ver;
     let document;
@@ -401,7 +456,7 @@ export class StorageService {
         touchesConfigVersion
       });
     }
-    this.patchQueue$.next(patch);
+    this.enqueuePatch(patch);
   }
 
   /**
@@ -416,6 +471,7 @@ export class StorageService {
    */
   public patchGlobal(configName: string, scope: string, config: IConfig, operation: string, fileVersion?: number) {
     this.ensureReady();
+    this.assertSlotName(configName, 'patchGlobal');
     const ver = fileVersion ?? this.configFileVersion;
   const url = this.serverEndpoint + scope + "/kip/" + ver;
 
@@ -457,7 +513,7 @@ export class StorageService {
       const appVer: unknown = config?.app?.configVersion;
       console.debug('[StorageService.patchGlobal]', { scope, configName, operation, ver, url, appConfigVersionInValue: appVer });
     }
-    this.patchQueue$.next(patch);
+    this.enqueuePatch(patch);
   }
 
   /**
@@ -474,6 +530,7 @@ export class StorageService {
    */
   public removeItem(scope: string, name: string, forceConfigFileVersion?: number) {
     this.ensureReady();
+    this.assertSlotName(name, 'removeItem');
     let url = this.serverEndpoint + scope + "/kip/" + this.configFileVersion;
     if (forceConfigFileVersion) {
       url = this.serverEndpoint + scope + "/kip/" + forceConfigFileVersion;
@@ -486,7 +543,7 @@ export class StorageService {
         }
       ]
     const patch: IPatchAction = { url, document };
-    this.patchQueue$.next(patch);
+    this.enqueuePatch(patch);
   }
 
   /**

--- a/src/app/core/services/storage.service.ts
+++ b/src/app/core/services/storage.service.ts
@@ -6,8 +6,10 @@ import { IConfig } from "../interfaces/app-settings.interfaces";
 import { compare } from 'compare-versions';
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { Subject } from 'rxjs/internal/Subject';
-import { tap, concatMap, catchError, lastValueFrom, BehaviorSubject } from 'rxjs';
+import { tap, concatMap, catchError, lastValueFrom, BehaviorSubject, EMPTY, timeout } from 'rxjs';
 import { AuthenticationService } from './authentication.service';
+
+const REMOTE_CONFIG_TIMEOUT_MS = 5000; // bounded so a hung applicationData fetch cannot stall the bootstrap
 
 export interface Config {
   name: string,
@@ -84,7 +86,15 @@ export class StorageService {
 
     // Patch request queue to insure JSON Patch requests to SK server don't run over each other and cause collisions/conflicts. SK does not handle multiple async applicationData access calls
     this.patchQueue$
-      .pipe(concatMap((arg: IPatchAction) => this.patch(arg)), takeUntilDestroyed())
+      .pipe(
+        // Keep the queue alive when one patch fails (e.g. a read-only session's 401): without this,
+        // a thrown inner error terminates the subscription and silently drops every later save.
+        concatMap((arg: IPatchAction) => this.patch(arg).pipe(catchError((err) => {
+          console.error('[Storage Service] Config patch failed; keeping the queue alive:', err);
+          return EMPTY;
+        }))),
+        takeUntilDestroyed()
+      )
       .subscribe(() => { /* queue item processed */ });
   }
 
@@ -223,7 +233,7 @@ export class StorageService {
     }
 
     try {
-      const remoteConfig = await lastValueFrom(this.http.get<IConfig>(url));
+      const remoteConfig = await lastValueFrom(this.http.get<IConfig>(url).pipe(timeout(REMOTE_CONFIG_TIMEOUT_MS)));
       if (this._logIO) {
         const appVer: unknown = (remoteConfig && typeof remoteConfig === 'object') ? (remoteConfig as IConfig)?.app?.configVersion : undefined;
         console.debug('[StorageService.getConfig Response]', { scope, configName, ver, appConfigVersion: appVer });

--- a/src/app/core/utils/login-redirect.util.spec.ts
+++ b/src/app/core/utils/login-redirect.util.spec.ts
@@ -24,6 +24,11 @@ describe('isSafeReturnTo', () => {
     expect(isSafeReturnTo('/\\/evil.example')).toBe(false);
   });
 
+  it('rejects a dot-segment path that normalizes to a protocol-relative path', () => {
+    expect(isSafeReturnTo('/a/..//evil.example')).toBe(false);
+    expect(isSafeReturnTo('/foo/../..//evil.example')).toBe(false);
+  });
+
   it('rejects control characters', () => {
     expect(isSafeReturnTo('/path\x00')).toBe(false);
     expect(isSafeReturnTo('/path\nmore')).toBe(false);

--- a/src/app/core/utils/login-redirect.util.spec.ts
+++ b/src/app/core/utils/login-redirect.util.spec.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { isSafeReturnTo, buildLoginRedirectUrl } from './login-redirect.util';
+
+describe('isSafeReturnTo', () => {
+  it('accepts a site-relative path', () => {
+    expect(isSafeReturnTo('/dashboard')).toBe(true);
+    expect(isSafeReturnTo('/dashboard/2?foo=bar')).toBe(true);
+  });
+
+  it('rejects empty / non-string', () => {
+    expect(isSafeReturnTo('')).toBe(false);
+    expect(isSafeReturnTo(null)).toBe(false);
+    expect(isSafeReturnTo(undefined)).toBe(false);
+  });
+
+  it('rejects protocol-relative and absolute URLs', () => {
+    expect(isSafeReturnTo('//evil.example')).toBe(false);
+    expect(isSafeReturnTo('https://evil.example/x')).toBe(false);
+    expect(isSafeReturnTo('http://evil.example')).toBe(false);
+  });
+
+  it('rejects a backslash (browsers normalize it to /)', () => {
+    expect(isSafeReturnTo('/\\evil.example')).toBe(false);
+    expect(isSafeReturnTo('/\\/evil.example')).toBe(false);
+  });
+
+  it('rejects control characters', () => {
+    expect(isSafeReturnTo('/path\x00')).toBe(false);
+    expect(isSafeReturnTo('/path\nmore')).toBe(false);
+    expect(isSafeReturnTo('/path\x7f')).toBe(false);
+  });
+
+  it('rejects a non-relative target (no leading slash)', () => {
+    expect(isSafeReturnTo('dashboard')).toBe(false);
+    expect(isSafeReturnTo('javascript:alert(1)')).toBe(false);
+  });
+
+  it('rejects the login self-route (avoids a redirect loop)', () => {
+    expect(isSafeReturnTo('/login')).toBe(false);
+  });
+});
+
+describe('buildLoginRedirectUrl', () => {
+  it('appends a validated returnTo to a query-style (OIDC) login URL', () => {
+    const url = buildLoginRedirectUrl({ loginUrl: '/signalk/v1/auth/oidc/login', returnTo: '/dashboard' });
+    expect(url).toBe('/signalk/v1/auth/oidc/login?returnTo=%2Fdashboard');
+  });
+
+  it('drops an unsafe returnTo but still returns the login URL', () => {
+    const url = buildLoginRedirectUrl({ loginUrl: '/signalk/v1/auth/oidc/login', returnTo: '//evil.example' });
+    expect(url).toBe('/signalk/v1/auth/oidc/login');
+  });
+
+  it('adds noAutoLogin for a recovery (manual) sign-in', () => {
+    const url = buildLoginRedirectUrl({ loginUrl: '/signalk/v1/auth/oidc/login', returnTo: '/x', noAutoLogin: true });
+    expect(url).toBe('/signalk/v1/auth/oidc/login?returnTo=%2Fx&noAutoLogin=true');
+  });
+
+  it('places params in the hash fragment for an admin hash-route login URL', () => {
+    const url = buildLoginRedirectUrl({ loginUrl: '/admin/#/login', noAutoLogin: true });
+    expect(url).toBe('/admin/#/login?noAutoLogin=true');
+  });
+
+  it('returns the login URL unchanged when there are no params', () => {
+    expect(buildLoginRedirectUrl({ loginUrl: '/signalk/v1/auth/oidc/login' })).toBe('/signalk/v1/auth/oidc/login');
+  });
+});

--- a/src/app/core/utils/login-redirect.util.ts
+++ b/src/app/core/utils/login-redirect.util.ts
@@ -33,6 +33,11 @@ export function isSafeReturnTo(target: string | null | undefined): boolean {
   if (resolved.origin !== window.location.origin) {
     return false;
   }
+  // Reject a normalized protocol-relative path (e.g. raw '/a/..//evil' resolves to '//evil'), so the
+  // check holds on the resolved path, not just the raw string.
+  if (resolved.pathname.startsWith('//')) {
+    return false;
+  }
   return !SELF_ROUTE_PATHS.includes(resolved.pathname);
 }
 

--- a/src/app/core/utils/login-redirect.util.ts
+++ b/src/app/core/utils/login-redirect.util.ts
@@ -1,0 +1,72 @@
+// KIP routes that must never be a returnTo target — redirecting back to them would loop the
+// SSO bounce instead of returning the user to real content.
+const SELF_ROUTE_PATHS = ['/login'];
+
+/**
+ * Validates a returnTo target for the SSO redirect. Accepts only site-relative paths on the app's
+ * own origin; rejects protocol-relative (`//host`), backslash (normalized to `/` by browsers),
+ * control characters, absolute/scheme URLs, cross-origin targets, and KIP's own login route (loop).
+ * Mirrors the Signal K server's loginRedirect validation so KIP cannot construct an open redirect.
+ */
+export function isSafeReturnTo(target: string | null | undefined): boolean {
+  if (!target || typeof target !== 'string') {
+    return false;
+  }
+  if (!target.startsWith('/') || target.startsWith('//')) {
+    return false;
+  }
+  if (target.includes('\\')) {
+    return false;
+  }
+  for (let i = 0; i < target.length; i++) {
+    const code = target.charCodeAt(i);
+    if (code < 0x20 || code === 0x7f) {
+      return false;
+    }
+  }
+  let resolved: URL;
+  try {
+    resolved = new URL(target, window.location.origin);
+  } catch {
+    return false;
+  }
+  if (resolved.origin !== window.location.origin) {
+    return false;
+  }
+  return !SELF_ROUTE_PATHS.includes(resolved.pathname);
+}
+
+/**
+ * Builds the login redirect URL, appending a validated `returnTo` and an optional `noAutoLogin`
+ * flag. Handles both query-style login URLs (OIDC, e.g. `/signalk/v1/auth/oidc/login`) and hash
+ * routes (admin login, e.g. `/admin/#/login`) by placing the params in the correct component.
+ * An unsafe `returnTo` is dropped (the redirect still proceeds without it).
+ */
+export function buildLoginRedirectUrl(opts: {
+  loginUrl: string;
+  returnTo?: string | null;
+  noAutoLogin?: boolean;
+}): string {
+  const params: [string, string][] = [];
+  if (opts.returnTo && isSafeReturnTo(opts.returnTo)) {
+    params.push(['returnTo', opts.returnTo]);
+  }
+  if (opts.noAutoLogin) {
+    params.push(['noAutoLogin', 'true']);
+  }
+  if (params.length === 0) {
+    return opts.loginUrl;
+  }
+
+  const query = params.map(([k, v]) => `${k}=${encodeURIComponent(v)}`).join('&');
+  const hashIndex = opts.loginUrl.indexOf('#');
+  if (hashIndex >= 0) {
+    // Hash route: the params belong to the hash fragment's own query string.
+    const base = opts.loginUrl.slice(0, hashIndex);
+    const hash = opts.loginUrl.slice(hashIndex);
+    const sep = hash.includes('?') ? '&' : '?';
+    return `${base}${hash}${sep}${query}`;
+  }
+  const sep = opts.loginUrl.includes('?') ? '&' : '?';
+  return `${opts.loginUrl}${sep}${query}`;
+}

--- a/src/app/widgets/widget-freeboardsk/freeboard-sk-url.util.spec.ts
+++ b/src/app/widgets/widget-freeboardsk/freeboard-sk-url.util.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { buildFreeboardSkUrl } from './freeboard-sk-url.util';
+
+describe('buildFreeboardSkUrl', () => {
+  it('cookie mode: uses the served origin and no token, ignoring a cross-origin server URL and any token', () => {
+    expect(
+      buildFreeboardSkUrl({
+        cookieMode: true,
+        appOrigin: 'https://boat.hal:4430',
+        serverUrl: 'https://elsewhere.example:9999',
+        token: 'should-not-appear'
+      })
+    ).toBe('https://boat.hal:4430/@signalk/freeboard-sk/');
+  });
+
+  it('token mode with a token: uses the server URL and appends ?token=', () => {
+    expect(
+      buildFreeboardSkUrl({
+        cookieMode: false,
+        appOrigin: 'https://app.example',
+        serverUrl: 'https://boat.example:3000',
+        token: 'abc123'
+      })
+    ).toBe('https://boat.example:3000/@signalk/freeboard-sk/?token=abc123');
+  });
+
+  it('token mode without a token: uses the server URL and no token param', () => {
+    expect(
+      buildFreeboardSkUrl({
+        cookieMode: false,
+        appOrigin: 'https://app.example',
+        serverUrl: 'https://boat.example:3000',
+        token: null
+      })
+    ).toBe('https://boat.example:3000/@signalk/freeboard-sk/');
+  });
+});

--- a/src/app/widgets/widget-freeboardsk/freeboard-sk-url.util.ts
+++ b/src/app/widgets/widget-freeboardsk/freeboard-sk-url.util.ts
@@ -1,0 +1,23 @@
+const FREEBOARD_SK_PATH = '/@signalk/freeboard-sk/';
+
+/**
+ * Builds the embedded Freeboard-SK iframe URL.
+ *
+ * In cookie mode the iframe must load from the origin KIP is served from (proxy mode leaves the
+ * configured server URL cross-origin) and carry no token, so the same-origin session cookie
+ * authenticates it. In token mode it loads from the configured server URL and appends the JWT as a
+ * query param when one is present.
+ */
+export function buildFreeboardSkUrl(params: {
+  cookieMode: boolean;
+  appOrigin: string;
+  serverUrl: string;
+  token?: string | null;
+}): string {
+  if (params.cookieMode) {
+    return `${params.appOrigin}${FREEBOARD_SK_PATH}`;
+  }
+  return params.token
+    ? `${params.serverUrl}${FREEBOARD_SK_PATH}?token=${params.token}`
+    : `${params.serverUrl}${FREEBOARD_SK_PATH}`;
+}

--- a/src/app/widgets/widget-freeboardsk/widget-freeboardsk.component.ts
+++ b/src/app/widgets/widget-freeboardsk/widget-freeboardsk.component.ts
@@ -5,6 +5,7 @@ import { AfterViewInit, Component, ElementRef, effect, inject, input, OnDestroy,
 import { ChangeDetectionStrategy } from '@angular/core';
 import { SafePipe } from "../../core/pipes/safe.pipe";
 import { generateSwipeScript } from '../../core/utils/iframe-inputs-inject.utils';
+import { buildFreeboardSkUrl } from './freeboard-sk-url.util';
 import { WidgetRuntimeDirective } from '../../core/directives/widget-runtime.directive';
 import { IWidgetSvcConfig } from '../../core/interfaces/widgets-interface';
 import { AppService, ITheme } from '../../core/services/app-service';
@@ -57,10 +58,12 @@ export class WidgetFreeboardskComponent implements AfterViewInit, OnDestroy {
       const token = this.authToken();
 
       untracked(() => {
-        const loginToken = token?.token;
-        this.widgetUrl = loginToken
-          ? `${this.appSettings.signalkUrl.url}/@signalk/freeboard-sk/?token=${loginToken}`
-          : `${this.appSettings.signalkUrl.url}/@signalk/freeboard-sk/`;
+        this.widgetUrl = buildFreeboardSkUrl({
+          cookieMode: this.auth.authMode === 'cookie',
+          appOrigin: window.location.origin,
+          serverUrl: this.appSettings.signalkUrl.url,
+          token: token?.token
+        });
       });
     });
 

--- a/src/app/widgets/widget-login/widget-login.component.html
+++ b/src/app/widgets/widget-login/widget-login.component.html
@@ -1,0 +1,5 @@
+@if (redirecting) {
+  <div class="sso-redirecting" role="status" aria-live="polite">
+    <p>Signing in via Signal K…</p>
+  </div>
+}

--- a/src/app/widgets/widget-login/widget-login.component.ts
+++ b/src/app/widgets/widget-login/widget-login.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit, inject } from '@angular/core';
 import { ChangeDetectionStrategy } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { AuthenticationService } from "../../core/services/authentication.service";
+import { SsoRedirectService } from '../../core/services/sso-redirect.service';
 import { SettingsService } from '../../core/services/settings.service';
 import { ModalUserCredentialComponent } from '../../core/components/modal-user-credential/modal-user-credential.component';
 import { IConnectionConfig } from "../../core/interfaces/app-settings.interfaces";
@@ -18,12 +19,21 @@ import { ToastService } from '../../core/services/toast.service';
 export class WidgetLoginComponent implements OnInit {
   dialog = inject(MatDialog);
   private auth = inject(AuthenticationService);
+  private ssoRedirect = inject(SsoRedirectService);
   private toast = inject(ToastService);
   private settings = inject(SettingsService);
 
   public connectionConfig: IConnectionConfig = null;
+  public redirecting = false;
 
   ngOnInit(): void {
+    if (this.auth.authMode === 'cookie') {
+      // Same-origin: no KIP-managed credential form. Redirect to the SK/SSO login instead (explicit
+      // sign-in: resets the redirect budget and disables auto-login so this is not auto-bounced).
+      this.redirecting = true;
+      this.ssoRedirect.manualSignIn();
+      return;
+    }
     this.connectionConfig = this.settings.getConnectionConfig();
     this.openUserCredentialModal("Sign in failed: Incorrect user/password. Enter valide credentials or access the Confifuration/Settings menu, validate the server URL or/and disable the user Sign in option");
   }

--- a/src/app/widgets/widget-login/widget-login.component.ts
+++ b/src/app/widgets/widget-login/widget-login.component.ts
@@ -51,7 +51,7 @@ export class WidgetLoginComponent implements OnInit {
   }
 
   private serverLogin(newUrl?: string) {
-    this.auth.login({ usr: this.connectionConfig.loginName, pwd: this.connectionConfig.loginPassword, newUrl })
+    this.auth.login({ usr: this.connectionConfig.loginName, pwd: this.connectionConfig.loginPassword ?? '', newUrl })
     .then(() => {
       this.settings.reloadApp();
     })

--- a/src/default-config/config.blank.const.ts
+++ b/src/default-config/config.blank.const.ts
@@ -8,8 +8,6 @@ export const DefaultAppConfig: IAppConfig = {
   "autoNightMode": true,
   "redNightMode": false,
   "nightModeBrightness": 0.27,
-  "isRemoteControl": false,
-  "instanceName": "",
   "dataSets": [],
   "unitDefaults": DefaultUnitsConfig,
   "notificationConfig": DefaultNotificationConfig,
@@ -30,7 +28,7 @@ export const defaultConfig: IConfig = {
 }
 
 export const DefaultConnectionConfig: IConnectionConfig = {
-  "configVersion": 12,
+  "configVersion": 13,
   "kipUUID": UUID.create(),
   "signalKUrl": null, // get's overwritten with host at getDefaultConnectionConfig()
   "proxyEnabled": false,
@@ -38,5 +36,7 @@ export const DefaultConnectionConfig: IConnectionConfig = {
   "useDeviceToken": false,
   "loginName": null,
   "useSharedConfig": false,
-  "sharedConfigName": "default"
+  "sharedConfigName": "default",
+  "isRemoteControl": false,
+  "instanceName": ""
 }

--- a/src/default-config/config.blank.const.ts
+++ b/src/default-config/config.blank.const.ts
@@ -37,7 +37,6 @@ export const DefaultConnectionConfig: IConnectionConfig = {
   "signalKSubscribeAll": false,
   "useDeviceToken": false,
   "loginName": null,
-  "loginPassword": null,
   "useSharedConfig": false,
   "sharedConfigName": "default"
 }

--- a/src/default-config/config.demo.const.ts
+++ b/src/default-config/config.demo.const.ts
@@ -8,8 +8,6 @@ export const DemoAppConfig: IAppConfig = {
   "autoNightMode": false,
   "redNightMode": false,
   "nightModeBrightness": 0.27,
-  "isRemoteControl": false,
-  "instanceName": "",
   "splitShellEnabled": true,
   "splitShellSide": "left",
   "splitShellSwipeDisabled": false,
@@ -771,7 +769,7 @@ export const DemoConfig: IConfig = {
 }
 
 export const DemoConnectionConfig: IConnectionConfig = {
-  "configVersion": 12,
+  "configVersion": 13,
   "kipUUID": UUID.create(),
   "signalKUrl": "https://demo.signalk.org",
   "proxyEnabled": false,
@@ -779,5 +777,7 @@ export const DemoConnectionConfig: IConnectionConfig = {
   "useDeviceToken": false,
   "loginName": null,
   "useSharedConfig": false,
-  "sharedConfigName": "default"
+  "sharedConfigName": "default",
+  "isRemoteControl": false,
+  "instanceName": ""
 }

--- a/src/default-config/config.demo.const.ts
+++ b/src/default-config/config.demo.const.ts
@@ -778,7 +778,6 @@ export const DemoConnectionConfig: IConnectionConfig = {
   "signalKSubscribeAll": false,
   "useDeviceToken": false,
   "loginName": null,
-  "loginPassword": null,
   "useSharedConfig": false,
   "sharedConfigName": "default"
 }

--- a/src/test-helpers/local-storage.test-helper.ts
+++ b/src/test-helpers/local-storage.test-helper.ts
@@ -1,0 +1,63 @@
+/**
+ * jsdom with an opaque origin (no document URL) does not expose Web Storage, so
+ * `window.localStorage` / the global `localStorage` are undefined under the unit-test
+ * runner. Services that read storage in their constructor then crash. This helper
+ * installs a minimal in-memory Storage when one is missing and returns a cleared
+ * instance for deterministic per-test seeding. It is a no-op (just clears) in
+ * environments that already provide localStorage.
+ */
+class MemoryStorage implements Storage {
+  private store = new Map<string, string>();
+
+  get length(): number {
+    return this.store.size;
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.store.has(key) ? (this.store.get(key) as string) : null;
+  }
+
+  key(index: number): string | null {
+    return Array.from(this.store.keys())[index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.store.set(key, String(value));
+  }
+}
+
+export function ensureLocalStorage(): Storage {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const g = globalThis as any;
+
+  let existing: Storage | undefined;
+  try {
+    existing = g.localStorage;
+  } catch {
+    existing = undefined;
+  }
+
+  if (!existing) {
+    const mem = new MemoryStorage();
+    Object.defineProperty(g, 'localStorage', { configurable: true, value: mem });
+    if (typeof window !== 'undefined') {
+      try {
+        Object.defineProperty(window, 'localStorage', { configurable: true, value: mem });
+      } catch {
+        /* ignore environments that forbid redefining window.localStorage */
+      }
+    }
+    existing = mem;
+  }
+
+  existing.clear();
+  return existing;
+}

--- a/src/test-helpers/local-storage.test-helper.ts
+++ b/src/test-helpers/local-storage.test-helper.ts
@@ -34,25 +34,25 @@ class MemoryStorage implements Storage {
   }
 }
 
-export function ensureLocalStorage(): Storage {
+function ensureStorage(prop: 'localStorage' | 'sessionStorage'): Storage {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const g = globalThis as any;
 
   let existing: Storage | undefined;
   try {
-    existing = g.localStorage;
+    existing = g[prop];
   } catch {
     existing = undefined;
   }
 
   if (!existing) {
     const mem = new MemoryStorage();
-    Object.defineProperty(g, 'localStorage', { configurable: true, value: mem });
+    Object.defineProperty(g, prop, { configurable: true, value: mem });
     if (typeof window !== 'undefined') {
       try {
-        Object.defineProperty(window, 'localStorage', { configurable: true, value: mem });
+        Object.defineProperty(window, prop, { configurable: true, value: mem });
       } catch {
-        /* ignore environments that forbid redefining window.localStorage */
+        /* ignore environments that forbid redefining the storage */
       }
     }
     existing = mem;
@@ -60,4 +60,16 @@ export function ensureLocalStorage(): Storage {
 
   existing.clear();
   return existing;
+}
+
+export function ensureLocalStorage(): Storage {
+  return ensureStorage('localStorage');
+}
+
+/**
+ * Same in-memory shim as {@link ensureLocalStorage}, for the SSO redirect budget which lives in
+ * sessionStorage (also undefined under the jsdom opaque origin).
+ */
+export function ensureSessionStorage(): Storage {
+  return ensureStorage('sessionStorage');
 }

--- a/src/test.ts
+++ b/src/test.ts
@@ -226,6 +226,15 @@ class AuthenticationServiceStub {
   public isLoggedIn$ = this._isLoggedIn$.asObservable();
   private _authToken$ = new BehaviorSubject<{ expiry: number | null; token: string | null; isDeviceAccessToken: boolean }>(null);
   public authToken$ = this._authToken$.asObservable();
+  // Cookie-mode session surface (Unit 3). Default to token mode so existing specs are unaffected.
+  public authMode: 'cookie' | 'token' = 'token';
+  private _loginStatus$ = new BehaviorSubject<unknown>(null);
+  public loginStatus$ = this._loginStatus$.asObservable();
+  private _isUserSession$ = new BehaviorSubject<boolean>(false);
+  public isUserSession$ = this._isUserSession$.asObservable();
+  private _canWriteUserData$ = new BehaviorSubject<boolean>(false);
+  public canWriteUserData$ = this._canWriteUserData$.asObservable();
+  refreshLoginStatus = async (): Promise<unknown> => null;
   login = async () => { this._isLoggedIn$.next(true); };
   logout = async () => { this._isLoggedIn$.next(false); this._authToken$.next(null); };
 }

--- a/src/test.ts
+++ b/src/test.ts
@@ -215,7 +215,7 @@ class MatBottomSheetRefStub { dismiss(): void { /* noop */ } }
 class MatDialogRefStub { close(): void { /* noop */ } }
 class AppNetworkInitServiceStub {
   private _bootstrapStatusSubject = new BehaviorSubject<'starting' | 'ready' | 'degraded'>('ready');
-  private _bootstrapIssueSubject = new BehaviorSubject<{ reason: 'none' | 'missing-shared-config' | 'network-unreachable' | 'unauthorized' | 'unknown'; statusCode?: number; sharedConfigName?: string; legacyUpgradeAvailable?: boolean }>({ reason: 'none' });
+  private _bootstrapIssueSubject = new BehaviorSubject<{ reason: 'none' | 'missing-shared-config' | 'network-unreachable' | 'unauthorized' | 'unknown' | 'auth-blocked'; statusCode?: number; sharedConfigName?: string; legacyUpgradeAvailable?: boolean; cause?: 'budget-exhausted' | 'sign-in-required' }>({ reason: 'none' });
 
   public bootstrapStatus$ = this._bootstrapStatusSubject.asObservable();
   public bootstrapIssue$ = this._bootstrapIssueSubject.asObservable();
@@ -234,7 +234,10 @@ class AuthenticationServiceStub {
   public isUserSession$ = this._isUserSession$.asObservable();
   private _canWriteUserData$ = new BehaviorSubject<boolean>(false);
   public canWriteUserData$ = this._canWriteUserData$.asObservable();
+  public get loginStatusValue(): unknown { return this._loginStatus$.getValue(); }
   refreshLoginStatus = async (): Promise<unknown> => null;
+  authModeForConfig = (): 'cookie' | 'token' => this.authMode;
+  deleteToken = () => { this._authToken$.next(null); this._isLoggedIn$.next(false); };
   login = async () => { this._isLoggedIn$.next(true); };
   logout = async () => { this._isLoggedIn$.next(false); this._authToken$.next(null); };
 }

--- a/src/test.ts
+++ b/src/test.ts
@@ -342,7 +342,7 @@ class SettingsServiceStub {
   public signalkUrl = { url: 'http://localhost', new: false };
   private _kipUUID = 'test-uuid';
   private _connectionConfig: import('./app/core/interfaces/app-settings.interfaces').IConnectionConfig = {
-    configVersion: 12,
+    configVersion: 13,
     signalKUrl: 'http://localhost',
     proxyEnabled: false,
     signalKSubscribeAll: false,
@@ -351,7 +351,9 @@ class SettingsServiceStub {
     loginPassword: '',
     useSharedConfig: false,
     sharedConfigName: '',
-    kipUUID: 'test-uuid'
+    kipUUID: 'test-uuid',
+    isRemoteControl: false,
+    instanceName: ''
   };
   private _notificationConfig = new BehaviorSubject<import('./app/core/interfaces/app-settings.interfaces').INotificationConfig>({
     disableNotifications: true,
@@ -430,8 +432,6 @@ class SettingsServiceStub {
       autoNightMode: this.autoNightModeSubject.value,
       redNightMode: this.redNightModeSubject.value,
       nightModeBrightness: this.nightModeBrightnessSubject.value,
-      isRemoteControl: this._isRemoteControlSubject.value,
-      instanceName: this.instanceNameSubject.value,
       dataSets: this.dataSets as IDatasetServiceDatasetConfig[],
       unitDefaults: this.unitDefaultsSubject.value as IUnitDefaults,
       notificationConfig: this._notificationConfig.value,


### PR DESCRIPTION
## Motivation

Let a user keep several full KIP configurations (dashboards, widgets, theme, units) on the Signal K server and switch the active one per device — e.g. a helm layout vs a cockpit layout, or per-crew setups. Profiles are user-scope Signal K applicationData, so they need a real per-user identity.

## Relationship to the authentication PR

**This PR includes the commits from #1091 (same-origin cookie/SSO authentication).** Profiles build on it: user-scope applicationData needs the per-user session that work provides. If #1091 merges first, this branch can be rebased to show only the profiles diff; as submitted it contains both.

## Approach

- A `ProfileService` owns the lifecycle — list / switch / create / rename / duplicate / delete / import — on the user scope, with name validation (URL- and JSON-Patch-safe charset, reserved `default`, no duplicates) and guard rails (can't delete the active, the last, or `default`; switching verifies the slot still exists; import rejects an unsupported config version).
- The active profile name and the per-device "remote control" identity live in a per-device connection config (its own schema version, migrated once from the previous in-profile location), so switching a profile never changes which display a screen is or whether it participates in remote control.
- A Profiles section in the Configurations tab. Write actions are gated on write capability — a read-only session can view and switch but not mutate.

## Testing

Unit tests for ProfileService CRUD + guard rails, the connection-config migration (all branches), storage write-safety/queue-failure reporting, and the read-only write gating. Same jsdom pre-existing-failures note as #1091.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
