### PR TITLE
Fix WidgetHost2Component test file

### DIFF
--- a/src/app/core/components/widget-host2/widget-host2.component.spec.ts
+++ b/src/app/core/components/widget-host2/widget-host2.component.spec.ts
@@ -351,9 +351,10 @@ describe('WidgetHost2Component', () => {
         testWidget.autoOpenOptionsOnCreate = true;
 
         fixture.detectChanges();
-        await Promise.resolve();
+        await vi.waitFor(() => {
+            expect(dialogServiceMock.openWidgetOptions).toHaveBeenCalledTimes(1);
+        });
 
-        expect(dialogServiceMock.openWidgetOptions).toHaveBeenCalledTimes(1);
         expect(testWidget.autoOpenOptionsOnCreate).toBeUndefined();
     });
 
@@ -374,9 +375,10 @@ describe('WidgetHost2Component', () => {
         dialogServiceMock.openWidgetOptions.mockReturnValue({ afterClosed: () => of(null) });
 
         fixture.detectChanges();
-        await Promise.resolve();
+        await vi.waitFor(() => {
+            expect(dialogServiceMock.openWidgetOptions).toHaveBeenCalledTimes(1);
+        });
 
-        expect(dialogServiceMock.openWidgetOptions).toHaveBeenCalledTimes(1);
         expect(testWidget.config).toEqual(configSnapshot);
     });
 });


### PR DESCRIPTION
Update the test to use `vi.waitFor` for better handling of asynchronous calls, ensuring the dialog service mock is properly verified.