### PR TITLE
Center content in dashboard overlay

### DIFF
--- a/src/app/core/components/dashboard/dashboard.component.scss
+++ b/src/app/core/components/dashboard/dashboard.component.scss
@@ -59,7 +59,7 @@
   flex-direction: column;
   flex-wrap: nowrap;
   align-items: center;
-  justify-content: space-around; /* centered instead of space-around to avoid implicit extra space */
+  justify-content: space-evenly;
   padding: 1.5rem; /* balanced padding, overlay does not affect container size */
   text-align: center;
   box-sizing: border-box;


### PR DESCRIPTION
Adjust the dashboard component's styling to use `space-evenly` for better centering of content within the overlay.