### PR TITLE
Rollback Chart.js and annotation plugin registration

### DIFF
--- a/src/app/core/components/widget-history-chart-dialog/widget-history-chart-dialog.component.ts
+++ b/src/app/core/components/widget-history-chart-dialog/widget-history-chart-dialog.component.ts
@@ -26,8 +26,6 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { FormsModule} from '@angular/forms';
 
-Chart.register(LineController, LineElement, LinearScale, PointElement, TimeScale, Tooltip, Legend);
-
 interface ChartPoint {
   x: number;
   y: number;

--- a/src/app/widgets/minichart/minichart.component.ts
+++ b/src/app/widgets/minichart/minichart.component.ts
@@ -8,10 +8,6 @@ import { UnitsService } from '../../core/services/units.service';
 
 import { Chart, ChartConfiguration, ChartData, TimeUnit, TimeScale, LinearScale, LineController, PointElement, LineElement, Filler, CategoryScale } from 'chart.js';
 import 'chartjs-adapter-date-fns';
-import ChartStreaming from '@aziham/chartjs-plugin-streaming';
-
-
-Chart.register(ChartStreaming, TimeScale, LinearScale, LineController, PointElement, LineElement, Filler, CategoryScale);
 
 interface IChartColors {
   valueLine: string,

--- a/src/app/widgets/minichart/minichart.component.ts
+++ b/src/app/widgets/minichart/minichart.component.ts
@@ -290,9 +290,6 @@ export class MinichartComponent implements OnDestroy {
       legend: {
         display: false
       },
-      annotation: {
-        annotations: {}
-      },
        streaming: {
         duration: dataSourceInfo.maxDataPoints * dataSourceInfo.sampleTime,
         delay: dataSourceInfo.sampleTime,

--- a/src/app/widgets/widget-data-chart/widget-data-chart.component.spec.ts
+++ b/src/app/widgets/widget-data-chart/widget-data-chart.component.spec.ts
@@ -1,0 +1,176 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { of } from 'rxjs';
+
+vi.mock('chart.js', () => {
+  class MockChart {
+    static defaults = {
+      color: '#000',
+      font: { family: 'sans-serif' },
+    };
+
+    static register = vi.fn();
+
+    public config: { type: string; data: unknown; options: unknown; plugins?: unknown[] };
+    public data: unknown;
+    public options: unknown;
+
+    constructor(_ctx: unknown, config: { type: string; data: unknown; options: unknown; plugins?: unknown[] }) {
+      this.config = config;
+      this.data = config.data;
+      this.options = config.options;
+    }
+
+    update = vi.fn();
+    destroy = vi.fn();
+  }
+
+  class Stub {}
+
+  return {
+    Chart: MockChart,
+    TimeScale: Stub,
+    LinearScale: Stub,
+    LineController: Stub,
+    PointElement: Stub,
+    LineElement: Stub,
+    Filler: Stub,
+    Title: Stub,
+    SubTitle: Stub,
+  };
+});
+
+import { WidgetDataChartComponent } from './widget-data-chart.component';
+import { DatasetStreamService } from '../../core/services/dataset-stream.service';
+import { CanvasService } from '../../core/services/canvas.service';
+import { UnitsService } from '../../core/services/units.service';
+import { WidgetDatasetOrchestratorService } from '../../core/services/widget-dataset-orchestrator.service';
+import { WidgetRuntimeDirective } from '../../core/directives/widget-runtime.directive';
+
+describe('WidgetDataChartComponent', () => {
+  let component: WidgetDataChartComponent;
+  let fixture: ComponentFixture<WidgetDataChartComponent>;
+
+  const runtimeConfig = {
+    ...WidgetDataChartComponent.DEFAULT_CONFIG,
+    displayName: 'Chart Label',
+    datachartPath: 'navigation.speedOverGround',
+    datachartSource: null,
+    timeScale: 'minute',
+    period: 10,
+    color: 'contrast',
+    showLabel: true,
+    showYScale: false,
+    showTimeScale: false,
+    verticalChart: false,
+    inverseYAxis: false,
+    startScaleAtZero: false,
+    enableMinMaxScaleLimit: false,
+    yScaleSuggestedMin: undefined,
+    yScaleSuggestedMax: undefined,
+    yScaleMin: undefined,
+    yScaleMax: undefined,
+    datasetAverageArray: 'sma',
+    showAverageData: true,
+    trackAgainstAverage: false,
+    showDatasetMinimumValueLine: false,
+    showDatasetMaximumValueLine: false,
+    showDatasetAverageValueLine: true,
+    numDecimal: 1,
+    convertUnitTo: null,
+  };
+
+  beforeEach(async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const runtimeStub: any = {
+      options: () => runtimeConfig,
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const datasetServiceStub: any = {
+      getDatasetConfig: () => ({ period: 10, timeScaleFormat: 'minute' }),
+      getDataSourceInfo: () => ({ maxDataPoints: 30, sampleTime: 1000 }),
+      getDatasetBatchThenLiveObservable: () => of([]),
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const datasetLifecycleStub: any = {
+      syncDataChartDataset: () => {},
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const canvasServiceStub: any = {
+      releaseCanvas: () => {},
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const unitsServiceStub: any = {
+      convertToUnit: (_unit: string, value: number) => value,
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [WidgetDataChartComponent],
+      providers: [
+        { provide: WidgetRuntimeDirective, useValue: runtimeStub },
+        { provide: DatasetStreamService, useValue: datasetServiceStub },
+        { provide: WidgetDatasetOrchestratorService, useValue: datasetLifecycleStub },
+        { provide: CanvasService, useValue: canvasServiceStub },
+        { provide: UnitsService, useValue: unitsServiceStub },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(WidgetDataChartComponent);
+    component = fixture.componentInstance;
+
+    fixture.componentRef.setInput('id', 'widget-data-chart-1');
+    fixture.componentRef.setInput('type', 'widget-data-chart');
+    fixture.componentRef.setInput('theme', {
+      contrast: '#fff',
+      contrastDim: '#ccc',
+      contrastDimmer: '#999',
+      blue: '#00f',
+      blueDim: '#00c',
+      blueDimmer: '#009',
+      green: '#0f0',
+      greenDim: '#0c0',
+      greenDimmer: '#090',
+      pink: '#f0f',
+      pinkDim: '#c0c',
+      pinkDimmer: '#909',
+      orange: '#f90',
+      orangeDim: '#c70',
+      orangeDimmer: '#950',
+      purple: '#90f',
+      purpleDim: '#70c',
+      purpleDimmer: '#509',
+      grey: '#888',
+      greyDim: '#666',
+      greyDimmer: '#444',
+      yellow: '#ff0',
+      yellowDim: '#cc0',
+      yellowDimmer: '#990',
+    });
+
+    fixture.detectChanges();
+
+    const canvas = component.widgetDataChart()?.nativeElement as HTMLCanvasElement | undefined;
+    if (canvas) {
+      vi.spyOn(canvas, 'getContext').mockReturnValue({} as CanvasRenderingContext2D);
+    }
+  });
+
+  it('uses annotation options while not configuring annotation as an inline chart plugin (only global plugin registration is supported as of annotation 3.0.1)', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (component as any).rebuildForDataset(runtimeConfig);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const chartConfig = ((component as any).chart?.config ?? {}) as { plugins?: unknown[]; options?: { plugins?: { annotation?: { annotations?: Record<string, unknown> } } } };
+
+    expect(chartConfig.plugins).toBeUndefined();
+    expect(chartConfig.options?.plugins?.annotation?.annotations).toMatchObject({
+      minimumLine: expect.any(Object),
+      maximumLine: expect.any(Object),
+      averageLine: expect.any(Object),
+    });
+  });
+});

--- a/src/app/widgets/widget-data-chart/widget-data-chart.component.ts
+++ b/src/app/widgets/widget-data-chart/widget-data-chart.component.ts
@@ -10,11 +10,7 @@ import { ITheme } from '../../core/services/app-service';
 import { WidgetDatasetOrchestratorService } from '../../core/services/widget-dataset-orchestrator.service';
 
 import { Chart, ChartConfiguration, ChartData, TimeUnit, TimeScale, LinearScale, LineController, PointElement, LineElement, Filler, Title, SubTitle } from 'chart.js';
-import annotationPlugin from 'chartjs-plugin-annotation';
 import 'chartjs-adapter-date-fns';
-import ChartStreaming from '@aziham/chartjs-plugin-streaming';
-
-Chart.register(annotationPlugin, ChartStreaming, Filler, Title, SubTitle, TimeScale, LinearScale, LineController, PointElement, LineElement,);
 
 interface AnnPlugin {
   annotation?: {

--- a/src/app/widgets/widget-data-chart/widget-data-chart.component.ts
+++ b/src/app/widgets/widget-data-chart/widget-data-chart.component.ts
@@ -18,7 +18,7 @@ Chart.register(annotationPlugin, ChartStreaming, Filler, Title, SubTitle, TimeSc
 
 interface AnnPlugin {
   annotation?: {
-    annotations?: Record<string, { value?: number; label?: { content?: string } }>
+    annotations?: Record<string, { value?: number; display?: boolean; label?: { display?: boolean; content?: string } }>
   }
 }
 interface IChartColors {
@@ -94,6 +94,9 @@ export class WidgetDataChartComponent implements OnDestroy {
   private datasetConfig: IDatasetServiceDatasetConfig | null = null;
   private dataSourceInfo: IDatasetServiceDataSourceInfo | null = null;
   private lastVerticalChart: boolean | null = null;
+  private lastAverageValue: number | null = null;
+  private lastMinimumValue: number | null = null;
+  private lastMaximumValue: number | null = null;
   protected hasPath = computed<boolean>(() => {
     const cfg = this.runtime.options();
     return !!cfg?.datachartPath;
@@ -366,11 +369,12 @@ export class WidgetDataChartComponent implements OnDestroy {
           minimumLine: {
             type: 'line',
             scaleID: cfg.verticalChart ? 'x' : 'y',
-            display: cfg.showDatasetMinimumValueLine,
-            value: undefined,
+            display: cfg.showDatasetMinimumValueLine && this.lastMinimumValue !== null,
+            value: this.lastMinimumValue ?? 0,
             drawTime: 'afterDatasetsDraw',
             label: {
-              display: true,
+              display: cfg.showDatasetMinimumValueLine && this.lastMinimumValue !== null,
+              content: this.lastMinimumValue !== null ? `${this.lastMinimumValue.toFixed(cfg.numDecimal ?? 1)}` : '',
               position: "start",
               yAdjust: 12,
               padding: 4,
@@ -381,11 +385,12 @@ export class WidgetDataChartComponent implements OnDestroy {
           maximumLine: {
             type: 'line',
             scaleID: cfg.verticalChart ? 'x' : 'y',
-            display: cfg.showDatasetMaximumValueLine,
-            value: undefined,
+            display: cfg.showDatasetMaximumValueLine && this.lastMaximumValue !== null,
+            value: this.lastMaximumValue ?? 0,
             drawTime: 'afterDatasetsDraw',
             label: {
-              display: true,
+              display: cfg.showDatasetMaximumValueLine && this.lastMaximumValue !== null,
+              content: this.lastMaximumValue !== null ? `${this.lastMaximumValue.toFixed(cfg.numDecimal ?? 1)}` : '',
               position: "start",
               yAdjust: -12,
               padding: 4,
@@ -396,13 +401,14 @@ export class WidgetDataChartComponent implements OnDestroy {
           averageLine: {
             type: 'line',
             scaleID: cfg.verticalChart ? 'x' : 'y',
-            display: cfg.showDatasetAverageValueLine,
-            value: undefined,
+            display: cfg.showDatasetAverageValueLine && this.lastAverageValue !== null,
+            value: this.lastAverageValue ?? 0,
             borderDash: [6, 6],
             borderColor: this.getThemeColors().averageChartLine,
             drawTime: 'afterDatasetsDraw',
             label: {
-              display: true,
+              display: cfg.showDatasetAverageValueLine && this.lastAverageValue !== null,
+              content: this.lastAverageValue !== null ? `${this.lastAverageValue.toFixed(cfg.numDecimal ?? 1)}` : '',
               position: "start",
               padding: 4,
               color: this.getThemeColors().chartValue,
@@ -545,11 +551,23 @@ export class WidgetDataChartComponent implements OnDestroy {
   private updateAnnotationVisibility(): void {
     const cfg = this.runtime.options();
     if (!cfg || !this.chart) return;
-    const annCfg = (this.chart.options.plugins as unknown as { annotation?: { annotations?: Record<string, { display?: boolean }> } }).annotation?.annotations;
+    const annCfg = (this.chart.options.plugins as unknown as { annotation?: { annotations?: Record<string, { display?: boolean; label?: { display?: boolean } }> } }).annotation?.annotations;
     if (!annCfg) return;
-    if (annCfg.minimumLine) annCfg.minimumLine.display = cfg.showDatasetMinimumValueLine;
-    if (annCfg.maximumLine) annCfg.maximumLine.display = cfg.showDatasetMaximumValueLine;
-    if (annCfg.averageLine) annCfg.averageLine.display = cfg.showDatasetAverageValueLine;
+    if (annCfg.minimumLine) {
+      const show = cfg.showDatasetMinimumValueLine && this.lastMinimumValue !== null;
+      annCfg.minimumLine.display = show;
+      if (annCfg.minimumLine.label) annCfg.minimumLine.label.display = show;
+    }
+    if (annCfg.maximumLine) {
+      const show = cfg.showDatasetMaximumValueLine && this.lastMaximumValue !== null;
+      annCfg.maximumLine.display = show;
+      if (annCfg.maximumLine.label) annCfg.maximumLine.label.display = show;
+    }
+    if (annCfg.averageLine) {
+      const show = cfg.showDatasetAverageValueLine && this.lastAverageValue !== null;
+      annCfg.averageLine.display = show;
+      if (annCfg.averageLine.label) annCfg.averageLine.label.display = show;
+    }
   }
 
   private getThemeColors(): IChartColors {
@@ -820,24 +838,58 @@ export class WidgetDataChartComponent implements OnDestroy {
     const ann = plugins.annotation?.annotations;
     if (!ann) return;
 
-    if (lastAverage != null && Number.isFinite(lastAverage) && ann.averageLine?.value !== lastAverage) {
-      ann.averageLine.value = lastAverage;
-      if (ann.averageLine.label) {
-        ann.averageLine.label.content = `${lastAverage.toFixed(decimals)}`;
+    this.lastAverageValue = lastAverage != null && Number.isFinite(lastAverage) ? lastAverage : null;
+    this.lastMinimumValue = lastMinimum != null && Number.isFinite(lastMinimum) ? lastMinimum : null;
+    this.lastMaximumValue = lastMaximum != null && Number.isFinite(lastMaximum) ? lastMaximum : null;
+
+    if (ann.averageLine) {
+      if (this.lastAverageValue !== null) {
+        ann.averageLine.value = this.lastAverageValue;
+        ann.averageLine.display = cfg.showDatasetAverageValueLine;
+        if (ann.averageLine.label) {
+          ann.averageLine.label.display = cfg.showDatasetAverageValueLine;
+          ann.averageLine.label.content = `${this.lastAverageValue.toFixed(decimals)}`;
+        }
+      } else {
+        ann.averageLine.display = false;
+        if (ann.averageLine.label) {
+          ann.averageLine.label.display = false;
+          ann.averageLine.label.content = '';
+        }
       }
     }
 
-    if (lastMinimum != null && Number.isFinite(lastMinimum) && ann.minimumLine?.value !== lastMinimum) {
-      ann.minimumLine.value = lastMinimum;
-      if (ann.minimumLine.label) {
-        ann.minimumLine.label.content = `${lastMinimum.toFixed(decimals)}`;
+    if (ann.minimumLine) {
+      if (this.lastMinimumValue !== null) {
+        ann.minimumLine.value = this.lastMinimumValue;
+        ann.minimumLine.display = cfg.showDatasetMinimumValueLine;
+        if (ann.minimumLine.label) {
+          ann.minimumLine.label.display = cfg.showDatasetMinimumValueLine;
+          ann.minimumLine.label.content = `${this.lastMinimumValue.toFixed(decimals)}`;
+        }
+      } else {
+        ann.minimumLine.display = false;
+        if (ann.minimumLine.label) {
+          ann.minimumLine.label.display = false;
+          ann.minimumLine.label.content = '';
+        }
       }
     }
 
-    if (lastMaximum != null && Number.isFinite(lastMaximum) && ann.maximumLine?.value !== lastMaximum) {
-      ann.maximumLine.value = lastMaximum;
-      if (ann.maximumLine.label) {
-        ann.maximumLine.label.content = `${lastMaximum.toFixed(decimals)}`;
+    if (ann.maximumLine) {
+      if (this.lastMaximumValue !== null) {
+        ann.maximumLine.value = this.lastMaximumValue;
+        ann.maximumLine.display = cfg.showDatasetMaximumValueLine;
+        if (ann.maximumLine.label) {
+          ann.maximumLine.label.display = cfg.showDatasetMaximumValueLine;
+          ann.maximumLine.label.content = `${this.lastMaximumValue.toFixed(decimals)}`;
+        }
+      } else {
+        ann.maximumLine.display = false;
+        if (ann.maximumLine.label) {
+          ann.maximumLine.label.display = false;
+          ann.maximumLine.label.content = '';
+        }
       }
     }
   }

--- a/src/app/widgets/widget-windtrends-chart/widget-windtrends-chart.component.ts
+++ b/src/app/widgets/widget-windtrends-chart/widget-windtrends-chart.component.ts
@@ -560,9 +560,6 @@ export class WidgetWindTrendsChartComponent implements OnDestroy {
       },
       legend: { display: false
       },
-      annotation: {
-        annotations: {}
-      },
       streaming: {
         duration: dataSourceInfo.maxDataPoints * dataSourceInfo.sampleTime,
         delay: dataSourceInfo.sampleTime,

--- a/src/app/widgets/widget-windtrends-chart/widget-windtrends-chart.component.ts
+++ b/src/app/widgets/widget-windtrends-chart/widget-windtrends-chart.component.ts
@@ -13,9 +13,6 @@ import { WidgetDatasetOrchestratorService } from '../../core/services/widget-dat
 
 import { Chart, ChartConfiguration, ChartData, TimeScale, LinearScale, LineController, PointElement, LineElement, Filler, Title, SubTitle, ChartArea, Scale } from 'chart.js';
 import 'chartjs-adapter-date-fns';
-import ChartStreaming from '@aziham/chartjs-plugin-streaming';
-
-Chart.register(ChartStreaming, TimeScale, LinearScale, LineController, PointElement, LineElement, Filler, Title, SubTitle);
 
 interface IChartColors {
   valueLine: string,

--- a/src/main.spec.ts
+++ b/src/main.spec.ts
@@ -1,0 +1,37 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Chart } from 'chart.js';
+import annotationPlugin from 'chartjs-plugin-annotation';
+
+const { bootstrapApplicationMock } = vi.hoisted(() => ({
+  bootstrapApplicationMock: vi.fn(() => Promise.resolve({})),
+}));
+
+vi.mock('@angular/platform-browser', async () => {
+  const actual = await vi.importActual<typeof import('@angular/platform-browser')>('@angular/platform-browser');
+  return {
+    ...actual,
+    bootstrapApplication: bootstrapApplicationMock,
+  };
+});
+
+describe('main startup chart plugin registration', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    bootstrapApplicationMock.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('registers annotation plugin at startup via Chart.register (inline plugin registration not supported as of annotation 3.0.1)', async () => {
+    const registerSpy = vi.spyOn(Chart, 'register');
+
+    await import('./main');
+
+    expect(registerSpy).toHaveBeenCalled();
+    const registeredItems = registerSpy.mock.calls.flat();
+    expect(registeredItems).toContain(annotationPlugin);
+    expect(bootstrapApplicationMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,10 +26,43 @@ import { HTTP_INTERCEPTORS, withInterceptorsFromDi, provideHttpClient, withXhr }
 import { OverlayContainer } from '@angular/cdk/overlay';
 import { AppOverlayContainer } from './app/core/utils/app-overlay-container';
 import { RouterOverlayNavigationService } from './app/core/services/router-overlay-navigation.service';
+import {
+  Chart,
+  CategoryScale,
+  Filler,
+  Legend,
+  LineController,
+  LineElement,
+  LinearScale,
+  PointElement,
+  SubTitle,
+  TimeScale,
+  Title,
+  Tooltip,
+} from 'chart.js';
+import annotationPlugin from 'chartjs-plugin-annotation';
+import ChartStreaming from '@aziham/chartjs-plugin-streaming';
 
 if (environment.production) {
   enableProdMode();
 }
+
+// Register Chart.js building blocks and plugins once at startup, before any chart instance is created.
+Chart.register(
+  annotationPlugin,
+  ChartStreaming,
+  CategoryScale,
+  Filler,
+  Legend,
+  LineController,
+  LineElement,
+  LinearScale,
+  PointElement,
+  SubTitle,
+  TimeScale,
+  Title,
+  Tooltip,
+);
 
 bootstrapApplication(AppComponent, {
   providers: [


### PR DESCRIPTION
Revert to global registration of Chart.js and the annotation plugin to enhance stability and compatibility across components. This change addresses issues with inline annotation v3.0.1 plugin registration not being supported.