### PR TITLE
Fix switch panel indicator state for better visibility

### DIFF
--- a/src/app/widgets/svg-boolean-button/svg-boolean-button.component.ts
+++ b/src/app/widgets/svg-boolean-button/svg-boolean-button.component.ts
@@ -19,7 +19,6 @@ export class SvgBooleanButtonComponent implements DoCheck, OnDestroy {
 
   private oldTheme: ITheme | null = null;
 
-  private holdTimeoutId: ReturnType<typeof setTimeout> | null = null; // delay before starting momentary emit
   private emitIntervalId: ReturnType<typeof setInterval> | null = null; // repeating emit while pressed
   private pressed = false;
   private isSwiping = false;
@@ -58,23 +57,17 @@ export class SvgBooleanButtonComponent implements DoCheck, OnDestroy {
     this.pointerStartX = event.clientX;
     this.pointerStartY = event.clientY;
 
-    // Wait 250ms before emitting the state
+    // Emit immediately on press, then continue emitting while held.
     this.clearTimers();
-    this.holdTimeoutId = setTimeout(() => {
-      if (!this.isSwiping) {
-        // Momentary mode
-        this.pressed = true;
+    this.pressed = true;
 
-        const state: IDynamicControl = cloneDeep(currentData);
-        state.value = this.pressed;
+    const state: IDynamicControl = cloneDeep(currentData);
+    state.value = this.pressed;
 
-        // Start emitting the state every 100ms
-        this.toggleClick.emit(state);
-        this.emitIntervalId = setInterval(() => {
-          this.toggleClick.emit(state);
-        }, 100);
-      }
-    }, 200);
+    this.toggleClick.emit(state);
+    this.emitIntervalId = setInterval(() => {
+      this.toggleClick.emit(state);
+    }, 100);
   }
 
   public handlePointerMove(event: PointerEvent): void {
@@ -84,12 +77,8 @@ export class SvgBooleanButtonComponent implements DoCheck, OnDestroy {
     // Mark as swiping if movement exceeds a threshold
     if (deltaX > 30 || deltaY > 30) {
       this.isSwiping = true;
-
-      // Cancel the timeout if swiping is detected
-      if (this.holdTimeoutId) {
-        clearTimeout(this.holdTimeoutId);
-        this.holdTimeoutId = null;
-      }
+      this.pressed = false;
+      this.clearTimers();
     }
   }
 
@@ -174,10 +163,6 @@ export class SvgBooleanButtonComponent implements DoCheck, OnDestroy {
   }
 
   private clearTimers(): void {
-    if (this.holdTimeoutId) {
-      clearTimeout(this.holdTimeoutId);
-      this.holdTimeoutId = null;
-    }
     if (this.emitIntervalId) {
       clearInterval(this.emitIntervalId);
       this.emitIntervalId = null;

--- a/src/app/widgets/svg-boolean-light/svg-boolean-light.component.svg
+++ b/src/app/widgets/svg-boolean-light/svg-boolean-light.component.svg
@@ -32,8 +32,9 @@
     <div
       xmlns="http://www.w3.org/1999/xhtml"
       [style.color]="isEnabled ? valueColor : labelColor"
+      [style.opacity]="isEnabled ? 1 : 0.6"
       [style.fontSize.px]="layout.labelFontSize"
-      [style.textShadow]="isEnabled ? '0 0 6px currentColor, 0 0 6px currentColor' : 'none'"
+      [style.textShadow]="isEnabled ? '0 0 4px currentColor, 0 0 4px currentColor' : 'none'"
       style="width:100%;height:100%;display:flex;align-items:center;justify-content:flex-start;font-family:Roboto,sans-serif;font-weight:700;line-height:1;white-space:nowrap;overflow:hidden;text-overflow:clip;">
       {{ data()?.ctrlLabel }}
     </div>

--- a/src/app/widgets/svg-boolean-light/svg-boolean-light.component.svg
+++ b/src/app/widgets/svg-boolean-light/svg-boolean-light.component.svg
@@ -40,7 +40,7 @@
     [attr.cx]="layout.lightCenterX"
     [attr.cy]="layout.lightCenterY"
     [attr.r]="layout.lightRadius"
-    [attr.fill]="isEnabled ? valueColor : labelColor"
-    style="stroke:url(#linearGradient33);stroke-opacity:0.2;stroke-dasharray:none"
+    [attr.fill]="isEnabled ? valueColor : offColor"
+    style="stroke:url(#linearGradient33);stroke-opacity:0.4;stroke-dasharray:none"
     [attr.stroke-width]="layout.lightStrokeWidth" />
 </svg>

--- a/src/app/widgets/svg-boolean-light/svg-boolean-light.component.svg
+++ b/src/app/widgets/svg-boolean-light/svg-boolean-light.component.svg
@@ -7,17 +7,20 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg">
   <defs id="defs1">
-    <linearGradient id="linearGradient32">
-      <stop style="stop-color:#000000;stop-opacity:0.88486844;" offset="0" />
-      <stop style="stop-color:#f7f7f7;stop-opacity:0.17763157;" offset="1" />
-    </linearGradient>
-    <linearGradient
-      xlink:href="#linearGradient32"
-      id="linearGradient33"
-      x1="0"
-      y1="0"
-      x2="1"
-      y2="1">
+    <radialGradient id="lightSpecular" cx="36%" cy="32%" r="68%">
+      <stop offset="0" stop-color="#ffffff" stop-opacity="0.5" />
+      <stop offset="0.55" stop-color="#ffffff" stop-opacity="0.16" />
+      <stop offset="1" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+    <radialGradient id="lightDepth" cx="68%" cy="70%" r="68%">
+      <stop offset="0" stop-color="#000000" stop-opacity="0" />
+      <stop offset="0.62" stop-color="#000000" stop-opacity="0.05" />
+      <stop offset="1" stop-color="#000000" stop-opacity="0.22" />
+    </radialGradient>
+    <linearGradient id="lightRim" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#ffffff" stop-opacity="0.36" />
+      <stop offset="0.45" stop-color="#ffffff" stop-opacity="0.09" />
+      <stop offset="1" stop-color="#000000" stop-opacity="0.3" />
     </linearGradient>
   </defs>
 
@@ -41,6 +44,28 @@
     [attr.cy]="layout.lightCenterY"
     [attr.r]="layout.lightRadius"
     [attr.fill]="isEnabled ? valueColor : offColor"
-    style="stroke:url(#linearGradient33);stroke-opacity:0.4;stroke-dasharray:none"
+    style="stroke:url(#lightRim);stroke-opacity:0.4;stroke-dasharray:none"
     [attr.stroke-width]="layout.lightStrokeWidth" />
+
+  <circle
+    [attr.cx]="layout.lightCenterX"
+    [attr.cy]="layout.lightCenterY"
+    [attr.r]="layout.lightRadius"
+    fill="url(#lightSpecular)"
+    [attr.opacity]="isEnabled ? 0.62 : 0.42" />
+
+  <circle
+    [attr.cx]="layout.lightCenterX"
+    [attr.cy]="layout.lightCenterY"
+    [attr.r]="layout.lightRadius"
+    fill="url(#lightDepth)"
+    [attr.opacity]="isEnabled ? 0.62 : 0.48" />
+
+  <ellipse
+    [attr.cx]="layout.lightCenterX - (layout.lightRadius * 0.32)"
+    [attr.cy]="layout.lightCenterY - (layout.lightRadius * 0.34)"
+    [attr.rx]="layout.lightRadius * 0.34"
+    [attr.ry]="layout.lightRadius * 0.2"
+    fill="#ffffff"
+    [attr.opacity]="isEnabled ? 0.2 : 0.12" />
 </svg>

--- a/src/app/widgets/svg-boolean-light/svg-boolean-light.component.ts
+++ b/src/app/widgets/svg-boolean-light/svg-boolean-light.component.ts
@@ -21,6 +21,7 @@ export class SvgBooleanLightComponent implements DoCheck {
   private ctrlColor = '';
   private oldTheme: ITheme | null = null;
 
+  public offColor: string | null = null;
   public labelColor: string | null = null;
   public valueColor: string | null = null;
 
@@ -73,38 +74,47 @@ export class SvgBooleanLightComponent implements DoCheck {
 
     switch (color) {
       case "contrast":
+        this.offColor = theme.contrastDimmer;
         this.labelColor = theme.contrastDim;
         this.valueColor = theme.contrast;
         break;
       case "blue":
+        this.offColor = theme.blueDimmer;
         this.labelColor = theme.blueDim;
         this.valueColor = theme.blue;
         break;
       case "green":
+        this.offColor = theme.greenDimmer;
         this.labelColor = theme.greenDim;
         this.valueColor = theme.green;
         break;
       case "pink":
+        this.offColor = theme.pinkDimmer;
         this.labelColor = theme.pinkDim;
         this.valueColor = theme.pink;
         break;
       case "orange":
+        this.offColor = theme.orangeDimmer;
         this.labelColor = theme.orangeDim;
         this.valueColor = theme.orange;
         break;
       case "purple":
+        this.offColor = theme.purpleDimmer;
         this.labelColor = theme.purpleDim;
         this.valueColor = theme.purple;
         break;
       case "grey":
+        this.offColor = theme.greyDimmer;
         this.labelColor = theme.greyDim;
         this.valueColor = theme.grey;
         break;
       case "yellow":
+        this.offColor = theme.yellowDimmer;
         this.labelColor = theme.yellowDim;
         this.valueColor = theme.yellow;
         break;
       default:
+        this.offColor = theme.contrastDimmer;
         this.labelColor = theme.contrastDim;
         this.valueColor = theme.contrast;
         break;

--- a/src/app/widgets/svg-boolean-switch/svg-boolean-switch.component.svg
+++ b/src/app/widgets/svg-boolean-switch/svg-boolean-switch.component.svg
@@ -40,8 +40,9 @@
     style="pointer-events:none;">
     <div
       [style.color]="isEnabled ? valueColor : labelColor"
+      [style.opacity]="isEnabled ? 1 : 0.6"
       [style.fontSize.px]="layout.labelFontSize"
-      [style.textShadow]="isEnabled ? '0 0 6px currentColor, 0 0 6px currentColor' : 'none'"
+      [style.textShadow]="isEnabled ? '0 0 4px currentColor, 0 0 4px currentColor' : 'none'"
       style="width:100%;height:100%;display:flex;align-items:center;justify-content: flex-start;font-family:Roboto,sans-serif;font-weight:700;line-height:1;white-space:nowrap;overflow:hidden;text-overflow:clip;">
       {{ data()?.ctrlLabel }}
     </div>

--- a/src/app/widgets/svg-boolean-switch/svg-boolean-switch.component.svg
+++ b/src/app/widgets/svg-boolean-switch/svg-boolean-switch.component.svg
@@ -10,6 +10,20 @@
    id="svg9"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg">
+   <defs id="defs1">
+    <linearGradient id="linearGradient32">
+      <stop style="stop-color:#000000;stop-opacity:0.88486844;" offset="0" />
+      <stop style="stop-color:#f7f7f7;stop-opacity:0.17763157;" offset="1" />
+    </linearGradient>
+    <linearGradient
+      xlink:href="#linearGradient32"
+      id="linearGradient33"
+      x1="0"
+      y1="0"
+      x2="1"
+      y2="1">
+    </linearGradient>
+  </defs>
   <rect
     [attr.width]="dimensions().width"
     [attr.height]="dimensions().height"
@@ -47,5 +61,6 @@
     [attr.cy]="layout.switchKnobY"
     [attr.r]="layout.switchKnobRadius"
     [attr.fill]="isEnabled ? valueColor : offColor"
-    style="stroke-width:1.5;stroke:white;stroke-opacity:0.2;stroke-dasharray:none" />
+    style="stroke:url(#linearGradient33);stroke-opacity:0.4;stroke-dasharray:none"
+    [attr.stroke-width]="layout.switchStrokeWidth" />
 </svg>

--- a/src/app/widgets/svg-boolean-switch/svg-boolean-switch.component.svg
+++ b/src/app/widgets/svg-boolean-switch/svg-boolean-switch.component.svg
@@ -39,13 +39,13 @@
     [attr.width]="layout.switchTrackWidth"
     [attr.height]="layout.switchTrackHeight"
     [attr.rx]="layout.switchTrackRadius"
-    [attr.fill]="isEnabled ? labelColor : 'var(--mat-sys-outline)'"
+    [attr.fill]="isEnabled ? labelColor : offColor"
     style="stroke-width:1.5;stroke:black;stroke-opacity:0.12" />
 
   <circle
     [attr.cx]="isEnabled ? layout.switchKnobOnX : layout.switchKnobOffX"
     [attr.cy]="layout.switchKnobY"
     [attr.r]="layout.switchKnobRadius"
-    [attr.fill]="isEnabled ? valueColor : labelColor"
-    style="stroke-width:1.5;stroke:black;stroke-opacity:0.2;stroke-dasharray:none" />
+    [attr.fill]="isEnabled ? valueColor : offColor"
+    style="stroke-width:1.5;stroke:white;stroke-opacity:0.2;stroke-dasharray:none" />
 </svg>

--- a/src/app/widgets/svg-boolean-switch/svg-boolean-switch.component.ts
+++ b/src/app/widgets/svg-boolean-switch/svg-boolean-switch.component.ts
@@ -20,6 +20,7 @@ export class SvgBooleanSwitchComponent implements DoCheck {
   private oldTheme: ITheme | null = null;
   private readonly swipeGuard = createSwipeGuard();
 
+  public offColor: string | null = null;
   public labelColor: string | null = null;
   public valueColor: string | null = null;
   private ctrlColor = '';
@@ -94,38 +95,47 @@ export class SvgBooleanSwitchComponent implements DoCheck {
 
     switch (color) {
       case "contrast":
+        this.offColor = theme.contrastDimmer;
         this.labelColor = theme.contrastDim;
         this.valueColor = theme.contrast;
         break;
       case "blue":
+        this.offColor = theme.blueDimmer;
         this.labelColor = theme.blueDim;
         this.valueColor = theme.blue;
         break;
       case "green":
+        this.offColor = theme.greenDimmer;
         this.labelColor = theme.greenDim;
         this.valueColor = theme.green;
         break;
       case "pink":
+        this.offColor = theme.pinkDimmer;
         this.labelColor = theme.pinkDim;
         this.valueColor = theme.pink;
         break;
       case "orange":
+        this.offColor = theme.orangeDimmer;
         this.labelColor = theme.orangeDim;
         this.valueColor = theme.orange;
         break;
       case "purple":
+        this.offColor = theme.purpleDimmer;
         this.labelColor = theme.purpleDim;
         this.valueColor = theme.purple;
         break;
       case "grey":
+        this.offColor = theme.greyDimmer;
         this.labelColor = theme.greyDim;
         this.valueColor = theme.grey;
         break;
       case "yellow":
+        this.offColor = theme.yellowDimmer;
         this.labelColor = theme.yellowDim;
         this.valueColor = theme.yellow;
         break;
       default:
+        this.offColor = theme.contrastDimmer;
         this.labelColor = theme.contrastDim;
         this.valueColor = theme.contrast;
         break;

--- a/src/app/widgets/widget-boolean-switch/boolean-control-layout.util.ts
+++ b/src/app/widgets/widget-boolean-switch/boolean-control-layout.util.ts
@@ -17,6 +17,7 @@ export interface BooleanControlLayout {
   switchKnobOnX: number;
   switchKnobY: number;
   switchKnobRadius: number;
+  switchStrokeWidth: number;
   lightCenterX: number;
   lightCenterY: number;
   lightRadius: number;
@@ -54,10 +55,11 @@ export function getBooleanControlLayout(type: string, width: number, height: num
     switchKnobOnX: 32.5 * scale,
     switchKnobY: 17 * scale,
     switchKnobRadius: 10 * scale,
+    switchStrokeWidth: 1.5 * scale,
     lightCenterX: 24.5 * scale,
     lightCenterY: 17.5 * scale,
     lightRadius: 13.5 * scale,
-    lightStrokeWidth: 5 * scale,
+    lightStrokeWidth: 3 * scale,
     buttonX: 6 * scale,
     buttonY: 5 * scale,
     buttonWidth: Math.max(0, safeWidth - (12 * scale)),


### PR DESCRIPTION
The changes enhance the visibility of the switch panel indicator state by introducing an off color for the inactive state and improving the visual effects with gradients. The implementation allows for a clearer distinction between the active and inactive states, addressing the issue of ambiguity in the switch's appearance.

Fixes #996