### PR TITLE
Add reproducible freeze-audit measurement harness (perf-harness/)

### DIFF
--- a/perf-harness/.gitignore
+++ b/perf-harness/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+worktrees/
+results/*.raw.json

--- a/perf-harness/.gitignore
+++ b/perf-harness/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 worktrees/
 results/*.raw.json
 results-*.log
+results/shots/

--- a/perf-harness/.gitignore
+++ b/perf-harness/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 worktrees/
 results/*.raw.json
+results-*.log

--- a/perf-harness/README.md
+++ b/perf-harness/README.md
@@ -1,0 +1,57 @@
+# KIP freeze-audit measurement harness
+
+Reproducible, honest before/after measurement of the main-thread **freezes** users
+report ("randomly unresponsive; can't exit fullscreen"). Self-contained — its deps
+live in `perf-harness/package.json` and never touch the app's `package.json`.
+
+## What it measures (the symptom, not proxies)
+
+The same probe (`probe.js`) is injected into every build under test via Playwright
+`addInitScript`, so measurement code is identical across branches:
+
+| Metric | Meaning |
+|---|---|
+| `longTaskMaxMs` / `blockingTimeMs` | Longest single main-thread task, and total blocking time (Σ max(0, dur−50)). The browser's own "the main thread was stuck" signal. |
+| `taskLatencyMaxMs` / `p95` | A 16 ms self-rescheduling timer's lateness = **how long a queued handler (e.g. the exit-fullscreen keydown) waits**. The honest "frozen" proxy. |
+| `frameMaxGapMs` / `framesDropped` | rAF inter-frame gaps → dropped frames. |
+| `heapGrowthMB` / `heapSlopeKBps` | `usedJSHeapSize` slope over time (unbounded-growth findings). |
+
+## How it works
+
+`run.mjs` builds a branch's **production** bundle in an isolated git worktree
+(`lib/build-serve.mjs`), serves it plus a **mock Signal K server** on one origin
+(`lib/server.mjs` — no CORS), injects the probe + a localStorage config that puts
+KIP in anonymous local mode (`lib/kip-config.mjs`), throttles CPU via CDP to emulate
+low-power marine hardware, runs each scenario K times, and writes
+`results/<label>.json` (raw + median/p95).
+
+## Scenarios → audit findings (`scenarios.mjs`)
+
+| Scenario | Reproduces |
+|---|---|
+| `resize-storm` | Rank 1 — shared ResizeObserver reallocates every canvas in one task (the fullscreen enter/exit storm). |
+| `delta-storm-30x10` / `reconnect-backlog` | Rank 2 — delta ingestion / reconnect snapshot fan-out. |
+| `ais-radar-150` | Ranks 4/5 — AIS radar full re-render loops. |
+| `gauges-16` | Rank 7 — ng-canvas-gauge animation duty cycle. |
+| `ais-growth-churn` | Ranks 8/9 — unbounded AIS/track growth (heap slope). |
+
+## Run
+
+```bash
+cd perf-harness && npm install
+# baseline a branch (throttle defaults to 10x CPU):
+node run.mjs --branch master --label master
+node run.mjs --branch integration/perf-preview --label perf-preview
+# fast iteration against an already-built ./public:
+node run.mjs --public ../public --label dev --scenarios ais-radar-150 --repeats 2
+```
+
+## Honesty safeguards
+
+- Identical probe + scenarios + fixed CPU throttle across all branches; Chrome
+  version recorded in each result.
+- K repeats reported as **median and p95**, with every raw run kept in the JSON.
+- Baselines captured on `master` (pre-perf) **and** `integration/perf-preview`
+  (master + the 5 `perf/*` PRs) so perf gains and freeze-fix gains are never conflated.
+- Negative results are reported too (e.g. the delta fan-out is *not* a measurable
+  freeze at realistic rates — the rendering loops are).

--- a/perf-harness/lib/build-serve.mjs
+++ b/perf-harness/lib/build-serve.mjs
@@ -37,8 +37,10 @@ export async function buildBranch(ref, label, { rebuild = true } = {}) {
     console.log(`[build] worktree ${label} <- ${ref}`);
     await sh('git', ['worktree', 'add', '--force', wt, ref], { cwd: REPO_DIR });
   }
-  console.log(`[build] npm ci (${label}) …`);
-  await sh('npm', ['ci', '--no-audit', '--no-fund'], { cwd: wt });
+  // npm install (not ci): the integration branch's lockfile trips npm ci's strict
+  // platform-optional-dep check; install reconciles it. Worktree is disposable.
+  console.log(`[build] npm install (${label}) …`);
+  await sh('npm', ['install', '--no-audit', '--no-fund'], { cwd: wt });
   console.log(`[build] production build (${label}) …`);
   await sh('npm', ['run', 'build:prod'], { cwd: wt });
   if (!(await exists(join(publicDir, 'index.html')))) {

--- a/perf-harness/lib/build-serve.mjs
+++ b/perf-harness/lib/build-serve.mjs
@@ -1,0 +1,71 @@
+/*
+ * Cross-branch build+serve helpers. To measure a branch honestly we build the
+ * REAL production bundle for that exact ref in an isolated git worktree, then
+ * serve it. The harness itself (which lives only on the harness branch) is never
+ * part of the measured bundle — identical measurement code, different builds.
+ */
+import { spawn } from 'node:child_process';
+import { rm, mkdir, access } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const HARNESS_DIR = dirname(dirname(fileURLToPath(import.meta.url)));
+const REPO_DIR = dirname(HARNESS_DIR);
+const WORKTREES = join(HARNESS_DIR, 'worktrees');
+
+export function sh(cmd, args, opts = {}) {
+  return new Promise((resolve, reject) => {
+    const p = spawn(cmd, args, { stdio: 'inherit', ...opts });
+    p.on('exit', (code) => (code === 0 ? resolve() : reject(new Error(`${cmd} ${args.join(' ')} -> ${code}`))));
+    p.on('error', reject);
+  });
+}
+
+async function exists(p) { try { await access(p); return true; } catch { return false; } }
+
+/** Create/refresh a worktree for `ref`, install deps, build prod. Returns the public/ dir. */
+export async function buildBranch(ref, label, { rebuild = true } = {}) {
+  await mkdir(WORKTREES, { recursive: true });
+  const wt = join(WORKTREES, label);
+  const publicDir = join(wt, 'public');
+
+  if (rebuild && await exists(wt)) {
+    await sh('git', ['worktree', 'remove', '--force', wt], { cwd: REPO_DIR }).catch(() => {});
+    await rm(wt, { recursive: true, force: true });
+  }
+  if (!(await exists(wt))) {
+    console.log(`[build] worktree ${label} <- ${ref}`);
+    await sh('git', ['worktree', 'add', '--force', wt, ref], { cwd: REPO_DIR });
+  }
+  console.log(`[build] npm ci (${label}) …`);
+  await sh('npm', ['ci', '--no-audit', '--no-fund'], { cwd: wt });
+  console.log(`[build] production build (${label}) …`);
+  await sh('npm', ['run', 'build:prod'], { cwd: wt });
+  if (!(await exists(join(publicDir, 'index.html')))) {
+    throw new Error(`build for ${label} produced no public/index.html`);
+  }
+  return publicDir;
+}
+
+/** Start the static SPA server for a built public dir. Returns {url, base, stop()}. */
+export async function serve(publicDir, port, base = '/@mxtommy/kip/') {
+  const child = spawn('node', [join(HARNESS_DIR, 'serve.mjs'), '--root', publicDir, '--port', String(port), '--base', base], {
+    stdio: 'inherit',
+  });
+  // Wait for it to accept connections.
+  const deadline = Date.now() + 10000;
+  while (Date.now() < deadline) {
+    try {
+      const r = await fetch(`http://localhost:${port}${base}index.html`);
+      if (r.ok) break;
+    } catch { /* not up yet */ }
+    await new Promise((r) => setTimeout(r, 150));
+  }
+  return {
+    url: `http://localhost:${port}${base}`,
+    base,
+    stop() { child.kill('SIGTERM'); },
+  };
+}
+
+export { REPO_DIR, HARNESS_DIR, WORKTREES };

--- a/perf-harness/lib/kip-config.mjs
+++ b/perf-harness/lib/kip-config.mjs
@@ -1,0 +1,117 @@
+/*
+ * Builders for the KIP localStorage bundle that puts the app in anonymous,
+ * local-config mode pointed at our mock Signal K server. Shapes are taken
+ * verbatim from src/default-config/* and the widget registry (configVersion 12).
+ */
+export const SELF_URN = 'vessels.urn:mrn:signalk:uuid:11111111-1111-4111-8111-111111111111';
+
+const DEFAULT_UNITS = {
+  Unitless: 'unitless', Speed: 'knots', Flow: 'l/h', Temperature: 'celsius', Length: 'm',
+  Volume: 'liter', Current: 'A', Potential: 'V', Charge: 'C', Power: 'W', Energy: 'J',
+  Pressure: 'mmHg', 'Fuel Distance': 'nm/l', 'Energy Distance': 'nm/kWh', Density: 'kg/m3',
+  Time: 'Hours', 'Angular Velocity': 'deg/min', Angle: 'deg', Frequency: 'Hz', Ratio: 'ratio',
+  Resistance: 'ohm',
+};
+
+const DEFAULT_NOTIF = {
+  disableNotifications: false, menuGrouping: true,
+  security: { disableSecurity: true },
+  devices: { disableDevices: false, showNormalState: false, showNominalState: false },
+  sound: { disableSound: false, muteNormal: true, muteNominal: true, muteWarn: true,
+    muteAlert: false, muteAlarm: false, muteEmergency: false },
+};
+
+export function appConfig(extra = {}) {
+  return {
+    configVersion: 12, autoNightMode: false, redNightMode: false, nightModeBrightness: 0.27,
+    isRemoteControl: false, instanceName: '', dataSets: [], unitDefaults: DEFAULT_UNITS,
+    notificationConfig: DEFAULT_NOTIF, splitShellEnabled: false, splitShellSide: 'left',
+    splitShellSwipeDisabled: false, splitShellWidth: 0.5, ...extra,
+  };
+}
+
+export function connectionConfig(subscribeAll = false) {
+  return {
+    configVersion: 12, kipUUID: '00000000-0000-4000-8000-000000000001',
+    signalKUrl: '__ORIGIN__', // replaced with the served origin at inject time
+    proxyEnabled: false, signalKSubscribeAll: subscribeAll, useDeviceToken: false,
+    loginName: null, loginPassword: null, useSharedConfig: false, sharedConfigName: 'default',
+  };
+}
+
+export const themeConfig = { themeName: '' };
+
+// --- widget factories (gridstack node wrapping widget-host2 + widgetProperties) ---
+let seq = 0;
+const uid = (p) => `${p}-0000-0000-0000-${String(++seq).padStart(12, '0')}`;
+
+function node(w, h, x, y, widgetProperties) {
+  const id = widgetProperties.uuid;
+  return { x, y, w, h, id, selector: 'widget-host2', input: { widgetProperties } };
+}
+
+export function numericWidget({ path = 'self.navigation.speedOverGround', unit = 'knots', sampleTime = 500, miniChart = false } = {}) {
+  const uuid = uid('num');
+  return (x, y) => node(4, 6, x, y, {
+    type: 'widget-numeric', uuid,
+    config: {
+      displayName: 'N', filterSelfPaths: true,
+      paths: { numericPath: { description: 'Numeric Data', path, source: 'default', pathType: 'number', isPathConfigurable: true, convertUnitTo: unit, sampleTime } },
+      numDecimal: 1, showMiniChart: miniChart, color: 'blue', enableTimeout: false, dataTimeout: 5, ignoreZones: false,
+    },
+  });
+}
+
+export function radialGaugeWidget({ path = 'self.navigation.speedOverGround', unit = 'knots', sampleTime = 500 } = {}) {
+  const uuid = uid('rad');
+  return (x, y) => node(4, 6, x, y, {
+    type: 'widget-gauge-ng-radial', uuid,
+    config: {
+      displayName: 'G', filterSelfPaths: true,
+      paths: { gaugePath: { description: 'Gauge', path, source: 'default', pathType: 'number', isPathConfigurable: true, convertUnitTo: unit, sampleTime } },
+      gauge: { type: 'ngRadial', subType: 'measuring' }, minValue: 0, maxValue: 30, numInt: 2, numDecimal: 1,
+      color: 'blue', enableTimeout: false, dataTimeout: 5,
+    },
+  });
+}
+
+export function aisRadarWidget() {
+  const uuid = uid('ais');
+  return (x, y) => node(12, 12, x, y, {
+    type: 'widget-ais-radar', uuid,
+    config: {
+      filterSelfPaths: false, enableTimeout: false, dataTimeout: 5, color: 'grey',
+      ais: {
+        filters: { anchoredMoored: false, noCollisionRisk: false, allAton: false, allButSar: false, allVessels: false, vesselTypes: [] },
+        viewMode: 'course-up', rangeRings: [1, 3, 6, 12, 24, 48], rangeIndex: '3',
+        showCogVectors: true, cogVectorsMinutes: 10, showLostTargets: true, showUnconfirmedTargets: true, showSelf: true,
+      },
+    },
+  });
+}
+
+/** Lay out widget factories in a grid and wrap them in one dashboard. */
+export function buildDashboards(factories, cols = 12) {
+  let x = 0, y = 0, rowH = 0;
+  const configuration = factories.map((make) => {
+    const probe = make(0, 0);
+    const w = probe.w, h = probe.h;
+    if (x + w > cols) { x = 0; y += rowH; rowH = 0; }
+    const n = make(x, y);
+    x += w; rowH = Math.max(rowH, h);
+    return n;
+  });
+  return [{ id: uid('dash'), name: 'Perf', icon: 'dashboard-dashboard', collapseSplitShell: false, configuration }];
+}
+
+/** The full localStorage bundle as {key: jsonString}. signalKUrl is patched to `origin` at inject time. */
+export function localStorageBundle({ origin, subscribeAll, dashboards, app = appConfig() }) {
+  const cc = connectionConfig(subscribeAll);
+  cc.signalKUrl = origin;
+  return {
+    connectionConfig: JSON.stringify(cc),
+    appConfig: JSON.stringify(app),
+    dashboardsConfig: JSON.stringify(dashboards),
+    themeConfig: JSON.stringify(themeConfig),
+  };
+}

--- a/perf-harness/lib/server.mjs
+++ b/perf-harness/lib/server.mjs
@@ -49,6 +49,26 @@ function aisDelta(mmsi, i, t) {
   });
 }
 
+// Deterministic scene deltas (for reproducible before/after radar screenshots).
+function selfSceneDelta(o, t) {
+  return JSON.stringify({ context: SELF_URN, updates: [{ $source: 'mock.0', timestamp: iso(t), values: [
+    { path: 'navigation.position', value: { latitude: o.lat, longitude: o.lon } },
+    { path: 'navigation.headingTrue', value: (o.heading ?? 0) * Math.PI / 180 },
+    { path: 'navigation.courseOverGroundTrue', value: (o.cog ?? o.heading ?? 0) * Math.PI / 180 },
+    { path: 'navigation.speedOverGround', value: o.sog ?? 5 },
+  ] }] });
+}
+function targetSceneDelta(tg, t) {
+  return JSON.stringify({ context: `vessels.urn:mrn:imo:mmsi:${tg.mmsi}`, updates: [{ $source: 'mock.ais', timestamp: iso(t), values: [
+    { path: 'navigation.position', value: { latitude: tg.lat, longitude: tg.lon } },
+    { path: 'navigation.headingTrue', value: (tg.heading ?? 0) * Math.PI / 180 },
+    { path: 'navigation.courseOverGroundTrue', value: (tg.cog ?? tg.heading ?? 0) * Math.PI / 180 },
+    { path: 'navigation.speedOverGround', value: tg.sog ?? 4 },
+    { path: 'name', value: tg.name ?? `T${tg.mmsi}` },
+    { path: 'mmsi', value: String(tg.mmsi) },
+  ] }] });
+}
+
 function helloMsg() {
   return JSON.stringify({ name: 'kip-mock', version: '2.3.0', self: SELF_URN, roles: ['master', 'main'], timestamp: iso(Date.now()) });
 }
@@ -117,6 +137,12 @@ export async function startServer({ publicDir, base, port }) {
     const timer = setInterval(() => {
       if (!control.streaming || ws.readyState !== ws.OPEN) return;
       const t = Date.now();
+      // Deterministic scene: fixed own-ship + fixed targets (reproducible screenshots).
+      if (control.staticScene) {
+        ws.send(selfSceneDelta(control.staticScene.ownShip, t)); sent++;
+        for (const tg of control.staticScene.targets) { ws.send(targetSceneDelta(tg, t)); sent++; }
+        return;
+      }
       ws.send(selfDelta(control.selfPaths, t)); sent++;
       const n = control.ais.count | 0;
       for (let i = 0; i < n; i++) { ws.send(aisDelta(mmsiBase + i, i, t)); sent++; }

--- a/perf-harness/lib/server.mjs
+++ b/perf-harness/lib/server.mjs
@@ -1,0 +1,155 @@
+/*
+ * Combined server for the harness: serves the built KIP app under `base`
+ * AND acts as the mock Signal K server (/signalk/ discovery, WS delta stream,
+ * v2 history) on the SAME origin — so signalKUrl is same-origin (no CORS) and
+ * the app talks to a fully controllable data source.
+ */
+import http from 'node:http';
+import { readFile, stat } from 'node:fs/promises';
+import { join, extname, normalize } from 'node:path';
+import { WebSocketServer } from 'ws';
+import { SELF_URN } from './kip-config.mjs';
+
+const TYPES = {
+  '.html': 'text/html; charset=utf-8', '.js': 'text/javascript', '.mjs': 'text/javascript',
+  '.css': 'text/css', '.json': 'application/json', '.svg': 'image/svg+xml', '.png': 'image/png',
+  '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg', '.webp': 'image/webp', '.ico': 'image/x-icon',
+  '.woff': 'font/woff', '.woff2': 'font/woff2', '.ttf': 'font/ttf', '.wasm': 'application/wasm', '.map': 'application/json',
+};
+
+const iso = (t) => new Date(t).toISOString();
+
+function genSelfValue(path, t) {
+  switch (path) {
+    case 'navigation.speedOverGround': return 5 + 2 * Math.sin(t / 1000);
+    case 'navigation.headingTrue':
+    case 'navigation.courseOverGroundTrue': return ((t / 40) % 360) * Math.PI / 180;
+    case 'navigation.position': return { latitude: 47.6 + 0.001 * Math.sin(t / 4000), longitude: -122.33 + 0.001 * Math.cos(t / 4000) };
+    case 'environment.depth.belowTransducer': return 12 + 3 * Math.sin(t / 2000);
+    case 'environment.wind.angleApparent': return Math.sin(t / 1000);
+    case 'environment.wind.speedApparent': return 8 + 3 * Math.sin(t / 1500);
+    default: return Math.sin(t / 1000) * 100;
+  }
+}
+
+function selfDelta(paths, t) {
+  return JSON.stringify({ context: SELF_URN, updates: [{ $source: 'mock.0', timestamp: iso(t), values: paths.map((p) => ({ path: p, value: genSelfValue(p, t) })) }] });
+}
+
+function aisDelta(mmsi, i, t) {
+  return JSON.stringify({
+    context: `vessels.urn:mrn:imo:mmsi:${mmsi}`,
+    updates: [{ $source: 'mock.ais', timestamp: iso(t), values: [
+      { path: 'navigation.position', value: { latitude: 47.6 + 0.02 * Math.sin(t / 3000 + i), longitude: -122.33 + 0.02 * Math.cos(t / 3000 + i) } },
+      { path: 'navigation.headingTrue', value: ((i * 11 + t / 50) % 360) * Math.PI / 180 },
+      { path: 'navigation.courseOverGroundTrue', value: ((i * 11) % 360) * Math.PI / 180 },
+      { path: 'navigation.speedOverGround', value: 3 + (i % 6) },
+      { path: 'mmsi', value: String(mmsi) },
+    ] }],
+  });
+}
+
+function helloMsg() {
+  return JSON.stringify({ name: 'kip-mock', version: '2.3.0', self: SELF_URN, roles: ['master', 'main'], timestamp: iso(Date.now()) });
+}
+
+function historyResponse(paths, rows, stepSec) {
+  const base = Date.parse('2026-06-30T00:00:00.000Z');
+  const values = paths.flatMap((p) => [{ path: p, method: 'sma' }, { path: p, method: 'avg' }, { path: p, method: 'min' }, { path: p, method: 'max' }]);
+  const data = [];
+  for (let i = 0; i < rows; i++) {
+    const row = [iso(base + i * stepSec * 1000)];
+    for (let k = 0; k < values.length; k++) row.push(5 + Math.sin((i + k) / 10));
+    data.push(row);
+  }
+  return { context: 'vessels.self', range: { from: iso(base), to: iso(base + rows * stepSec * 1000) }, values, data };
+}
+
+/**
+ * @param {object} o { publicDir, base, port }
+ * Returns { origin, appUrl, setControl(c), blast(n), streamCount(), stop() }.
+ * control: { streaming:bool, rateHz, selfPaths:[], ais:{count, churnPerSec} }
+ */
+export async function startServer({ publicDir, base, port }) {
+  const control = { streaming: false, rateHz: 10, selfPaths: ['navigation.speedOverGround'], ais: { count: 0, churnPerSec: 0 } };
+  let history = { rows: 0, stepSec: 1, paths: ['navigation.speedOverGround'] };
+  let sent = 0;
+  let mmsiBase = 100000000;
+
+  const server = http.createServer(async (req, res) => {
+    const url = new URL(req.url, 'http://x');
+    const p = decodeURIComponent(url.pathname);
+    // --- Signal K endpoints (origin root) ---
+    if (p === '/signalk' || p === '/signalk/') {
+      res.writeHead(200, { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' });
+      return res.end(JSON.stringify({
+        endpoints: { v1: { version: '2.3.0', 'signalk-http': `http://localhost:${port}/signalk/v1/api/`, 'signalk-ws': `ws://localhost:${port}/signalk/v1/stream` } },
+        server: { id: 'kip-mock', version: '2.3.0' },
+      }));
+    }
+    if (p.startsWith('/signalk/v2/api/history/values')) {
+      res.writeHead(200, { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' });
+      return res.end(JSON.stringify(historyResponse(history.paths, history.rows, history.stepSec)));
+    }
+    if (p.startsWith('/signalk/v1/api')) { // snapshot / misc — empty model
+      res.writeHead(200, { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' });
+      return res.end('{}');
+    }
+    // --- static app ---
+    let rel = p.startsWith(base) ? p.slice(base.length) : p.replace(/^\//, '');
+    if (p === '/') { res.writeHead(302, { Location: base }); return res.end(); }
+    rel = normalize(rel).replace(/^(\.\.[/\\])+/, '');
+    let file = join(publicDir, rel);
+    try { if (!(await stat(file)).isFile()) throw 0; } catch {
+      if (!extname(rel)) file = join(publicDir, 'index.html'); else { res.writeHead(404); return res.end('nf'); }
+    }
+    try {
+      const body = await readFile(file);
+      res.writeHead(200, { 'Content-Type': TYPES[extname(file)] || 'application/octet-stream', 'Cache-Control': 'no-store' });
+      res.end(body);
+    } catch { res.writeHead(404); res.end('nf'); }
+  });
+
+  const wss = new WebSocketServer({ server, path: '/signalk/v1/stream' });
+  wss.on('connection', (ws) => {
+    ws.send(helloMsg());
+    let tick = 0;
+    const timer = setInterval(() => {
+      if (!control.streaming || ws.readyState !== ws.OPEN) return;
+      const t = Date.now();
+      ws.send(selfDelta(control.selfPaths, t)); sent++;
+      const n = control.ais.count | 0;
+      for (let i = 0; i < n; i++) { ws.send(aisDelta(mmsiBase + i, i, t)); sent++; }
+      // churn: introduce brand-new MMSIs over time (unbounded-growth scenario)
+      const churn = control.ais.churnPerSec | 0;
+      if (churn) {
+        const per = Math.max(1, Math.round(churn / control.rateHz));
+        for (let c = 0; c < per; c++) { mmsiBase++; ws.send(aisDelta(mmsiBase + n, n + c, t)); sent++; }
+      }
+      tick++;
+    }, Math.max(1, Math.round(1000 / control.rateHz)));
+    ws.on('close', () => clearInterval(timer));
+    // Many separate frames (sustained flood) — each is its own onmessage task.
+    ws._blast = (count) => { const t = Date.now(); for (let i = 0; i < count; i++) { ws.send(selfDelta(control.selfPaths, t + i)); sent++; } };
+    // ONE frame carrying many values (reconnect snapshot) — a single synchronous
+    // parse + fan-out, i.e. the worst-case long task that coalescing must bound.
+    ws._blastBig = (nValues) => {
+      const t = Date.now();
+      const values = [];
+      for (let i = 0; i < nValues; i++) values.push({ path: `sensors.mock.n${i}.value`, value: Math.sin((t + i) / 1000) });
+      ws.send(JSON.stringify({ context: SELF_URN, updates: [{ $source: 'mock.0', timestamp: iso(t), values }] }));
+      sent++;
+    };
+  });
+
+  await new Promise((r) => server.listen(port, r));
+  const origin = `http://localhost:${port}`;
+  return {
+    origin, appUrl: `${origin}${base}`,
+    setControl(c) { Object.assign(control, c); if (c.history) history = { ...history, ...c.history }; },
+    blast(count) { for (const ws of wss.clients) if (ws._blast) ws._blast(count); },
+    blastBig(nValues) { for (const ws of wss.clients) if (ws._blastBig) ws._blastBig(nValues); },
+    streamCount() { return sent; },
+    stop() { return new Promise((r) => { for (const ws of wss.clients) ws.terminate(); server.close(() => r()); }); },
+  };
+}

--- a/perf-harness/package-lock.json
+++ b/perf-harness/package-lock.json
@@ -1,0 +1,49 @@
+{
+  "name": "kip-perf-harness",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "kip-perf-harness",
+      "version": "0.1.0",
+      "dependencies": {
+        "playwright-core": "^1.49.0",
+        "ws": "^8.18.0"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/perf-harness/package.json
+++ b/perf-harness/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "kip-perf-harness",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Reproducible main-thread / freeze measurement harness for KIP. Self-contained: its deps never touch the app package.json.",
+  "scripts": {
+    "measure": "node run.mjs",
+    "serve": "node serve.mjs"
+  },
+  "dependencies": {
+    "playwright-core": "^1.49.0",
+    "ws": "^8.18.0"
+  }
+}

--- a/perf-harness/probe.js
+++ b/perf-harness/probe.js
@@ -1,0 +1,148 @@
+/*
+ * KIP performance probe — injected into the page via Playwright addInitScript
+ * BEFORE any app code runs, so identical measurement code is used across every
+ * branch/build under test (master, integration/perf-preview, freeze fixes).
+ *
+ * It measures the *symptom* — main-thread blocking and responsiveness — not
+ * proxy microbenchmarks:
+ *
+ *  - longtasks:      PerformanceObserver('longtask') — every task >50ms (the
+ *                    browser's own definition of "the main thread was blocked").
+ *  - blockingTime:   Total Blocking Time proxy = sum(max(0, dur-50)) over tasks.
+ *  - taskLatency:    a MessageChannel canary posts to itself continuously; the
+ *                    delay before the reply runs = how long a queued handler
+ *                    (e.g. the exit-fullscreen keydown) would wait. This is the
+ *                    honest proxy for "the UI is frozen / can't exit fullscreen".
+ *  - frameGaps:      requestAnimationFrame inter-frame gaps — dropped frames.
+ *  - heap:           usedJSHeapSize samples over time (growth-slope findings).
+ *
+ * Everything is exposed on window.__perf. The harness calls __perf.reset()
+ * before a scenario window and __perf.snapshot() after.
+ */
+(() => {
+  if (window.__perf) return;
+
+  const state = {
+    startedAt: performance.now(),
+    longtasks: [],       // { start, duration }
+    taskLatency: [],     // ms of canary reply delay
+    frameGaps: [],       // ms between rAF callbacks
+    heap: [],            // { t, used }
+    marks: {},           // name -> [durations ms]
+    windowStart: performance.now(),
+  };
+
+  // --- Long tasks (main-thread blocking) ---
+  try {
+    const po = new PerformanceObserver((list) => {
+      for (const e of list.getEntries()) {
+        state.longtasks.push({ start: e.startTime, duration: e.duration });
+      }
+    });
+    po.observe({ entryTypes: ['longtask'] });
+  } catch { /* longtask unsupported */ }
+
+  // --- Event-loop lag canary (task-queue responsiveness) ---
+  // A self-rescheduling timer measures how much LATER than its interval it
+  // actually fires. That lateness == how long an already-queued handler (e.g.
+  // the exit-fullscreen keydown) would sit starved while the thread is busy.
+  const CANARY_PERIOD_MS = 16;
+  let scheduledAt = performance.now();
+  function tick() {
+    const lateness = performance.now() - scheduledAt - CANARY_PERIOD_MS;
+    if (lateness > 0) state.taskLatency.push(lateness);
+    scheduledAt = performance.now();
+    setTimeout(tick, CANARY_PERIOD_MS);
+  }
+  setTimeout(tick, CANARY_PERIOD_MS);
+
+  // --- Frame gaps (rendering smoothness) ---
+  let lastFrame = performance.now();
+  function frame(now) {
+    const gap = now - lastFrame;
+    lastFrame = now;
+    if (gap > 0) state.frameGaps.push(gap);
+    requestAnimationFrame(frame);
+  }
+  requestAnimationFrame(frame);
+
+  // --- Heap sampling ---
+  const perfMem = () => (performance.memory ? performance.memory.usedJSHeapSize : null);
+  setInterval(() => {
+    const used = perfMem();
+    if (used != null) state.heap.push({ t: performance.now(), used });
+  }, 500);
+
+  // --- Custom marks the harness / app can bracket operations with ---
+  function measure(name, fn) {
+    const t0 = performance.now();
+    const r = fn();
+    const record = () => {
+      const d = performance.now() - t0;
+      (state.marks[name] = state.marks[name] || []).push(d);
+    };
+    if (r && typeof r.then === 'function') { r.then(record, record); return r; }
+    record();
+    return r;
+  }
+
+  function pct(arr, p) {
+    if (!arr.length) return 0;
+    const s = [...arr].sort((a, b) => a - b);
+    return s[Math.min(s.length - 1, Math.floor((p / 100) * s.length))];
+  }
+
+  window.__perf = {
+    reset() {
+      state.windowStart = performance.now();
+      state.longtasks.length = 0;
+      state.taskLatency.length = 0;
+      state.frameGaps.length = 0;
+      // keep heap series (growth is measured across the whole run)
+      for (const k of Object.keys(state.marks)) delete state.marks[k];
+    },
+    mark: measure,
+    snapshot() {
+      const durMs = performance.now() - state.windowStart;
+      const lts = state.longtasks;
+      const blockingTime = lts.reduce((a, e) => a + Math.max(0, e.duration - 50), 0);
+      const heap = state.heap;
+      let heapSlope = 0;
+      if (heap.length > 1) {
+        const first = heap[0], last = heap[heap.length - 1];
+        heapSlope = (last.used - first.used) / ((last.t - first.t) / 1000); // bytes/sec
+      }
+      const marks = {};
+      for (const [k, v] of Object.entries(state.marks)) {
+        marks[k] = { count: v.length, max: Math.max(...v), p50: pct(v, 50), p95: pct(v, 95) };
+      }
+      return {
+        windowMs: Math.round(durMs),
+        longTasks: {
+          count: lts.length,
+          totalMs: Math.round(lts.reduce((a, e) => a + e.duration, 0)),
+          maxMs: Math.round(lts.reduce((a, e) => Math.max(a, e.duration), 0)),
+          blockingTimeMs: Math.round(blockingTime),
+        },
+        taskLatencyMs: {
+          samples: state.taskLatency.length,
+          maxMs: Math.round(state.taskLatency.reduce((a, b) => Math.max(a, b), 0)),
+          p95Ms: Math.round(pct(state.taskLatency, 95)),
+        },
+        frames: {
+          samples: state.frameGaps.length,
+          maxGapMs: Math.round(state.frameGaps.reduce((a, b) => Math.max(a, b), 0)),
+          p95GapMs: Math.round(pct(state.frameGaps, 95)),
+          droppedOver50ms: state.frameGaps.filter((g) => g > 50).length,
+        },
+        heap: {
+          samples: heap.length,
+          firstBytes: heap.length ? heap[0].used : null,
+          lastBytes: heap.length ? heap[heap.length - 1].used : null,
+          slopeBytesPerSec: Math.round(heapSlope),
+        },
+        marks,
+      };
+    },
+  };
+})();

--- a/perf-harness/report.mjs
+++ b/perf-harness/report.mjs
@@ -1,0 +1,63 @@
+/*
+ * Build an honest before/after markdown report from two result files.
+ *   node report.mjs --a master --b perf-preview [--out results/report.md]
+ * Reads results/<label>.json written by run.mjs.
+ */
+import { readFile, writeFile } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const arg = (n, d) => { const i = process.argv.indexOf(`--${n}`); return i >= 0 ? process.argv[i + 1] : d; };
+
+const A = arg('a', 'master');
+const B = arg('b', 'perf-preview');
+const OUT = arg('out', join(HERE, 'results', `report-${A}-vs-${B}.md`));
+
+const load = async (label) => JSON.parse(await readFile(join(HERE, 'results', `${label}.json`), 'utf8'));
+
+// metric key -> [display, lowerIsBetter]
+const METRICS = [
+  ['longTaskMaxMs', 'Longest task (ms)', true],
+  ['blockingTimeMs', 'Blocking time (ms)', true],
+  ['taskLatencyMaxMs', 'Max handler wait (ms)', true],
+  ['taskLatencyP95Ms', 'p95 handler wait (ms)', true],
+  ['framesDropped', 'Dropped frames', true],
+  ['heapGrowthMB', 'Heap growth (MB)', true],
+];
+
+function pctChange(a, b) {
+  if (a === 0 && b === 0) return '0%';
+  if (a === 0) return b > 0 ? `+${b} (was 0)` : '0%';
+  const d = Math.round(((b - a) / Math.abs(a)) * 100);
+  return `${d > 0 ? '+' : ''}${d}%`;
+}
+
+const a = await load(A), b = await load(B);
+const lines = [];
+lines.push(`# Freeze metrics: ${A} → ${B}`);
+lines.push('');
+lines.push(`- CPU throttle: ${a.throttle}× (${A}) / ${b.throttle}× (${B}); repeats: ${a.repeats}/${b.repeats}; Chrome ${a.chrome}`);
+lines.push('- Values are **medians** across repeats. Lower is better for every metric.');
+lines.push('');
+
+const scenarios = Object.keys(a.scenarios).filter((s) => b.scenarios[s]);
+for (const s of scenarios) {
+  const sa = a.scenarios[s].agg, sb = b.scenarios[s].agg;
+  lines.push(`## ${s}`);
+  lines.push(`_${a.scenarios[s].note}_`);
+  lines.push('');
+  lines.push(`| Metric | ${A} | ${B} | Δ |`);
+  lines.push('|---|--:|--:|--:|');
+  for (const [k, label] of METRICS) {
+    const va = sa[k]?.median ?? 0, vb = sb[k]?.median ?? 0;
+    lines.push(`| ${label} | ${va} | ${vb} | ${pctChange(va, vb)} |`);
+  }
+  lines.push(`| _(context: widgets / deltas)_ | ${sa.widgetCount?.median}/${sa.deltasSent?.median} | ${sb.widgetCount?.median}/${sb.deltasSent?.median} | |`);
+  lines.push('');
+}
+
+const md = lines.join('\n');
+await writeFile(OUT, md);
+console.log(md);
+console.log(`\n[report] wrote ${OUT}`);

--- a/perf-harness/results/freeze-ais.json
+++ b/perf-harness/results/freeze-ais.json
@@ -1,0 +1,401 @@
+{
+  "label": "freeze-ais",
+  "branch": "master",
+  "throttle": 10,
+  "repeats": 3,
+  "chrome": "149.0.7827.201",
+  "scenarios": {
+    "ais-radar-150": {
+      "note": "150 AIS targets @ 4Hz + streaming own-ship (ranks 4/5, radar render loops)",
+      "agg": {
+        "longTaskCount": {
+          "median": 20,
+          "p95": 45,
+          "all": [
+            20,
+            16,
+            45
+          ]
+        },
+        "longTaskMaxMs": {
+          "median": 761,
+          "p95": 1431,
+          "all": [
+            761,
+            1431,
+            347
+          ]
+        },
+        "blockingTimeMs": {
+          "median": 5670,
+          "p95": 8437,
+          "all": [
+            5670,
+            8437,
+            5077
+          ]
+        },
+        "taskLatencyMaxMs": {
+          "median": 888,
+          "p95": 1690,
+          "all": [
+            888,
+            1690,
+            476
+          ]
+        },
+        "taskLatencyP95Ms": {
+          "median": 704,
+          "p95": 1535,
+          "all": [
+            704,
+            1535,
+            270
+          ]
+        },
+        "frameMaxGapMs": {
+          "median": 859,
+          "p95": 1642,
+          "all": [
+            859,
+            1642,
+            392
+          ]
+        },
+        "framesDropped": {
+          "median": 49,
+          "p95": 58,
+          "all": [
+            58,
+            31,
+            49
+          ]
+        },
+        "heapSlopeKBps": {
+          "median": 772,
+          "p95": 1227,
+          "all": [
+            772,
+            1227,
+            593
+          ]
+        },
+        "heapGrowthMB": {
+          "median": 12,
+          "p95": 18,
+          "all": [
+            12,
+            18,
+            9
+          ]
+        },
+        "deltasSent": {
+          "median": 7550,
+          "p95": 18573,
+          "all": [
+            18573,
+            7550,
+            7550
+          ]
+        },
+        "widgetCount": {
+          "median": 1,
+          "p95": 1,
+          "all": [
+            1,
+            1,
+            1
+          ]
+        }
+      },
+      "raw": [
+        {
+          "windowMs": 12285,
+          "longTasks": {
+            "count": 20,
+            "totalMs": 6670,
+            "maxMs": 761,
+            "blockingTimeMs": 5670
+          },
+          "taskLatencyMs": {
+            "samples": 45,
+            "maxMs": 888,
+            "p95Ms": 704
+          },
+          "frames": {
+            "samples": 63,
+            "maxGapMs": 859,
+            "p95GapMs": 633,
+            "droppedOver50ms": 58
+          },
+          "heap": {
+            "samples": 28,
+            "firstBytes": 10908795,
+            "lastBytes": 23646402,
+            "slopeBytesPerSec": 790287
+          },
+          "marks": {},
+          "deltasSent": 18573,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 4530
+        },
+        {
+          "windowMs": 12732,
+          "longTasks": {
+            "count": 16,
+            "totalMs": 9237,
+            "maxMs": 1431,
+            "blockingTimeMs": 8437
+          },
+          "taskLatencyMs": {
+            "samples": 30,
+            "maxMs": 1690,
+            "p95Ms": 1535
+          },
+          "frames": {
+            "samples": 46,
+            "maxGapMs": 1642,
+            "p95GapMs": 1125,
+            "droppedOver50ms": 31
+          },
+          "heap": {
+            "samples": 23,
+            "firstBytes": 10912127,
+            "lastBytes": 29851738,
+            "slopeBytesPerSec": 1256184
+          },
+          "marks": {},
+          "deltasSent": 7550,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 1963
+        },
+        {
+          "windowMs": 12397,
+          "longTasks": {
+            "count": 45,
+            "totalMs": 7327,
+            "maxMs": 347,
+            "blockingTimeMs": 5077
+          },
+          "taskLatencyMs": {
+            "samples": 184,
+            "maxMs": 476,
+            "p95Ms": 270
+          },
+          "frames": {
+            "samples": 406,
+            "maxGapMs": 392,
+            "p95GapMs": 158,
+            "droppedOver50ms": 49
+          },
+          "heap": {
+            "samples": 32,
+            "firstBytes": 10916079,
+            "lastBytes": 20631720,
+            "slopeBytesPerSec": 607661
+          },
+          "marks": {},
+          "deltasSent": 7550,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 1812
+        }
+      ]
+    },
+    "ais-growth-churn": {
+      "note": "AIS radar with 40 targets + 40 new MMSIs/sec churn for 30s (ranks 8/9, heap growth)",
+      "agg": {
+        "longTaskCount": {
+          "median": 26,
+          "p95": 41,
+          "all": [
+            26,
+            41,
+            24
+          ]
+        },
+        "longTaskMaxMs": {
+          "median": 5159,
+          "p95": 5847,
+          "all": [
+            5847,
+            1889,
+            5159
+          ]
+        },
+        "blockingTimeMs": {
+          "median": 25762,
+          "p95": 26308,
+          "all": [
+            26308,
+            23569,
+            25762
+          ]
+        },
+        "taskLatencyMaxMs": {
+          "median": 5451,
+          "p95": 5962,
+          "all": [
+            5962,
+            2957,
+            5451
+          ]
+        },
+        "taskLatencyP95Ms": {
+          "median": 2766,
+          "p95": 5320,
+          "all": [
+            2766,
+            1347,
+            5320
+          ]
+        },
+        "frameMaxGapMs": {
+          "median": 5341,
+          "p95": 5941,
+          "all": [
+            5941,
+            1991,
+            5341
+          ]
+        },
+        "framesDropped": {
+          "median": 44,
+          "p95": 58,
+          "all": [
+            38,
+            58,
+            44
+          ]
+        },
+        "heapSlopeKBps": {
+          "median": 466,
+          "p95": 532,
+          "all": [
+            282,
+            466,
+            532
+          ]
+        },
+        "heapGrowthMB": {
+          "median": 15,
+          "p95": 17,
+          "all": [
+            9,
+            15,
+            17
+          ]
+        },
+        "deltasSent": {
+          "median": 7742,
+          "p95": 8575,
+          "all": [
+            5880,
+            7742,
+            8575
+          ]
+        },
+        "widgetCount": {
+          "median": 1,
+          "p95": 1,
+          "all": [
+            1,
+            1,
+            1
+          ]
+        }
+      },
+      "raw": [
+        {
+          "windowMs": 30118,
+          "longTasks": {
+            "count": 26,
+            "totalMs": 27608,
+            "maxMs": 5847,
+            "blockingTimeMs": 26308
+          },
+          "taskLatencyMs": {
+            "samples": 42,
+            "maxMs": 5962,
+            "p95Ms": 2766
+          },
+          "frames": {
+            "samples": 64,
+            "maxGapMs": 5941,
+            "p95GapMs": 2134,
+            "droppedOver50ms": 38
+          },
+          "heap": {
+            "samples": 33,
+            "firstBytes": 10908383,
+            "lastBytes": 20810407,
+            "slopeBytesPerSec": 288798
+          },
+          "marks": {},
+          "deltasSent": 5880,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 637
+        },
+        {
+          "windowMs": 31757,
+          "longTasks": {
+            "count": 41,
+            "totalMs": 25619,
+            "maxMs": 1889,
+            "blockingTimeMs": 23569
+          },
+          "taskLatencyMs": {
+            "samples": 91,
+            "maxMs": 2957,
+            "p95Ms": 1347
+          },
+          "frames": {
+            "samples": 148,
+            "maxGapMs": 1991,
+            "p95GapMs": 1008,
+            "droppedOver50ms": 58
+          },
+          "heap": {
+            "samples": 45,
+            "firstBytes": 10917479,
+            "lastBytes": 26688670,
+            "slopeBytesPerSec": 477361
+          },
+          "marks": {},
+          "deltasSent": 7742,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 735
+        },
+        {
+          "windowMs": 35071,
+          "longTasks": {
+            "count": 24,
+            "totalMs": 26962,
+            "maxMs": 5159,
+            "blockingTimeMs": 25762
+          },
+          "taskLatencyMs": {
+            "samples": 40,
+            "maxMs": 5451,
+            "p95Ms": 5320
+          },
+          "frames": {
+            "samples": 62,
+            "maxGapMs": 5341,
+            "p95GapMs": 2951,
+            "droppedOver50ms": 44
+          },
+          "heap": {
+            "samples": 32,
+            "firstBytes": 10924011,
+            "lastBytes": 29257125,
+            "slopeBytesPerSec": 545171
+          },
+          "marks": {},
+          "deltasSent": 8575,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 735
+        }
+      ]
+    }
+  }
+}

--- a/perf-harness/results/freeze-transform.json
+++ b/perf-harness/results/freeze-transform.json
@@ -1,0 +1,401 @@
+{
+  "label": "freeze-transform",
+  "branch": "master",
+  "throttle": 10,
+  "repeats": 3,
+  "chrome": "149.0.7827.201",
+  "scenarios": {
+    "ais-radar-150": {
+      "note": "150 AIS targets @ 4Hz + streaming own-ship (ranks 4/5, radar render loops)",
+      "agg": {
+        "longTaskCount": {
+          "median": 14,
+          "p95": 18,
+          "all": [
+            14,
+            18,
+            13
+          ]
+        },
+        "longTaskMaxMs": {
+          "median": 1379,
+          "p95": 1942,
+          "all": [
+            1316,
+            1942,
+            1379
+          ]
+        },
+        "blockingTimeMs": {
+          "median": 7682,
+          "p95": 8756,
+          "all": [
+            7229,
+            8756,
+            7682
+          ]
+        },
+        "taskLatencyMaxMs": {
+          "median": 1983,
+          "p95": 2405,
+          "all": [
+            1457,
+            2405,
+            1983
+          ]
+        },
+        "taskLatencyP95Ms": {
+          "median": 1515,
+          "p95": 2056,
+          "all": [
+            1338,
+            2056,
+            1515
+          ]
+        },
+        "frameMaxGapMs": {
+          "median": 1474,
+          "p95": 2334,
+          "all": [
+            1417,
+            2334,
+            1474
+          ]
+        },
+        "framesDropped": {
+          "median": 35,
+          "p95": 42,
+          "all": [
+            42,
+            35,
+            29
+          ]
+        },
+        "heapSlopeKBps": {
+          "median": 1163,
+          "p95": 1230,
+          "all": [
+            1230,
+            1163,
+            856
+          ]
+        },
+        "heapGrowthMB": {
+          "median": 18,
+          "p95": 21,
+          "all": [
+            21,
+            18,
+            12
+          ]
+        },
+        "deltasSent": {
+          "median": 8305,
+          "p95": 19328,
+          "all": [
+            19328,
+            8305,
+            7399
+          ]
+        },
+        "widgetCount": {
+          "median": 1,
+          "p95": 1,
+          "all": [
+            1,
+            1,
+            1
+          ]
+        }
+      },
+      "raw": [
+        {
+          "windowMs": 12941,
+          "longTasks": {
+            "count": 14,
+            "totalMs": 7929,
+            "maxMs": 1316,
+            "blockingTimeMs": 7229
+          },
+          "taskLatencyMs": {
+            "samples": 30,
+            "maxMs": 1457,
+            "p95Ms": 1338
+          },
+          "frames": {
+            "samples": 42,
+            "maxGapMs": 1417,
+            "p95GapMs": 1284,
+            "droppedOver50ms": 42
+          },
+          "heap": {
+            "samples": 24,
+            "firstBytes": 10924148,
+            "lastBytes": 32570554,
+            "slopeBytesPerSec": 1259493
+          },
+          "marks": {},
+          "deltasSent": 19328,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 4681
+        },
+        {
+          "windowMs": 13937,
+          "longTasks": {
+            "count": 18,
+            "totalMs": 9656,
+            "maxMs": 1942,
+            "blockingTimeMs": 8756
+          },
+          "taskLatencyMs": {
+            "samples": 33,
+            "maxMs": 2405,
+            "p95Ms": 2056
+          },
+          "frames": {
+            "samples": 49,
+            "maxGapMs": 2334,
+            "p95GapMs": 1342,
+            "droppedOver50ms": 35
+          },
+          "heap": {
+            "samples": 25,
+            "firstBytes": 10912956,
+            "lastBytes": 29490689,
+            "slopeBytesPerSec": 1191369
+          },
+          "marks": {},
+          "deltasSent": 8305,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 1812
+        },
+        {
+          "windowMs": 12269,
+          "longTasks": {
+            "count": 13,
+            "totalMs": 8332,
+            "maxMs": 1379,
+            "blockingTimeMs": 7682
+          },
+          "taskLatencyMs": {
+            "samples": 29,
+            "maxMs": 1983,
+            "p95Ms": 1515
+          },
+          "frames": {
+            "samples": 40,
+            "maxGapMs": 1474,
+            "p95GapMs": 1426,
+            "droppedOver50ms": 29
+          },
+          "heap": {
+            "samples": 21,
+            "firstBytes": 10696712,
+            "lastBytes": 23441962,
+            "slopeBytesPerSec": 876733
+          },
+          "marks": {},
+          "deltasSent": 7399,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 1812
+        }
+      ]
+    },
+    "ais-growth-churn": {
+      "note": "AIS radar with 40 targets + 40 new MMSIs/sec churn for 30s (ranks 8/9, heap growth)",
+      "agg": {
+        "longTaskCount": {
+          "median": 22,
+          "p95": 36,
+          "all": [
+            36,
+            22,
+            18
+          ]
+        },
+        "longTaskMaxMs": {
+          "median": 5908,
+          "p95": 8942,
+          "all": [
+            4310,
+            5908,
+            8942
+          ]
+        },
+        "blockingTimeMs": {
+          "median": 25869,
+          "p95": 25892,
+          "all": [
+            25058,
+            25869,
+            25892
+          ]
+        },
+        "taskLatencyMaxMs": {
+          "median": 6083,
+          "p95": 9068,
+          "all": [
+            4311,
+            6083,
+            9068
+          ]
+        },
+        "taskLatencyP95Ms": {
+          "median": 4112,
+          "p95": 7929,
+          "all": [
+            2129,
+            4112,
+            7929
+          ]
+        },
+        "frameMaxGapMs": {
+          "median": 6012,
+          "p95": 10326,
+          "all": [
+            4333,
+            6012,
+            10326
+          ]
+        },
+        "framesDropped": {
+          "median": 39,
+          "p95": 53,
+          "all": [
+            53,
+            39,
+            28
+          ]
+        },
+        "heapSlopeKBps": {
+          "median": 191,
+          "p95": 486,
+          "all": [
+            134,
+            191,
+            486
+          ]
+        },
+        "heapGrowthMB": {
+          "median": 6,
+          "p95": 15,
+          "all": [
+            4,
+            6,
+            15
+          ]
+        },
+        "deltasSent": {
+          "median": 7399,
+          "p95": 9506,
+          "all": [
+            5929,
+            7399,
+            9506
+          ]
+        },
+        "widgetCount": {
+          "median": 1,
+          "p95": 1,
+          "all": [
+            1,
+            1,
+            1
+          ]
+        }
+      },
+      "raw": [
+        {
+          "windowMs": 30500,
+          "longTasks": {
+            "count": 36,
+            "totalMs": 26858,
+            "maxMs": 4310,
+            "blockingTimeMs": 25058
+          },
+          "taskLatencyMs": {
+            "samples": 63,
+            "maxMs": 4311,
+            "p95Ms": 2129
+          },
+          "frames": {
+            "samples": 104,
+            "maxGapMs": 4333,
+            "p95GapMs": 1250,
+            "droppedOver50ms": 53
+          },
+          "heap": {
+            "samples": 39,
+            "firstBytes": 10685700,
+            "lastBytes": 15378159,
+            "slopeBytesPerSec": 137640
+          },
+          "marks": {},
+          "deltasSent": 5929,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 637
+        },
+        {
+          "windowMs": 30328,
+          "longTasks": {
+            "count": 22,
+            "totalMs": 26969,
+            "maxMs": 5908,
+            "blockingTimeMs": 25869
+          },
+          "taskLatencyMs": {
+            "samples": 41,
+            "maxMs": 6083,
+            "p95Ms": 4112
+          },
+          "frames": {
+            "samples": 62,
+            "maxGapMs": 6012,
+            "p95GapMs": 2092,
+            "droppedOver50ms": 39
+          },
+          "heap": {
+            "samples": 29,
+            "firstBytes": 10930624,
+            "lastBytes": 17589902,
+            "slopeBytesPerSec": 195664
+          },
+          "marks": {},
+          "deltasSent": 7399,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 784
+        },
+        {
+          "windowMs": 38818,
+          "longTasks": {
+            "count": 18,
+            "totalMs": 26792,
+            "maxMs": 8942,
+            "blockingTimeMs": 25892
+          },
+          "taskLatencyMs": {
+            "samples": 31,
+            "maxMs": 9068,
+            "p95Ms": 7929
+          },
+          "frames": {
+            "samples": 52,
+            "maxGapMs": 10326,
+            "p95GapMs": 7876,
+            "droppedOver50ms": 28
+          },
+          "heap": {
+            "samples": 22,
+            "firstBytes": 10911896,
+            "lastBytes": 27033359,
+            "slopeBytesPerSec": 498065
+          },
+          "marks": {},
+          "deltasSent": 9506,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 735
+        }
+      ]
+    }
+  }
+}

--- a/perf-harness/results/freeze-transform2.json
+++ b/perf-harness/results/freeze-transform2.json
@@ -1,0 +1,401 @@
+{
+  "label": "freeze-transform2",
+  "branch": "master",
+  "throttle": 10,
+  "repeats": 3,
+  "chrome": "149.0.7827.201",
+  "scenarios": {
+    "ais-radar-150": {
+      "note": "150 AIS targets @ 4Hz + streaming own-ship (ranks 4/5, radar render loops)",
+      "agg": {
+        "longTaskCount": {
+          "median": 16,
+          "p95": 26,
+          "all": [
+            26,
+            16,
+            11
+          ]
+        },
+        "longTaskMaxMs": {
+          "median": 1524,
+          "p95": 1737,
+          "all": [
+            474,
+            1524,
+            1737
+          ]
+        },
+        "blockingTimeMs": {
+          "median": 8586,
+          "p95": 9225,
+          "all": [
+            4419,
+            9225,
+            8586
+          ]
+        },
+        "taskLatencyMaxMs": {
+          "median": 1585,
+          "p95": 1874,
+          "all": [
+            598,
+            1585,
+            1874
+          ]
+        },
+        "taskLatencyP95Ms": {
+          "median": 1234,
+          "p95": 1675,
+          "all": [
+            464,
+            1234,
+            1675
+          ]
+        },
+        "frameMaxGapMs": {
+          "median": 1609,
+          "p95": 1834,
+          "all": [
+            575,
+            1609,
+            1834
+          ]
+        },
+        "framesDropped": {
+          "median": 31,
+          "p95": 70,
+          "all": [
+            70,
+            31,
+            28
+          ]
+        },
+        "heapSlopeKBps": {
+          "median": 961,
+          "p95": 1243,
+          "all": [
+            961,
+            1243,
+            813
+          ]
+        },
+        "heapGrowthMB": {
+          "median": 15,
+          "p95": 19,
+          "all": [
+            15,
+            19,
+            12
+          ]
+        },
+        "deltasSent": {
+          "median": 7399,
+          "p95": 18271,
+          "all": [
+            18271,
+            7248,
+            7399
+          ]
+        },
+        "widgetCount": {
+          "median": 1,
+          "p95": 1,
+          "all": [
+            1,
+            1,
+            1
+          ]
+        }
+      },
+      "raw": [
+        {
+          "windowMs": 12224,
+          "longTasks": {
+            "count": 26,
+            "totalMs": 5719,
+            "maxMs": 474,
+            "blockingTimeMs": 4419
+          },
+          "taskLatencyMs": {
+            "samples": 58,
+            "maxMs": 598,
+            "p95Ms": 464
+          },
+          "frames": {
+            "samples": 78,
+            "maxGapMs": 575,
+            "p95GapMs": 400,
+            "droppedOver50ms": 70
+          },
+          "heap": {
+            "samples": 32,
+            "firstBytes": 10676720,
+            "lastBytes": 26515604,
+            "slopeBytesPerSec": 984118
+          },
+          "marks": {},
+          "deltasSent": 18271,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 4832
+        },
+        {
+          "windowMs": 12125,
+          "longTasks": {
+            "count": 16,
+            "totalMs": 10025,
+            "maxMs": 1524,
+            "blockingTimeMs": 9225
+          },
+          "taskLatencyMs": {
+            "samples": 31,
+            "maxMs": 1585,
+            "p95Ms": 1234
+          },
+          "frames": {
+            "samples": 47,
+            "maxGapMs": 1609,
+            "p95GapMs": 1191,
+            "droppedOver50ms": 31
+          },
+          "heap": {
+            "samples": 26,
+            "firstBytes": 10714448,
+            "lastBytes": 30274163,
+            "slopeBytesPerSec": 1272947
+          },
+          "marks": {},
+          "deltasSent": 7248,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 1963
+        },
+        {
+          "windowMs": 12257,
+          "longTasks": {
+            "count": 11,
+            "totalMs": 9136,
+            "maxMs": 1737,
+            "blockingTimeMs": 8586
+          },
+          "taskLatencyMs": {
+            "samples": 23,
+            "maxMs": 1874,
+            "p95Ms": 1675
+          },
+          "frames": {
+            "samples": 35,
+            "maxGapMs": 1834,
+            "p95GapMs": 1625,
+            "droppedOver50ms": 28
+          },
+          "heap": {
+            "samples": 20,
+            "firstBytes": 10931624,
+            "lastBytes": 23802906,
+            "slopeBytesPerSec": 832554
+          },
+          "marks": {},
+          "deltasSent": 7399,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 1812
+        }
+      ]
+    },
+    "ais-growth-churn": {
+      "note": "AIS radar with 40 targets + 40 new MMSIs/sec churn for 30s (ranks 8/9, heap growth)",
+      "agg": {
+        "longTaskCount": {
+          "median": 30,
+          "p95": 38,
+          "all": [
+            38,
+            18,
+            30
+          ]
+        },
+        "longTaskMaxMs": {
+          "median": 5160,
+          "p95": 7912,
+          "all": [
+            5160,
+            7912,
+            4155
+          ]
+        },
+        "blockingTimeMs": {
+          "median": 25265,
+          "p95": 27259,
+          "all": [
+            23378,
+            27259,
+            25265
+          ]
+        },
+        "taskLatencyMaxMs": {
+          "median": 6337,
+          "p95": 8018,
+          "all": [
+            6337,
+            8018,
+            4250
+          ]
+        },
+        "taskLatencyP95Ms": {
+          "median": 3812,
+          "p95": 7162,
+          "all": [
+            3812,
+            7162,
+            2960
+          ]
+        },
+        "frameMaxGapMs": {
+          "median": 6250,
+          "p95": 8017,
+          "all": [
+            6250,
+            8017,
+            4250
+          ]
+        },
+        "framesDropped": {
+          "median": 46,
+          "p95": 48,
+          "all": [
+            46,
+            29,
+            48
+          ]
+        },
+        "heapSlopeKBps": {
+          "median": 240,
+          "p95": 490,
+          "all": [
+            490,
+            240,
+            235
+          ]
+        },
+        "heapGrowthMB": {
+          "median": 8,
+          "p95": 15,
+          "all": [
+            15,
+            8,
+            8
+          ]
+        },
+        "deltasSent": {
+          "median": 7497,
+          "p95": 7497,
+          "all": [
+            6664,
+            7497,
+            7497
+          ]
+        },
+        "widgetCount": {
+          "median": 1,
+          "p95": 1,
+          "all": [
+            1,
+            1,
+            1
+          ]
+        }
+      },
+      "raw": [
+        {
+          "windowMs": 34136,
+          "longTasks": {
+            "count": 38,
+            "totalMs": 25278,
+            "maxMs": 5160,
+            "blockingTimeMs": 23378
+          },
+          "taskLatencyMs": {
+            "samples": 68,
+            "maxMs": 6337,
+            "p95Ms": 3812
+          },
+          "frames": {
+            "samples": 125,
+            "maxGapMs": 6250,
+            "p95GapMs": 900,
+            "droppedOver50ms": 46
+          },
+          "heap": {
+            "samples": 30,
+            "firstBytes": 10936464,
+            "lastBytes": 27007075,
+            "slopeBytesPerSec": 501494
+          },
+          "marks": {},
+          "deltasSent": 6664,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 588
+        },
+        {
+          "windowMs": 30612,
+          "longTasks": {
+            "count": 18,
+            "totalMs": 28159,
+            "maxMs": 7912,
+            "blockingTimeMs": 27259
+          },
+          "taskLatencyMs": {
+            "samples": 32,
+            "maxMs": 8018,
+            "p95Ms": 7162
+          },
+          "frames": {
+            "samples": 51,
+            "maxGapMs": 8017,
+            "p95GapMs": 4691,
+            "droppedOver50ms": 29
+          },
+          "heap": {
+            "samples": 23,
+            "firstBytes": 10942044,
+            "lastBytes": 19347506,
+            "slopeBytesPerSec": 245282
+          },
+          "marks": {},
+          "deltasSent": 7497,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 735
+        },
+        {
+          "windowMs": 30655,
+          "longTasks": {
+            "count": 30,
+            "totalMs": 26765,
+            "maxMs": 4155,
+            "blockingTimeMs": 25265
+          },
+          "taskLatencyMs": {
+            "samples": 50,
+            "maxMs": 4250,
+            "p95Ms": 2960
+          },
+          "frames": {
+            "samples": 83,
+            "maxGapMs": 4250,
+            "p95GapMs": 2325,
+            "droppedOver50ms": 48
+          },
+          "heap": {
+            "samples": 35,
+            "firstBytes": 10719704,
+            "lastBytes": 18943592,
+            "slopeBytesPerSec": 240264
+          },
+          "marks": {},
+          "deltasSent": 7497,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 735
+        }
+      ]
+    }
+  }
+}

--- a/perf-harness/results/freeze-work-v1.json
+++ b/perf-harness/results/freeze-work-v1.json
@@ -1,0 +1,1381 @@
+{
+  "label": "freeze-work-v1",
+  "branch": "master",
+  "throttle": 10,
+  "repeats": 3,
+  "chrome": "149.0.7827.201",
+  "scenarios": {
+    "idle-numeric-24": {
+      "note": "baseline render/CD load: 24 numeric widgets, low data rate (WS4 baseline)",
+      "agg": {
+        "longTaskCount": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0
+          ]
+        },
+        "longTaskMaxMs": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0
+          ]
+        },
+        "blockingTimeMs": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0
+          ]
+        },
+        "taskLatencyMaxMs": {
+          "median": 4,
+          "p95": 4,
+          "all": [
+            4,
+            4,
+            3
+          ]
+        },
+        "taskLatencyP95Ms": {
+          "median": 2,
+          "p95": 3,
+          "all": [
+            3,
+            2,
+            2
+          ]
+        },
+        "frameMaxGapMs": {
+          "median": 10,
+          "p95": 10,
+          "all": [
+            10,
+            10,
+            10
+          ]
+        },
+        "framesDropped": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0
+          ]
+        },
+        "heapSlopeKBps": {
+          "median": 119,
+          "p95": 205,
+          "all": [
+            205,
+            117,
+            119
+          ]
+        },
+        "heapGrowthMB": {
+          "median": 1,
+          "p95": 2,
+          "all": [
+            2,
+            1,
+            1
+          ]
+        },
+        "deltasSent": {
+          "median": 16,
+          "p95": 79,
+          "all": [
+            79,
+            16,
+            16
+          ]
+        },
+        "widgetCount": {
+          "median": 24,
+          "p95": 24,
+          "all": [
+            24,
+            24,
+            24
+          ]
+        }
+      },
+      "raw": [
+        {
+          "windowMs": 8003,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 458,
+            "maxMs": 4,
+            "p95Ms": 3
+          },
+          "frames": {
+            "samples": 960,
+            "maxGapMs": 10,
+            "p95GapMs": 10,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 24,
+            "firstBytes": 12180935,
+            "lastBytes": 14555775,
+            "slopeBytesPerSec": 209986
+          },
+          "marks": {},
+          "deltasSent": 79,
+          "widgetCount": 24,
+          "streamedDuringWarmup": 20
+        },
+        {
+          "windowMs": 8003,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 458,
+            "maxMs": 4,
+            "p95Ms": 2
+          },
+          "frames": {
+            "samples": 960,
+            "maxGapMs": 10,
+            "p95GapMs": 10,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 24,
+            "firstBytes": 12192103,
+            "lastBytes": 13550562,
+            "slopeBytesPerSec": 119974
+          },
+          "marks": {},
+          "deltasSent": 16,
+          "widgetCount": 24,
+          "streamedDuringWarmup": 4
+        },
+        {
+          "windowMs": 8005,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 457,
+            "maxMs": 3,
+            "p95Ms": 2
+          },
+          "frames": {
+            "samples": 961,
+            "maxGapMs": 10,
+            "p95GapMs": 10,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 24,
+            "firstBytes": 12165903,
+            "lastBytes": 13547054,
+            "slopeBytesPerSec": 122280
+          },
+          "marks": {},
+          "deltasSent": 16,
+          "widgetCount": 24,
+          "streamedDuringWarmup": 4
+        }
+      ]
+    },
+    "delta-storm-30x10": {
+      "note": "sustained ingestion: 30 paths @ 10Hz over a numeric+gauge dashboard (rank 2, delta coalescing)",
+      "agg": {
+        "longTaskCount": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0
+          ]
+        },
+        "longTaskMaxMs": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0
+          ]
+        },
+        "blockingTimeMs": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0
+          ]
+        },
+        "taskLatencyMaxMs": {
+          "median": 6,
+          "p95": 6,
+          "all": [
+            4,
+            6,
+            6
+          ]
+        },
+        "taskLatencyP95Ms": {
+          "median": 2,
+          "p95": 2,
+          "all": [
+            2,
+            2,
+            2
+          ]
+        },
+        "frameMaxGapMs": {
+          "median": 10,
+          "p95": 11,
+          "all": [
+            10,
+            10,
+            11
+          ]
+        },
+        "framesDropped": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0
+          ]
+        },
+        "heapSlopeKBps": {
+          "median": 99,
+          "p95": 141,
+          "all": [
+            141,
+            99,
+            90
+          ]
+        },
+        "heapGrowthMB": {
+          "median": 1,
+          "p95": 2,
+          "all": [
+            2,
+            1,
+            1
+          ]
+        },
+        "deltasSent": {
+          "median": 118,
+          "p95": 119,
+          "all": [
+            24,
+            119,
+            118
+          ]
+        },
+        "widgetCount": {
+          "median": 20,
+          "p95": 20,
+          "all": [
+            20,
+            20,
+            20
+          ]
+        }
+      },
+      "raw": [
+        {
+          "windowMs": 12006,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 685,
+            "maxMs": 4,
+            "p95Ms": 2
+          },
+          "frames": {
+            "samples": 1440,
+            "maxGapMs": 10,
+            "p95GapMs": 10,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 32,
+            "firstBytes": 11944003,
+            "lastBytes": 14163785,
+            "slopeBytesPerSec": 144680
+          },
+          "marks": {},
+          "deltasSent": 24,
+          "widgetCount": 20,
+          "streamedDuringWarmup": 4
+        },
+        {
+          "windowMs": 12005,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 688,
+            "maxMs": 6,
+            "p95Ms": 2
+          },
+          "frames": {
+            "samples": 1440,
+            "maxGapMs": 10,
+            "p95GapMs": 10,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 31,
+            "firstBytes": 11969171,
+            "lastBytes": 13476819,
+            "slopeBytesPerSec": 101523
+          },
+          "marks": {},
+          "deltasSent": 119,
+          "widgetCount": 20,
+          "streamedDuringWarmup": 20
+        },
+        {
+          "windowMs": 12004,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 686,
+            "maxMs": 6,
+            "p95Ms": 2
+          },
+          "frames": {
+            "samples": 1440,
+            "maxGapMs": 11,
+            "p95GapMs": 10,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 31,
+            "firstBytes": 12009543,
+            "lastBytes": 13379631,
+            "slopeBytesPerSec": 92383
+          },
+          "marks": {},
+          "deltasSent": 118,
+          "widgetCount": 20,
+          "streamedDuringWarmup": 20
+        }
+      ]
+    },
+    "reconnect-backlog": {
+      "note": "reconnect snapshot: one frame carrying 6000 values (rank 2, single synchronous parse+fan-out long task)",
+      "agg": {
+        "longTaskCount": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0
+          ]
+        },
+        "longTaskMaxMs": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0
+          ]
+        },
+        "blockingTimeMs": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0
+          ]
+        },
+        "taskLatencyMaxMs": {
+          "median": 46,
+          "p95": 59,
+          "all": [
+            46,
+            43,
+            59
+          ]
+        },
+        "taskLatencyP95Ms": {
+          "median": 3,
+          "p95": 3,
+          "all": [
+            2,
+            3,
+            3
+          ]
+        },
+        "frameMaxGapMs": {
+          "median": 49,
+          "p95": 50,
+          "all": [
+            50,
+            49,
+            49
+          ]
+        },
+        "framesDropped": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0
+          ]
+        },
+        "heapSlopeKBps": {
+          "median": 330,
+          "p95": 394,
+          "all": [
+            394,
+            304,
+            330
+          ]
+        },
+        "heapGrowthMB": {
+          "median": 3,
+          "p95": 4,
+          "all": [
+            4,
+            3,
+            3
+          ]
+        },
+        "deltasSent": {
+          "median": 29,
+          "p95": 71,
+          "all": [
+            71,
+            29,
+            29
+          ]
+        },
+        "widgetCount": {
+          "median": 20,
+          "p95": 20,
+          "all": [
+            20,
+            20,
+            20
+          ]
+        }
+      },
+      "raw": [
+        {
+          "windowMs": 7006,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 396,
+            "maxMs": 46,
+            "p95Ms": 2
+          },
+          "frames": {
+            "samples": 836,
+            "maxGapMs": 50,
+            "p95GapMs": 10,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 22,
+            "firstBytes": 11940735,
+            "lastBytes": 16114716,
+            "slopeBytesPerSec": 403283
+          },
+          "marks": {},
+          "deltasSent": 71,
+          "widgetCount": 20,
+          "streamedDuringWarmup": 19
+        },
+        {
+          "windowMs": 7008,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 396,
+            "maxMs": 43,
+            "p95Ms": 3
+          },
+          "frames": {
+            "samples": 836,
+            "maxGapMs": 49,
+            "p95GapMs": 10,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 21,
+            "firstBytes": 11972735,
+            "lastBytes": 15031451,
+            "slopeBytesPerSec": 310842
+          },
+          "marks": {},
+          "deltasSent": 29,
+          "widgetCount": 20,
+          "streamedDuringWarmup": 8
+        },
+        {
+          "windowMs": 7007,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 395,
+            "maxMs": 59,
+            "p95Ms": 3
+          },
+          "frames": {
+            "samples": 836,
+            "maxGapMs": 49,
+            "p95GapMs": 10,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 21,
+            "firstBytes": 11963283,
+            "lastBytes": 15290554,
+            "slopeBytesPerSec": 337421
+          },
+          "marks": {},
+          "deltasSent": 29,
+          "widgetCount": 20,
+          "streamedDuringWarmup": 8
+        }
+      ]
+    },
+    "resize-storm": {
+      "note": "28 canvas widgets + repeated viewport resizes: shared ResizeObserver reallocates every canvas in one task (rank 1, the fullscreen enter/exit storm)",
+      "agg": {
+        "longTaskCount": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0
+          ]
+        },
+        "longTaskMaxMs": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0
+          ]
+        },
+        "blockingTimeMs": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0
+          ]
+        },
+        "taskLatencyMaxMs": {
+          "median": 71,
+          "p95": 74,
+          "all": [
+            69,
+            71,
+            74
+          ]
+        },
+        "taskLatencyP95Ms": {
+          "median": 43,
+          "p95": 45,
+          "all": [
+            45,
+            43,
+            43
+          ]
+        },
+        "frameMaxGapMs": {
+          "median": 59,
+          "p95": 67,
+          "all": [
+            58,
+            67,
+            59
+          ]
+        },
+        "framesDropped": {
+          "median": 3,
+          "p95": 4,
+          "all": [
+            4,
+            2,
+            3
+          ]
+        },
+        "heapSlopeKBps": {
+          "median": 78,
+          "p95": 189,
+          "all": [
+            189,
+            64,
+            78
+          ]
+        },
+        "heapGrowthMB": {
+          "median": 1,
+          "p95": 2,
+          "all": [
+            2,
+            1,
+            1
+          ]
+        },
+        "deltasSent": {
+          "median": 14,
+          "p95": 28,
+          "all": [
+            28,
+            14,
+            14
+          ]
+        },
+        "widgetCount": {
+          "median": 28,
+          "p95": 28,
+          "all": [
+            28,
+            28,
+            28
+          ]
+        }
+      },
+      "raw": [
+        {
+          "windowMs": 7146,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 277,
+            "maxMs": 69,
+            "p95Ms": 45
+          },
+          "frames": {
+            "samples": 581,
+            "maxGapMs": 58,
+            "p95GapMs": 32,
+            "droppedOver50ms": 4
+          },
+          "heap": {
+            "samples": 23,
+            "firstBytes": 11494899,
+            "lastBytes": 13590150,
+            "slopeBytesPerSec": 193609
+          },
+          "marks": {},
+          "deltasSent": 28,
+          "widgetCount": 28,
+          "streamedDuringWarmup": 10
+        },
+        {
+          "windowMs": 7130,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 269,
+            "maxMs": 71,
+            "p95Ms": 43
+          },
+          "frames": {
+            "samples": 572,
+            "maxGapMs": 67,
+            "p95GapMs": 32,
+            "droppedOver50ms": 2
+          },
+          "heap": {
+            "samples": 23,
+            "firstBytes": 12299211,
+            "lastBytes": 13007089,
+            "slopeBytesPerSec": 65375
+          },
+          "marks": {},
+          "deltasSent": 14,
+          "widgetCount": 28,
+          "streamedDuringWarmup": 5
+        },
+        {
+          "windowMs": 7116,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 272,
+            "maxMs": 74,
+            "p95Ms": 43
+          },
+          "frames": {
+            "samples": 568,
+            "maxGapMs": 59,
+            "p95GapMs": 27,
+            "droppedOver50ms": 3
+          },
+          "heap": {
+            "samples": 23,
+            "firstBytes": 12312479,
+            "lastBytes": 13170982,
+            "slopeBytesPerSec": 79391
+          },
+          "marks": {},
+          "deltasSent": 14,
+          "widgetCount": 28,
+          "streamedDuringWarmup": 5
+        }
+      ]
+    },
+    "ais-radar-150": {
+      "note": "150 AIS targets @ 4Hz + streaming own-ship (ranks 4/5, radar render loops)",
+      "agg": {
+        "longTaskCount": {
+          "median": 24,
+          "p95": 55,
+          "all": [
+            55,
+            17,
+            24
+          ]
+        },
+        "longTaskMaxMs": {
+          "median": 1164,
+          "p95": 1316,
+          "all": [
+            320,
+            1316,
+            1164
+          ]
+        },
+        "blockingTimeMs": {
+          "median": 8184,
+          "p95": 8271,
+          "all": [
+            5904,
+            8184,
+            8271
+          ]
+        },
+        "taskLatencyMaxMs": {
+          "median": 1284,
+          "p95": 1643,
+          "all": [
+            508,
+            1643,
+            1284
+          ]
+        },
+        "taskLatencyP95Ms": {
+          "median": 824,
+          "p95": 1434,
+          "all": [
+            305,
+            1434,
+            824
+          ]
+        },
+        "frameMaxGapMs": {
+          "median": 1250,
+          "p95": 1418,
+          "all": [
+            356,
+            1418,
+            1250
+          ]
+        },
+        "framesDropped": {
+          "median": 37,
+          "p95": 60,
+          "all": [
+            60,
+            29,
+            37
+          ]
+        },
+        "heapSlopeKBps": {
+          "median": 904,
+          "p95": 922,
+          "all": [
+            587,
+            904,
+            922
+          ]
+        },
+        "heapGrowthMB": {
+          "median": 15,
+          "p95": 15,
+          "all": [
+            9,
+            15,
+            15
+          ]
+        },
+        "deltasSent": {
+          "median": 7248,
+          "p95": 7550,
+          "all": [
+            3624,
+            7550,
+            7248
+          ]
+        },
+        "widgetCount": {
+          "median": 1,
+          "p95": 1,
+          "all": [
+            1,
+            1,
+            1
+          ]
+        }
+      },
+      "raw": [
+        {
+          "windowMs": 12251,
+          "longTasks": {
+            "count": 55,
+            "totalMs": 8654,
+            "maxMs": 320,
+            "blockingTimeMs": 5904
+          },
+          "taskLatencyMs": {
+            "samples": 168,
+            "maxMs": 508,
+            "p95Ms": 305
+          },
+          "frames": {
+            "samples": 353,
+            "maxGapMs": 356,
+            "p95GapMs": 200,
+            "droppedOver50ms": 60
+          },
+          "heap": {
+            "samples": 33,
+            "firstBytes": 10948772,
+            "lastBytes": 20552414,
+            "slopeBytesPerSec": 601434
+          },
+          "marks": {},
+          "deltasSent": 3624,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 906
+        },
+        {
+          "windowMs": 12400,
+          "longTasks": {
+            "count": 17,
+            "totalMs": 9034,
+            "maxMs": 1316,
+            "blockingTimeMs": 8184
+          },
+          "taskLatencyMs": {
+            "samples": 35,
+            "maxMs": 1643,
+            "p95Ms": 1434
+          },
+          "frames": {
+            "samples": 52,
+            "maxGapMs": 1418,
+            "p95GapMs": 932,
+            "droppedOver50ms": 29
+          },
+          "heap": {
+            "samples": 26,
+            "firstBytes": 10905692,
+            "lastBytes": 26213817,
+            "slopeBytesPerSec": 925186
+          },
+          "marks": {},
+          "deltasSent": 7550,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 1812
+        },
+        {
+          "windowMs": 12064,
+          "longTasks": {
+            "count": 24,
+            "totalMs": 9471,
+            "maxMs": 1164,
+            "blockingTimeMs": 8271
+          },
+          "taskLatencyMs": {
+            "samples": 57,
+            "maxMs": 1284,
+            "p95Ms": 824
+          },
+          "frames": {
+            "samples": 100,
+            "maxGapMs": 1250,
+            "p95GapMs": 668,
+            "droppedOver50ms": 37
+          },
+          "heap": {
+            "samples": 28,
+            "firstBytes": 10926824,
+            "lastBytes": 26191813,
+            "slopeBytesPerSec": 943903
+          },
+          "marks": {},
+          "deltasSent": 7248,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 1963
+        }
+      ]
+    },
+    "gauges-16": {
+      "note": "16 radial ng-canvas-gauges @ 4Hz (rank 7, animation duty cycle)",
+      "agg": {
+        "longTaskCount": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0
+          ]
+        },
+        "longTaskMaxMs": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0
+          ]
+        },
+        "blockingTimeMs": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0
+          ]
+        },
+        "taskLatencyMaxMs": {
+          "median": 31,
+          "p95": 33,
+          "all": [
+            33,
+            31,
+            20
+          ]
+        },
+        "taskLatencyP95Ms": {
+          "median": 9,
+          "p95": 10,
+          "all": [
+            9,
+            9,
+            10
+          ]
+        },
+        "frameMaxGapMs": {
+          "median": 25,
+          "p95": 33,
+          "all": [
+            33,
+            25,
+            25
+          ]
+        },
+        "framesDropped": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0
+          ]
+        },
+        "heapSlopeKBps": {
+          "median": 180,
+          "p95": 259,
+          "all": [
+            180,
+            259,
+            167
+          ]
+        },
+        "heapGrowthMB": {
+          "median": 2,
+          "p95": 3,
+          "all": [
+            2,
+            3,
+            2
+          ]
+        },
+        "deltasSent": {
+          "median": 40,
+          "p95": 40,
+          "all": [
+            39,
+            40,
+            40
+          ]
+        },
+        "widgetCount": {
+          "median": 16,
+          "p95": 16,
+          "all": [
+            16,
+            16,
+            16
+          ]
+        }
+      },
+      "raw": [
+        {
+          "windowMs": 10009,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 509,
+            "maxMs": 33,
+            "p95Ms": 9
+          },
+          "frames": {
+            "samples": 1194,
+            "maxGapMs": 33,
+            "p95GapMs": 10,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 27,
+            "firstBytes": 11817083,
+            "lastBytes": 14185855,
+            "slopeBytesPerSec": 184626
+          },
+          "marks": {},
+          "deltasSent": 39,
+          "widgetCount": 16,
+          "streamedDuringWarmup": 8
+        },
+        {
+          "windowMs": 10012,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 513,
+            "maxMs": 31,
+            "p95Ms": 9
+          },
+          "frames": {
+            "samples": 1195,
+            "maxGapMs": 25,
+            "p95GapMs": 10,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 27,
+            "firstBytes": 11809007,
+            "lastBytes": 15223389,
+            "slopeBytesPerSec": 264989
+          },
+          "marks": {},
+          "deltasSent": 40,
+          "widgetCount": 16,
+          "streamedDuringWarmup": 8
+        },
+        {
+          "windowMs": 10011,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 504,
+            "maxMs": 20,
+            "p95Ms": 10
+          },
+          "frames": {
+            "samples": 1194,
+            "maxGapMs": 25,
+            "p95GapMs": 10,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 27,
+            "firstBytes": 11829323,
+            "lastBytes": 14038962,
+            "slopeBytesPerSec": 171507
+          },
+          "marks": {},
+          "deltasSent": 40,
+          "widgetCount": 16,
+          "streamedDuringWarmup": 8
+        }
+      ]
+    },
+    "ais-growth-churn": {
+      "note": "AIS radar with 40 targets + 40 new MMSIs/sec churn for 30s (ranks 8/9, heap growth)",
+      "agg": {
+        "longTaskCount": {
+          "median": 16,
+          "p95": 40,
+          "all": [
+            40,
+            16,
+            15
+          ]
+        },
+        "longTaskMaxMs": {
+          "median": 6506,
+          "p95": 7396,
+          "all": [
+            2451,
+            6506,
+            7396
+          ]
+        },
+        "blockingTimeMs": {
+          "median": 22336,
+          "p95": 23701,
+          "all": [
+            22336,
+            23701,
+            20910
+          ]
+        },
+        "taskLatencyMaxMs": {
+          "median": 8973,
+          "p95": 10426,
+          "all": [
+            5420,
+            10426,
+            8973
+          ]
+        },
+        "taskLatencyP95Ms": {
+          "median": 6659,
+          "p95": 7549,
+          "all": [
+            1689,
+            6659,
+            7549
+          ]
+        },
+        "frameMaxGapMs": {
+          "median": 8825,
+          "p95": 10367,
+          "all": [
+            2547,
+            10367,
+            8825
+          ]
+        },
+        "framesDropped": {
+          "median": 24,
+          "p95": 48,
+          "all": [
+            48,
+            24,
+            22
+          ]
+        },
+        "heapSlopeKBps": {
+          "median": 533,
+          "p95": 538,
+          "all": [
+            377,
+            533,
+            538
+          ]
+        },
+        "heapGrowthMB": {
+          "median": 14,
+          "p95": 16,
+          "all": [
+            11,
+            16,
+            14
+          ]
+        },
+        "deltasSent": {
+          "median": 7791,
+          "p95": 8869,
+          "all": [
+            6272,
+            8869,
+            7791
+          ]
+        },
+        "widgetCount": {
+          "median": 1,
+          "p95": 1,
+          "all": [
+            1,
+            1,
+            1
+          ]
+        }
+      },
+      "raw": [
+        {
+          "windowMs": 32216,
+          "longTasks": {
+            "count": 40,
+            "totalMs": 24336,
+            "maxMs": 2451,
+            "blockingTimeMs": 22336
+          },
+          "taskLatencyMs": {
+            "samples": 80,
+            "maxMs": 5420,
+            "p95Ms": 1689
+          },
+          "frames": {
+            "samples": 137,
+            "maxGapMs": 2547,
+            "p95GapMs": 1079,
+            "droppedOver50ms": 48
+          },
+          "heap": {
+            "samples": 40,
+            "firstBytes": 10927724,
+            "lastBytes": 22873008,
+            "slopeBytesPerSec": 385973
+          },
+          "marks": {},
+          "deltasSent": 6272,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 637
+        },
+        {
+          "windowMs": 36225,
+          "longTasks": {
+            "count": 16,
+            "totalMs": 24501,
+            "maxMs": 6506,
+            "blockingTimeMs": 23701
+          },
+          "taskLatencyMs": {
+            "samples": 25,
+            "maxMs": 10426,
+            "p95Ms": 6659
+          },
+          "frames": {
+            "samples": 39,
+            "maxGapMs": 10367,
+            "p95GapMs": 6608,
+            "droppedOver50ms": 24
+          },
+          "heap": {
+            "samples": 23,
+            "firstBytes": 10708772,
+            "lastBytes": 27027554,
+            "slopeBytesPerSec": 546228
+          },
+          "marks": {},
+          "deltasSent": 8869,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 735
+        },
+        {
+          "windowMs": 31803,
+          "longTasks": {
+            "count": 15,
+            "totalMs": 21660,
+            "maxMs": 7396,
+            "blockingTimeMs": 20910
+          },
+          "taskLatencyMs": {
+            "samples": 21,
+            "maxMs": 8973,
+            "p95Ms": 7549
+          },
+          "frames": {
+            "samples": 32,
+            "maxGapMs": 8825,
+            "p95GapMs": 7501,
+            "droppedOver50ms": 22
+          },
+          "heap": {
+            "samples": 22,
+            "firstBytes": 10912788,
+            "lastBytes": 25896060,
+            "slopeBytesPerSec": 550554
+          },
+          "marks": {},
+          "deltasSent": 7791,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 735
+        }
+      ]
+    }
+  }
+}

--- a/perf-harness/results/master.json
+++ b/perf-harness/results/master.json
@@ -1,0 +1,1381 @@
+{
+  "label": "master",
+  "branch": "master",
+  "throttle": 10,
+  "repeats": 3,
+  "chrome": "149.0.7827.201",
+  "scenarios": {
+    "idle-numeric-24": {
+      "note": "baseline render/CD load: 24 numeric widgets, low data rate (WS4 baseline)",
+      "agg": {
+        "longTaskCount": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0
+          ]
+        },
+        "longTaskMaxMs": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0
+          ]
+        },
+        "blockingTimeMs": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0
+          ]
+        },
+        "taskLatencyMaxMs": {
+          "median": 4,
+          "p95": 4,
+          "all": [
+            4,
+            4,
+            3
+          ]
+        },
+        "taskLatencyP95Ms": {
+          "median": 3,
+          "p95": 3,
+          "all": [
+            3,
+            2,
+            3
+          ]
+        },
+        "frameMaxGapMs": {
+          "median": 10,
+          "p95": 10,
+          "all": [
+            10,
+            10,
+            10
+          ]
+        },
+        "framesDropped": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0
+          ]
+        },
+        "heapSlopeKBps": {
+          "median": 13,
+          "p95": 102,
+          "all": [
+            102,
+            13,
+            -2
+          ]
+        },
+        "heapGrowthMB": {
+          "median": 0,
+          "p95": 1,
+          "all": [
+            1,
+            0,
+            0
+          ]
+        },
+        "deltasSent": {
+          "median": 16,
+          "p95": 79,
+          "all": [
+            79,
+            16,
+            16
+          ]
+        },
+        "widgetCount": {
+          "median": 24,
+          "p95": 24,
+          "all": [
+            24,
+            24,
+            24
+          ]
+        }
+      },
+      "raw": [
+        {
+          "windowMs": 8003,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 458,
+            "maxMs": 4,
+            "p95Ms": 3
+          },
+          "frames": {
+            "samples": 960,
+            "maxGapMs": 10,
+            "p95GapMs": 10,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 24,
+            "firstBytes": 15710475,
+            "lastBytes": 16864616,
+            "slopeBytesPerSec": 104571
+          },
+          "marks": {},
+          "deltasSent": 79,
+          "widgetCount": 24,
+          "streamedDuringWarmup": 20
+        },
+        {
+          "windowMs": 8005,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 455,
+            "maxMs": 4,
+            "p95Ms": 2
+          },
+          "frames": {
+            "samples": 961,
+            "maxGapMs": 10,
+            "p95GapMs": 10,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 23,
+            "firstBytes": 15579163,
+            "lastBytes": 15728537,
+            "slopeBytesPerSec": 13581
+          },
+          "marks": {},
+          "deltasSent": 16,
+          "widgetCount": 24,
+          "streamedDuringWarmup": 4
+        },
+        {
+          "windowMs": 8005,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 456,
+            "maxMs": 3,
+            "p95Ms": 3
+          },
+          "frames": {
+            "samples": 960,
+            "maxGapMs": 10,
+            "p95GapMs": 10,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 23,
+            "firstBytes": 16081351,
+            "lastBytes": 16061293,
+            "slopeBytesPerSec": -1838
+          },
+          "marks": {},
+          "deltasSent": 16,
+          "widgetCount": 24,
+          "streamedDuringWarmup": 4
+        }
+      ]
+    },
+    "delta-storm-30x10": {
+      "note": "sustained ingestion: 30 paths @ 10Hz over a numeric+gauge dashboard (rank 2, delta coalescing)",
+      "agg": {
+        "longTaskCount": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0
+          ]
+        },
+        "longTaskMaxMs": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0
+          ]
+        },
+        "blockingTimeMs": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0
+          ]
+        },
+        "taskLatencyMaxMs": {
+          "median": 8,
+          "p95": 13,
+          "all": [
+            4,
+            8,
+            13
+          ]
+        },
+        "taskLatencyP95Ms": {
+          "median": 3,
+          "p95": 3,
+          "all": [
+            3,
+            3,
+            3
+          ]
+        },
+        "frameMaxGapMs": {
+          "median": 10,
+          "p95": 16,
+          "all": [
+            10,
+            16,
+            10
+          ]
+        },
+        "framesDropped": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0
+          ]
+        },
+        "heapSlopeKBps": {
+          "median": -29,
+          "p95": 233,
+          "all": [
+            233,
+            -72,
+            -29
+          ]
+        },
+        "heapGrowthMB": {
+          "median": 0,
+          "p95": 3,
+          "all": [
+            3,
+            -1,
+            0
+          ]
+        },
+        "deltasSent": {
+          "median": 119,
+          "p95": 119,
+          "all": [
+            24,
+            119,
+            119
+          ]
+        },
+        "widgetCount": {
+          "median": 20,
+          "p95": 20,
+          "all": [
+            20,
+            20,
+            20
+          ]
+        }
+      },
+      "raw": [
+        {
+          "windowMs": 12004,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 677,
+            "maxMs": 4,
+            "p95Ms": 3
+          },
+          "frames": {
+            "samples": 1440,
+            "maxGapMs": 10,
+            "p95GapMs": 10,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 31,
+            "firstBytes": 12962409,
+            "lastBytes": 16521853,
+            "slopeBytesPerSec": 238583
+          },
+          "marks": {},
+          "deltasSent": 24,
+          "widgetCount": 20,
+          "streamedDuringWarmup": 4
+        },
+        {
+          "windowMs": 12005,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 687,
+            "maxMs": 8,
+            "p95Ms": 3
+          },
+          "frames": {
+            "samples": 1440,
+            "maxGapMs": 16,
+            "p95GapMs": 10,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 31,
+            "firstBytes": 15718703,
+            "lastBytes": 14614907,
+            "slopeBytesPerSec": -73698
+          },
+          "marks": {},
+          "deltasSent": 119,
+          "widgetCount": 20,
+          "streamedDuringWarmup": 19
+        },
+        {
+          "windowMs": 12004,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 686,
+            "maxMs": 13,
+            "p95Ms": 3
+          },
+          "frames": {
+            "samples": 1441,
+            "maxGapMs": 10,
+            "p95GapMs": 10,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 31,
+            "firstBytes": 15338411,
+            "lastBytes": 14895633,
+            "slopeBytesPerSec": -29580
+          },
+          "marks": {},
+          "deltasSent": 119,
+          "widgetCount": 20,
+          "streamedDuringWarmup": 19
+        }
+      ]
+    },
+    "reconnect-backlog": {
+      "note": "reconnect snapshot: one frame carrying 6000 values (rank 2, single synchronous parse+fan-out long task)",
+      "agg": {
+        "longTaskCount": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0
+          ]
+        },
+        "longTaskMaxMs": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0
+          ]
+        },
+        "blockingTimeMs": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0
+          ]
+        },
+        "taskLatencyMaxMs": {
+          "median": 56,
+          "p95": 60,
+          "all": [
+            60,
+            56,
+            44
+          ]
+        },
+        "taskLatencyP95Ms": {
+          "median": 3,
+          "p95": 3,
+          "all": [
+            2,
+            3,
+            3
+          ]
+        },
+        "frameMaxGapMs": {
+          "median": 49,
+          "p95": 51,
+          "all": [
+            49,
+            51,
+            43
+          ]
+        },
+        "framesDropped": {
+          "median": 0,
+          "p95": 1,
+          "all": [
+            0,
+            1,
+            0
+          ]
+        },
+        "heapSlopeKBps": {
+          "median": 205,
+          "p95": 263,
+          "all": [
+            263,
+            205,
+            195
+          ]
+        },
+        "heapGrowthMB": {
+          "median": 2,
+          "p95": 3,
+          "all": [
+            3,
+            2,
+            2
+          ]
+        },
+        "deltasSent": {
+          "median": 29,
+          "p95": 70,
+          "all": [
+            70,
+            29,
+            29
+          ]
+        },
+        "widgetCount": {
+          "median": 20,
+          "p95": 20,
+          "all": [
+            20,
+            20,
+            20
+          ]
+        }
+      },
+      "raw": [
+        {
+          "windowMs": 7008,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 398,
+            "maxMs": 60,
+            "p95Ms": 2
+          },
+          "frames": {
+            "samples": 836,
+            "maxGapMs": 49,
+            "p95GapMs": 10,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 21,
+            "firstBytes": 15722743,
+            "lastBytes": 18406977,
+            "slopeBytesPerSec": 269272
+          },
+          "marks": {},
+          "deltasSent": 70,
+          "widgetCount": 20,
+          "streamedDuringWarmup": 20
+        },
+        {
+          "windowMs": 7010,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 396,
+            "maxMs": 56,
+            "p95Ms": 3
+          },
+          "frames": {
+            "samples": 836,
+            "maxGapMs": 51,
+            "p95GapMs": 10,
+            "droppedOver50ms": 1
+          },
+          "heap": {
+            "samples": 21,
+            "firstBytes": 15269295,
+            "lastBytes": 17368979,
+            "slopeBytesPerSec": 210124
+          },
+          "marks": {},
+          "deltasSent": 29,
+          "widgetCount": 20,
+          "streamedDuringWarmup": 8
+        },
+        {
+          "windowMs": 7006,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 396,
+            "maxMs": 44,
+            "p95Ms": 3
+          },
+          "frames": {
+            "samples": 836,
+            "maxGapMs": 43,
+            "p95GapMs": 10,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 21,
+            "firstBytes": 15315939,
+            "lastBytes": 17304055,
+            "slopeBytesPerSec": 199875
+          },
+          "marks": {},
+          "deltasSent": 29,
+          "widgetCount": 20,
+          "streamedDuringWarmup": 8
+        }
+      ]
+    },
+    "resize-storm": {
+      "note": "28 canvas widgets + repeated viewport resizes: shared ResizeObserver reallocates every canvas in one task (rank 1, the fullscreen enter/exit storm)",
+      "agg": {
+        "longTaskCount": {
+          "median": 29,
+          "p95": 30,
+          "all": [
+            28,
+            29,
+            30
+          ]
+        },
+        "longTaskMaxMs": {
+          "median": 183,
+          "p95": 247,
+          "all": [
+            183,
+            177,
+            247
+          ]
+        },
+        "blockingTimeMs": {
+          "median": 1774,
+          "p95": 1787,
+          "all": [
+            1787,
+            1774,
+            1703
+          ]
+        },
+        "taskLatencyMaxMs": {
+          "median": 328,
+          "p95": 337,
+          "all": [
+            311,
+            337,
+            328
+          ]
+        },
+        "taskLatencyP95Ms": {
+          "median": 173,
+          "p95": 174,
+          "all": [
+            174,
+            173,
+            157
+          ]
+        },
+        "frameMaxGapMs": {
+          "median": 200,
+          "p95": 241,
+          "all": [
+            200,
+            200,
+            241
+          ]
+        },
+        "framesDropped": {
+          "median": 29,
+          "p95": 30,
+          "all": [
+            28,
+            29,
+            30
+          ]
+        },
+        "heapSlopeKBps": {
+          "median": -61,
+          "p95": 131,
+          "all": [
+            131,
+            -67,
+            -61
+          ]
+        },
+        "heapGrowthMB": {
+          "median": -1,
+          "p95": 1,
+          "all": [
+            1,
+            -1,
+            -1
+          ]
+        },
+        "deltasSent": {
+          "median": 14,
+          "p95": 28,
+          "all": [
+            28,
+            14,
+            14
+          ]
+        },
+        "widgetCount": {
+          "median": 28,
+          "p95": 28,
+          "all": [
+            28,
+            28,
+            28
+          ]
+        }
+      },
+      "raw": [
+        {
+          "windowMs": 7182,
+          "longTasks": {
+            "count": 28,
+            "totalMs": 3187,
+            "maxMs": 183,
+            "blockingTimeMs": 1787
+          },
+          "taskLatencyMs": {
+            "samples": 210,
+            "maxMs": 311,
+            "p95Ms": 174
+          },
+          "frames": {
+            "samples": 446,
+            "maxGapMs": 200,
+            "p95GapMs": 108,
+            "droppedOver50ms": 28
+          },
+          "heap": {
+            "samples": 23,
+            "firstBytes": 15980591,
+            "lastBytes": 17430038,
+            "slopeBytesPerSec": 133668
+          },
+          "marks": {},
+          "deltasSent": 28,
+          "widgetCount": 28,
+          "streamedDuringWarmup": 10
+        },
+        {
+          "windowMs": 7203,
+          "longTasks": {
+            "count": 29,
+            "totalMs": 3224,
+            "maxMs": 177,
+            "blockingTimeMs": 1774
+          },
+          "taskLatencyMs": {
+            "samples": 212,
+            "maxMs": 337,
+            "p95Ms": 173
+          },
+          "frames": {
+            "samples": 448,
+            "maxGapMs": 200,
+            "p95GapMs": 92,
+            "droppedOver50ms": 29
+          },
+          "heap": {
+            "samples": 23,
+            "firstBytes": 16438783,
+            "lastBytes": 15697107,
+            "slopeBytesPerSec": -68559
+          },
+          "marks": {},
+          "deltasSent": 14,
+          "widgetCount": 28,
+          "streamedDuringWarmup": 5
+        },
+        {
+          "windowMs": 7142,
+          "longTasks": {
+            "count": 30,
+            "totalMs": 3203,
+            "maxMs": 247,
+            "blockingTimeMs": 1703
+          },
+          "taskLatencyMs": {
+            "samples": 216,
+            "maxMs": 328,
+            "p95Ms": 157
+          },
+          "frames": {
+            "samples": 458,
+            "maxGapMs": 241,
+            "p95GapMs": 92,
+            "droppedOver50ms": 30
+          },
+          "heap": {
+            "samples": 22,
+            "firstBytes": 16439607,
+            "lastBytes": 15783458,
+            "slopeBytesPerSec": -62648
+          },
+          "marks": {},
+          "deltasSent": 14,
+          "widgetCount": 28,
+          "streamedDuringWarmup": 5
+        }
+      ]
+    },
+    "ais-radar-150": {
+      "note": "150 AIS targets @ 4Hz + streaming own-ship (ranks 4/5, radar render loops)",
+      "agg": {
+        "longTaskCount": {
+          "median": 45,
+          "p95": 50,
+          "all": [
+            50,
+            44,
+            45
+          ]
+        },
+        "longTaskMaxMs": {
+          "median": 530,
+          "p95": 593,
+          "all": [
+            530,
+            593,
+            485
+          ]
+        },
+        "blockingTimeMs": {
+          "median": 7215,
+          "p95": 7419,
+          "all": [
+            4813,
+            7215,
+            7419
+          ]
+        },
+        "taskLatencyMaxMs": {
+          "median": 1025,
+          "p95": 1312,
+          "all": [
+            619,
+            1312,
+            1025
+          ]
+        },
+        "taskLatencyP95Ms": {
+          "median": 723,
+          "p95": 921,
+          "all": [
+            255,
+            921,
+            723
+          ]
+        },
+        "frameMaxGapMs": {
+          "median": 582,
+          "p95": 700,
+          "all": [
+            573,
+            700,
+            582
+          ]
+        },
+        "framesDropped": {
+          "median": 47,
+          "p95": 50,
+          "all": [
+            50,
+            47,
+            46
+          ]
+        },
+        "heapSlopeKBps": {
+          "median": 284,
+          "p95": 469,
+          "all": [
+            469,
+            284,
+            245
+          ]
+        },
+        "heapGrowthMB": {
+          "median": 4,
+          "p95": 7,
+          "all": [
+            7,
+            4,
+            4
+          ]
+        },
+        "deltasSent": {
+          "median": 7248,
+          "p95": 7248,
+          "all": [
+            3624,
+            7248,
+            7248
+          ]
+        },
+        "widgetCount": {
+          "median": 1,
+          "p95": 1,
+          "all": [
+            1,
+            1,
+            1
+          ]
+        }
+      },
+      "raw": [
+        {
+          "windowMs": 12043,
+          "longTasks": {
+            "count": 50,
+            "totalMs": 7313,
+            "maxMs": 530,
+            "blockingTimeMs": 4813
+          },
+          "taskLatencyMs": {
+            "samples": 211,
+            "maxMs": 619,
+            "p95Ms": 255
+          },
+          "frames": {
+            "samples": 453,
+            "maxGapMs": 573,
+            "p95GapMs": 151,
+            "droppedOver50ms": 50
+          },
+          "heap": {
+            "samples": 32,
+            "firstBytes": 14218632,
+            "lastBytes": 21844686,
+            "slopeBytesPerSec": 480012
+          },
+          "marks": {},
+          "deltasSent": 3624,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 906
+        },
+        {
+          "windowMs": 12154,
+          "longTasks": {
+            "count": 44,
+            "totalMs": 9415,
+            "maxMs": 593,
+            "blockingTimeMs": 7215
+          },
+          "taskLatencyMs": {
+            "samples": 33,
+            "maxMs": 1312,
+            "p95Ms": 921
+          },
+          "frames": {
+            "samples": 49,
+            "maxGapMs": 700,
+            "p95GapMs": 583,
+            "droppedOver50ms": 47
+          },
+          "heap": {
+            "samples": 27,
+            "firstBytes": 13838136,
+            "lastBytes": 18482014,
+            "slopeBytesPerSec": 290397
+          },
+          "marks": {},
+          "deltasSent": 7248,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 1963
+        },
+        {
+          "windowMs": 12100,
+          "longTasks": {
+            "count": 45,
+            "totalMs": 9669,
+            "maxMs": 485,
+            "blockingTimeMs": 7419
+          },
+          "taskLatencyMs": {
+            "samples": 31,
+            "maxMs": 1025,
+            "p95Ms": 723
+          },
+          "frames": {
+            "samples": 46,
+            "maxGapMs": 582,
+            "p95GapMs": 534,
+            "droppedOver50ms": 46
+          },
+          "heap": {
+            "samples": 28,
+            "firstBytes": 13825972,
+            "lastBytes": 17950334,
+            "slopeBytesPerSec": 250846
+          },
+          "marks": {},
+          "deltasSent": 7248,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 2114
+        }
+      ]
+    },
+    "gauges-16": {
+      "note": "16 radial ng-canvas-gauges @ 4Hz (rank 7, animation duty cycle)",
+      "agg": {
+        "longTaskCount": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0
+          ]
+        },
+        "longTaskMaxMs": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0
+          ]
+        },
+        "blockingTimeMs": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0
+          ]
+        },
+        "taskLatencyMaxMs": {
+          "median": 35,
+          "p95": 51,
+          "all": [
+            35,
+            51,
+            31
+          ]
+        },
+        "taskLatencyP95Ms": {
+          "median": 11,
+          "p95": 12,
+          "all": [
+            11,
+            12,
+            11
+          ]
+        },
+        "frameMaxGapMs": {
+          "median": 42,
+          "p95": 51,
+          "all": [
+            33,
+            51,
+            42
+          ]
+        },
+        "framesDropped": {
+          "median": 0,
+          "p95": 1,
+          "all": [
+            0,
+            1,
+            0
+          ]
+        },
+        "heapSlopeKBps": {
+          "median": 85,
+          "p95": 116,
+          "all": [
+            85,
+            -1,
+            116
+          ]
+        },
+        "heapGrowthMB": {
+          "median": 1,
+          "p95": 1,
+          "all": [
+            1,
+            0,
+            1
+          ]
+        },
+        "deltasSent": {
+          "median": 40,
+          "p95": 40,
+          "all": [
+            40,
+            40,
+            39
+          ]
+        },
+        "widgetCount": {
+          "median": 16,
+          "p95": 16,
+          "all": [
+            16,
+            16,
+            16
+          ]
+        }
+      },
+      "raw": [
+        {
+          "windowMs": 10016,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 488,
+            "maxMs": 35,
+            "p95Ms": 11
+          },
+          "frames": {
+            "samples": 1186,
+            "maxGapMs": 33,
+            "p95GapMs": 10,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 27,
+            "firstBytes": 15170493,
+            "lastBytes": 16267827,
+            "slopeBytesPerSec": 86554
+          },
+          "marks": {},
+          "deltasSent": 40,
+          "widgetCount": 16,
+          "streamedDuringWarmup": 8
+        },
+        {
+          "windowMs": 10014,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 473,
+            "maxMs": 51,
+            "p95Ms": 12
+          },
+          "frames": {
+            "samples": 1192,
+            "maxGapMs": 51,
+            "p95GapMs": 10,
+            "droppedOver50ms": 1
+          },
+          "heap": {
+            "samples": 27,
+            "firstBytes": 15215201,
+            "lastBytes": 15203888,
+            "slopeBytesPerSec": -895
+          },
+          "marks": {},
+          "deltasSent": 40,
+          "widgetCount": 16,
+          "streamedDuringWarmup": 8
+        },
+        {
+          "windowMs": 10015,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 487,
+            "maxMs": 31,
+            "p95Ms": 11
+          },
+          "frames": {
+            "samples": 1192,
+            "maxGapMs": 42,
+            "p95GapMs": 10,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 27,
+            "firstBytes": 15239065,
+            "lastBytes": 16736537,
+            "slopeBytesPerSec": 118534
+          },
+          "marks": {},
+          "deltasSent": 39,
+          "widgetCount": 16,
+          "streamedDuringWarmup": 8
+        }
+      ]
+    },
+    "ais-growth-churn": {
+      "note": "AIS radar with 40 targets + 40 new MMSIs/sec churn for 30s (ranks 8/9, heap growth)",
+      "agg": {
+        "longTaskCount": {
+          "median": 44,
+          "p95": 46,
+          "all": [
+            44,
+            46,
+            23
+          ]
+        },
+        "longTaskMaxMs": {
+          "median": 5636,
+          "p95": 11253,
+          "all": [
+            2654,
+            11253,
+            5636
+          ]
+        },
+        "blockingTimeMs": {
+          "median": 23973,
+          "p95": 35484,
+          "all": [
+            23973,
+            35484,
+            19385
+          ]
+        },
+        "taskLatencyMaxMs": {
+          "median": 6486,
+          "p95": 15052,
+          "all": [
+            3358,
+            6486,
+            15052
+          ]
+        },
+        "taskLatencyP95Ms": {
+          "median": 2942,
+          "p95": 15052,
+          "all": [
+            2942,
+            2002,
+            15052
+          ]
+        },
+        "frameMaxGapMs": {
+          "median": 8893,
+          "p95": 11349,
+          "all": [
+            2883,
+            11349,
+            8893
+          ]
+        },
+        "framesDropped": {
+          "median": 46,
+          "p95": 47,
+          "all": [
+            46,
+            47,
+            25
+          ]
+        },
+        "heapSlopeKBps": {
+          "median": 212,
+          "p95": 295,
+          "all": [
+            212,
+            295,
+            178
+          ]
+        },
+        "heapGrowthMB": {
+          "median": 7,
+          "p95": 13,
+          "all": [
+            7,
+            13,
+            6
+          ]
+        },
+        "deltasSent": {
+          "median": 7693,
+          "p95": 14945,
+          "all": [
+            7497,
+            14945,
+            7693
+          ]
+        },
+        "widgetCount": {
+          "median": 1,
+          "p95": 1,
+          "all": [
+            1,
+            1,
+            1
+          ]
+        }
+      },
+      "raw": [
+        {
+          "windowMs": 38383,
+          "longTasks": {
+            "count": 44,
+            "totalMs": 26173,
+            "maxMs": 2654,
+            "blockingTimeMs": 23973
+          },
+          "taskLatencyMs": {
+            "samples": 32,
+            "maxMs": 3358,
+            "p95Ms": 2942
+          },
+          "frames": {
+            "samples": 46,
+            "maxGapMs": 2883,
+            "p95GapMs": 1866,
+            "droppedOver50ms": 46
+          },
+          "heap": {
+            "samples": 29,
+            "firstBytes": 14208308,
+            "lastBytes": 22022197,
+            "slopeBytesPerSec": 216858
+          },
+          "marks": {},
+          "deltasSent": 7497,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 637
+        },
+        {
+          "windowMs": 61532,
+          "longTasks": {
+            "count": 46,
+            "totalMs": 37784,
+            "maxMs": 11253,
+            "blockingTimeMs": 35484
+          },
+          "taskLatencyMs": {
+            "samples": 32,
+            "maxMs": 6486,
+            "p95Ms": 2002
+          },
+          "frames": {
+            "samples": 48,
+            "maxGapMs": 11349,
+            "p95GapMs": 2235,
+            "droppedOver50ms": 47
+          },
+          "heap": {
+            "samples": 30,
+            "firstBytes": 13855372,
+            "lastBytes": 27484848,
+            "slopeBytesPerSec": 302466
+          },
+          "marks": {},
+          "deltasSent": 14945,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 784
+        },
+        {
+          "windowMs": 31556,
+          "longTasks": {
+            "count": 23,
+            "totalMs": 20535,
+            "maxMs": 5636,
+            "blockingTimeMs": 19385
+          },
+          "taskLatencyMs": {
+            "samples": 17,
+            "maxMs": 15052,
+            "p95Ms": 15052
+          },
+          "frames": {
+            "samples": 26,
+            "maxGapMs": 8893,
+            "p95GapMs": 5741,
+            "droppedOver50ms": 25
+          },
+          "heap": {
+            "samples": 21,
+            "firstBytes": 14277872,
+            "lastBytes": 20617833,
+            "slopeBytesPerSec": 182111
+          },
+          "marks": {},
+          "deltasSent": 7693,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 784
+        }
+      ]
+    }
+  }
+}

--- a/perf-harness/results/perf-preview.json
+++ b/perf-harness/results/perf-preview.json
@@ -1,0 +1,1381 @@
+{
+  "label": "perf-preview",
+  "branch": "integration/perf-preview",
+  "throttle": 10,
+  "repeats": 3,
+  "chrome": "149.0.7827.201",
+  "scenarios": {
+    "idle-numeric-24": {
+      "note": "baseline render/CD load: 24 numeric widgets, low data rate (WS4 baseline)",
+      "agg": {
+        "longTaskCount": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0
+          ]
+        },
+        "longTaskMaxMs": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0
+          ]
+        },
+        "blockingTimeMs": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0
+          ]
+        },
+        "taskLatencyMaxMs": {
+          "median": 4,
+          "p95": 4,
+          "all": [
+            4,
+            3,
+            4
+          ]
+        },
+        "taskLatencyP95Ms": {
+          "median": 3,
+          "p95": 3,
+          "all": [
+            3,
+            2,
+            3
+          ]
+        },
+        "frameMaxGapMs": {
+          "median": 10,
+          "p95": 10,
+          "all": [
+            10,
+            10,
+            10
+          ]
+        },
+        "framesDropped": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0
+          ]
+        },
+        "heapSlopeKBps": {
+          "median": 135,
+          "p95": 192,
+          "all": [
+            192,
+            135,
+            132
+          ]
+        },
+        "heapGrowthMB": {
+          "median": 1,
+          "p95": 2,
+          "all": [
+            2,
+            1,
+            1
+          ]
+        },
+        "deltasSent": {
+          "median": 16,
+          "p95": 79,
+          "all": [
+            79,
+            16,
+            16
+          ]
+        },
+        "widgetCount": {
+          "median": 24,
+          "p95": 24,
+          "all": [
+            24,
+            24,
+            24
+          ]
+        }
+      },
+      "raw": [
+        {
+          "windowMs": 8004,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 457,
+            "maxMs": 4,
+            "p95Ms": 3
+          },
+          "frames": {
+            "samples": 961,
+            "maxGapMs": 10,
+            "p95GapMs": 10,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 24,
+            "firstBytes": 12149258,
+            "lastBytes": 14359466,
+            "slopeBytesPerSec": 196632
+          },
+          "marks": {},
+          "deltasSent": 79,
+          "widgetCount": 24,
+          "streamedDuringWarmup": 20
+        },
+        {
+          "windowMs": 8008,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 460,
+            "maxMs": 3,
+            "p95Ms": 2
+          },
+          "frames": {
+            "samples": 961,
+            "maxGapMs": 10,
+            "p95GapMs": 10,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 24,
+            "firstBytes": 12155130,
+            "lastBytes": 13705911,
+            "slopeBytesPerSec": 137759
+          },
+          "marks": {},
+          "deltasSent": 16,
+          "widgetCount": 24,
+          "streamedDuringWarmup": 4
+        },
+        {
+          "windowMs": 8006,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 454,
+            "maxMs": 4,
+            "p95Ms": 3
+          },
+          "frames": {
+            "samples": 960,
+            "maxGapMs": 10,
+            "p95GapMs": 10,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 24,
+            "firstBytes": 12171666,
+            "lastBytes": 13697371,
+            "slopeBytesPerSec": 135398
+          },
+          "marks": {},
+          "deltasSent": 16,
+          "widgetCount": 24,
+          "streamedDuringWarmup": 4
+        }
+      ]
+    },
+    "delta-storm-30x10": {
+      "note": "sustained ingestion: 30 paths @ 10Hz over a numeric+gauge dashboard (rank 2, delta coalescing)",
+      "agg": {
+        "longTaskCount": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0
+          ]
+        },
+        "longTaskMaxMs": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0
+          ]
+        },
+        "blockingTimeMs": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0
+          ]
+        },
+        "taskLatencyMaxMs": {
+          "median": 3,
+          "p95": 6,
+          "all": [
+            3,
+            6,
+            3
+          ]
+        },
+        "taskLatencyP95Ms": {
+          "median": 2,
+          "p95": 3,
+          "all": [
+            3,
+            2,
+            2
+          ]
+        },
+        "frameMaxGapMs": {
+          "median": 10,
+          "p95": 10,
+          "all": [
+            10,
+            10,
+            10
+          ]
+        },
+        "framesDropped": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0
+          ]
+        },
+        "heapSlopeKBps": {
+          "median": 93,
+          "p95": 129,
+          "all": [
+            129,
+            89,
+            93
+          ]
+        },
+        "heapGrowthMB": {
+          "median": 1,
+          "p95": 2,
+          "all": [
+            2,
+            1,
+            1
+          ]
+        },
+        "deltasSent": {
+          "median": 118,
+          "p95": 119,
+          "all": [
+            24,
+            118,
+            119
+          ]
+        },
+        "widgetCount": {
+          "median": 20,
+          "p95": 20,
+          "all": [
+            20,
+            20,
+            20
+          ]
+        }
+      },
+      "raw": [
+        {
+          "windowMs": 12002,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 687,
+            "maxMs": 3,
+            "p95Ms": 3
+          },
+          "frames": {
+            "samples": 1440,
+            "maxGapMs": 10,
+            "p95GapMs": 10,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 32,
+            "firstBytes": 11966202,
+            "lastBytes": 13990942,
+            "slopeBytesPerSec": 132603
+          },
+          "marks": {},
+          "deltasSent": 24,
+          "widgetCount": 20,
+          "streamedDuringWarmup": 4
+        },
+        {
+          "windowMs": 12005,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 687,
+            "maxMs": 6,
+            "p95Ms": 2
+          },
+          "frames": {
+            "samples": 1441,
+            "maxGapMs": 10,
+            "p95GapMs": 10,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 32,
+            "firstBytes": 11980210,
+            "lastBytes": 13379601,
+            "slopeBytesPerSec": 91462
+          },
+          "marks": {},
+          "deltasSent": 118,
+          "widgetCount": 20,
+          "streamedDuringWarmup": 20
+        },
+        {
+          "windowMs": 12006,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 687,
+            "maxMs": 3,
+            "p95Ms": 2
+          },
+          "frames": {
+            "samples": 1441,
+            "maxGapMs": 10,
+            "p95GapMs": 10,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 32,
+            "firstBytes": 11928222,
+            "lastBytes": 13385686,
+            "slopeBytesPerSec": 95523
+          },
+          "marks": {},
+          "deltasSent": 119,
+          "widgetCount": 20,
+          "streamedDuringWarmup": 20
+        }
+      ]
+    },
+    "reconnect-backlog": {
+      "note": "reconnect snapshot: one frame carrying 6000 values (rank 2, single synchronous parse+fan-out long task)",
+      "agg": {
+        "longTaskCount": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0
+          ]
+        },
+        "longTaskMaxMs": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0
+          ]
+        },
+        "blockingTimeMs": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0
+          ]
+        },
+        "taskLatencyMaxMs": {
+          "median": 49,
+          "p95": 58,
+          "all": [
+            58,
+            49,
+            46
+          ]
+        },
+        "taskLatencyP95Ms": {
+          "median": 3,
+          "p95": 3,
+          "all": [
+            3,
+            3,
+            2
+          ]
+        },
+        "frameMaxGapMs": {
+          "median": 50,
+          "p95": 50,
+          "all": [
+            50,
+            40,
+            50
+          ]
+        },
+        "framesDropped": {
+          "median": 0,
+          "p95": 1,
+          "all": [
+            0,
+            0,
+            1
+          ]
+        },
+        "heapSlopeKBps": {
+          "median": 311,
+          "p95": 402,
+          "all": [
+            402,
+            292,
+            311
+          ]
+        },
+        "heapGrowthMB": {
+          "median": 3,
+          "p95": 4,
+          "all": [
+            4,
+            3,
+            3
+          ]
+        },
+        "deltasSent": {
+          "median": 29,
+          "p95": 70,
+          "all": [
+            70,
+            29,
+            29
+          ]
+        },
+        "widgetCount": {
+          "median": 20,
+          "p95": 20,
+          "all": [
+            20,
+            20,
+            20
+          ]
+        }
+      },
+      "raw": [
+        {
+          "windowMs": 7007,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 396,
+            "maxMs": 58,
+            "p95Ms": 3
+          },
+          "frames": {
+            "samples": 836,
+            "maxGapMs": 50,
+            "p95GapMs": 10,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 22,
+            "firstBytes": 11950126,
+            "lastBytes": 16164164,
+            "slopeBytesPerSec": 411463
+          },
+          "marks": {},
+          "deltasSent": 70,
+          "widgetCount": 20,
+          "streamedDuringWarmup": 20
+        },
+        {
+          "windowMs": 7010,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 399,
+            "maxMs": 49,
+            "p95Ms": 3
+          },
+          "frames": {
+            "samples": 837,
+            "maxGapMs": 40,
+            "p95GapMs": 10,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 22,
+            "firstBytes": 11946194,
+            "lastBytes": 15021167,
+            "slopeBytesPerSec": 299017
+          },
+          "marks": {},
+          "deltasSent": 29,
+          "widgetCount": 20,
+          "streamedDuringWarmup": 8
+        },
+        {
+          "windowMs": 7011,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 400,
+            "maxMs": 46,
+            "p95Ms": 2
+          },
+          "frames": {
+            "samples": 836,
+            "maxGapMs": 50,
+            "p95GapMs": 10,
+            "droppedOver50ms": 1
+          },
+          "heap": {
+            "samples": 22,
+            "firstBytes": 11913174,
+            "lastBytes": 15158238,
+            "slopeBytesPerSec": 318000
+          },
+          "marks": {},
+          "deltasSent": 29,
+          "widgetCount": 20,
+          "streamedDuringWarmup": 8
+        }
+      ]
+    },
+    "resize-storm": {
+      "note": "28 canvas widgets + repeated viewport resizes: shared ResizeObserver reallocates every canvas in one task (rank 1, the fullscreen enter/exit storm)",
+      "agg": {
+        "longTaskCount": {
+          "median": 42,
+          "p95": 43,
+          "all": [
+            39,
+            43,
+            42
+          ]
+        },
+        "longTaskMaxMs": {
+          "median": 148,
+          "p95": 154,
+          "all": [
+            154,
+            135,
+            148
+          ]
+        },
+        "blockingTimeMs": {
+          "median": 1097,
+          "p95": 1149,
+          "all": [
+            1034,
+            1149,
+            1097
+          ]
+        },
+        "taskLatencyMaxMs": {
+          "median": 263,
+          "p95": 271,
+          "all": [
+            263,
+            210,
+            271
+          ]
+        },
+        "taskLatencyP95Ms": {
+          "median": 140,
+          "p95": 140,
+          "all": [
+            138,
+            140,
+            140
+          ]
+        },
+        "frameMaxGapMs": {
+          "median": 175,
+          "p95": 177,
+          "all": [
+            177,
+            175,
+            168
+          ]
+        },
+        "framesDropped": {
+          "median": 44,
+          "p95": 45,
+          "all": [
+            44,
+            43,
+            45
+          ]
+        },
+        "heapSlopeKBps": {
+          "median": 127,
+          "p95": 150,
+          "all": [
+            100,
+            150,
+            127
+          ]
+        },
+        "heapGrowthMB": {
+          "median": 1,
+          "p95": 2,
+          "all": [
+            1,
+            2,
+            1
+          ]
+        },
+        "deltasSent": {
+          "median": 14,
+          "p95": 29,
+          "all": [
+            29,
+            14,
+            14
+          ]
+        },
+        "widgetCount": {
+          "median": 28,
+          "p95": 28,
+          "all": [
+            28,
+            28,
+            28
+          ]
+        }
+      },
+      "raw": [
+        {
+          "windowMs": 7275,
+          "longTasks": {
+            "count": 39,
+            "totalMs": 2984,
+            "maxMs": 154,
+            "blockingTimeMs": 1034
+          },
+          "taskLatencyMs": {
+            "samples": 210,
+            "maxMs": 263,
+            "p95Ms": 138
+          },
+          "frames": {
+            "samples": 443,
+            "maxGapMs": 177,
+            "p95GapMs": 82,
+            "droppedOver50ms": 44
+          },
+          "heap": {
+            "samples": 23,
+            "firstBytes": 12323146,
+            "lastBytes": 13422904,
+            "slopeBytesPerSec": 102038
+          },
+          "marks": {},
+          "deltasSent": 29,
+          "widgetCount": 28,
+          "streamedDuringWarmup": 10
+        },
+        {
+          "windowMs": 7247,
+          "longTasks": {
+            "count": 43,
+            "totalMs": 3299,
+            "maxMs": 135,
+            "blockingTimeMs": 1149
+          },
+          "taskLatencyMs": {
+            "samples": 206,
+            "maxMs": 210,
+            "p95Ms": 140
+          },
+          "frames": {
+            "samples": 434,
+            "maxGapMs": 175,
+            "p95GapMs": 83,
+            "droppedOver50ms": 43
+          },
+          "heap": {
+            "samples": 23,
+            "firstBytes": 11471590,
+            "lastBytes": 13120975,
+            "slopeBytesPerSec": 153267
+          },
+          "marks": {},
+          "deltasSent": 14,
+          "widgetCount": 28,
+          "streamedDuringWarmup": 5
+        },
+        {
+          "windowMs": 7290,
+          "longTasks": {
+            "count": 42,
+            "totalMs": 3197,
+            "maxMs": 148,
+            "blockingTimeMs": 1097
+          },
+          "taskLatencyMs": {
+            "samples": 203,
+            "maxMs": 271,
+            "p95Ms": 140
+          },
+          "frames": {
+            "samples": 432,
+            "maxGapMs": 168,
+            "p95GapMs": 83,
+            "droppedOver50ms": 45
+          },
+          "heap": {
+            "samples": 23,
+            "firstBytes": 11472470,
+            "lastBytes": 12866523,
+            "slopeBytesPerSec": 129876
+          },
+          "marks": {},
+          "deltasSent": 14,
+          "widgetCount": 28,
+          "streamedDuringWarmup": 5
+        }
+      ]
+    },
+    "ais-radar-150": {
+      "note": "150 AIS targets @ 4Hz + streaming own-ship (ranks 4/5, radar render loops)",
+      "agg": {
+        "longTaskCount": {
+          "median": 17,
+          "p95": 35,
+          "all": [
+            35,
+            16,
+            17
+          ]
+        },
+        "longTaskMaxMs": {
+          "median": 1567,
+          "p95": 1787,
+          "all": [
+            164,
+            1567,
+            1787
+          ]
+        },
+        "blockingTimeMs": {
+          "median": 9690,
+          "p95": 11706,
+          "all": [
+            1629,
+            9690,
+            11706
+          ]
+        },
+        "taskLatencyMaxMs": {
+          "median": 3436,
+          "p95": 4263,
+          "all": [
+            206,
+            4263,
+            3436
+          ]
+        },
+        "taskLatencyP95Ms": {
+          "median": 3436,
+          "p95": 4263,
+          "all": [
+            109,
+            4263,
+            3436
+          ]
+        },
+        "frameMaxGapMs": {
+          "median": 1892,
+          "p95": 2008,
+          "all": [
+            209,
+            2008,
+            1892
+          ]
+        },
+        "framesDropped": {
+          "median": 17,
+          "p95": 35,
+          "all": [
+            35,
+            17,
+            17
+          ]
+        },
+        "heapSlopeKBps": {
+          "median": 749,
+          "p95": 829,
+          "all": [
+            201,
+            829,
+            749
+          ]
+        },
+        "heapGrowthMB": {
+          "median": 13,
+          "p95": 13,
+          "all": [
+            3,
+            13,
+            13
+          ]
+        },
+        "deltasSent": {
+          "median": 9513,
+          "p95": 9513,
+          "all": [
+            3624,
+            9513,
+            9513
+          ]
+        },
+        "widgetCount": {
+          "median": 1,
+          "p95": 1,
+          "all": [
+            1,
+            1,
+            1
+          ]
+        }
+      },
+      "raw": [
+        {
+          "windowMs": 12009,
+          "longTasks": {
+            "count": 35,
+            "totalMs": 3379,
+            "maxMs": 164,
+            "blockingTimeMs": 1629
+          },
+          "taskLatencyMs": {
+            "samples": 416,
+            "maxMs": 206,
+            "p95Ms": 109
+          },
+          "frames": {
+            "samples": 872,
+            "maxGapMs": 209,
+            "p95GapMs": 42,
+            "droppedOver50ms": 35
+          },
+          "heap": {
+            "samples": 33,
+            "firstBytes": 10948003,
+            "lastBytes": 14215159,
+            "slopeBytesPerSec": 205399
+          },
+          "marks": {},
+          "deltasSent": 3624,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 906
+        },
+        {
+          "windowMs": 15849,
+          "longTasks": {
+            "count": 16,
+            "totalMs": 10490,
+            "maxMs": 1567,
+            "blockingTimeMs": 9690
+          },
+          "taskLatencyMs": {
+            "samples": 13,
+            "maxMs": 4263,
+            "p95Ms": 4263
+          },
+          "frames": {
+            "samples": 17,
+            "maxGapMs": 2008,
+            "p95GapMs": 2008,
+            "droppedOver50ms": 17
+          },
+          "heap": {
+            "samples": 17,
+            "firstBytes": 10904623,
+            "lastBytes": 24360986,
+            "slopeBytesPerSec": 848768
+          },
+          "marks": {},
+          "deltasSent": 9513,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 1963
+        },
+        {
+          "windowMs": 15693,
+          "longTasks": {
+            "count": 17,
+            "totalMs": 12556,
+            "maxMs": 1787,
+            "blockingTimeMs": 11706
+          },
+          "taskLatencyMs": {
+            "samples": 12,
+            "maxMs": 3436,
+            "p95Ms": 3436
+          },
+          "frames": {
+            "samples": 17,
+            "maxGapMs": 1892,
+            "p95GapMs": 1892,
+            "droppedOver50ms": 17
+          },
+          "heap": {
+            "samples": 17,
+            "firstBytes": 10917319,
+            "lastBytes": 24860474,
+            "slopeBytesPerSec": 766954
+          },
+          "marks": {},
+          "deltasSent": 9513,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 1963
+        }
+      ]
+    },
+    "gauges-16": {
+      "note": "16 radial ng-canvas-gauges @ 4Hz (rank 7, animation duty cycle)",
+      "agg": {
+        "longTaskCount": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0
+          ]
+        },
+        "longTaskMaxMs": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0
+          ]
+        },
+        "blockingTimeMs": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0
+          ]
+        },
+        "taskLatencyMaxMs": {
+          "median": 36,
+          "p95": 43,
+          "all": [
+            43,
+            36,
+            28
+          ]
+        },
+        "taskLatencyP95Ms": {
+          "median": 12,
+          "p95": 12,
+          "all": [
+            12,
+            10,
+            12
+          ]
+        },
+        "frameMaxGapMs": {
+          "median": 27,
+          "p95": 42,
+          "all": [
+            42,
+            26,
+            27
+          ]
+        },
+        "framesDropped": {
+          "median": 0,
+          "p95": 0,
+          "all": [
+            0,
+            0,
+            0
+          ]
+        },
+        "heapSlopeKBps": {
+          "median": 128,
+          "p95": 193,
+          "all": [
+            26,
+            128,
+            193
+          ]
+        },
+        "heapGrowthMB": {
+          "median": 2,
+          "p95": 2,
+          "all": [
+            0,
+            2,
+            2
+          ]
+        },
+        "deltasSent": {
+          "median": 39,
+          "p95": 40,
+          "all": [
+            39,
+            39,
+            40
+          ]
+        },
+        "widgetCount": {
+          "median": 16,
+          "p95": 16,
+          "all": [
+            16,
+            16,
+            16
+          ]
+        }
+      },
+      "raw": [
+        {
+          "windowMs": 10013,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 481,
+            "maxMs": 43,
+            "p95Ms": 12
+          },
+          "frames": {
+            "samples": 1191,
+            "maxGapMs": 42,
+            "p95GapMs": 10,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 27,
+            "firstBytes": 11589414,
+            "lastBytes": 11932723,
+            "slopeBytesPerSec": 26738
+          },
+          "marks": {},
+          "deltasSent": 39,
+          "widgetCount": 16,
+          "streamedDuringWarmup": 8
+        },
+        {
+          "windowMs": 10006,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 497,
+            "maxMs": 36,
+            "p95Ms": 10
+          },
+          "frames": {
+            "samples": 1194,
+            "maxGapMs": 26,
+            "p95GapMs": 10,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 27,
+            "firstBytes": 11798198,
+            "lastBytes": 13478278,
+            "slopeBytesPerSec": 131263
+          },
+          "marks": {},
+          "deltasSent": 39,
+          "widgetCount": 16,
+          "streamedDuringWarmup": 8
+        },
+        {
+          "windowMs": 10011,
+          "longTasks": {
+            "count": 0,
+            "totalMs": 0,
+            "maxMs": 0,
+            "blockingTimeMs": 0
+          },
+          "taskLatencyMs": {
+            "samples": 485,
+            "maxMs": 28,
+            "p95Ms": 12
+          },
+          "frames": {
+            "samples": 1186,
+            "maxGapMs": 27,
+            "p95GapMs": 10,
+            "droppedOver50ms": 0
+          },
+          "heap": {
+            "samples": 27,
+            "firstBytes": 11775746,
+            "lastBytes": 14296736,
+            "slopeBytesPerSec": 197664
+          },
+          "marks": {},
+          "deltasSent": 40,
+          "widgetCount": 16,
+          "streamedDuringWarmup": 8
+        }
+      ]
+    },
+    "ais-growth-churn": {
+      "note": "AIS radar with 40 targets + 40 new MMSIs/sec churn for 30s (ranks 8/9, heap growth)",
+      "agg": {
+        "longTaskCount": {
+          "median": 30,
+          "p95": 40,
+          "all": [
+            30,
+            23,
+            40
+          ]
+        },
+        "longTaskMaxMs": {
+          "median": 3871,
+          "p95": 7241,
+          "all": [
+            3832,
+            7241,
+            3871
+          ]
+        },
+        "blockingTimeMs": {
+          "median": 26533,
+          "p95": 28851,
+          "all": [
+            24307,
+            28851,
+            26533
+          ]
+        },
+        "taskLatencyMaxMs": {
+          "median": 4036,
+          "p95": 12665,
+          "all": [
+            3940,
+            12665,
+            4036
+          ]
+        },
+        "taskLatencyP95Ms": {
+          "median": 3912,
+          "p95": 12665,
+          "all": [
+            3781,
+            12665,
+            3912
+          ]
+        },
+        "frameMaxGapMs": {
+          "median": 3976,
+          "p95": 7335,
+          "all": [
+            3924,
+            7335,
+            3976
+          ]
+        },
+        "framesDropped": {
+          "median": 32,
+          "p95": 41,
+          "all": [
+            32,
+            23,
+            41
+          ]
+        },
+        "heapSlopeKBps": {
+          "median": 263,
+          "p95": 385,
+          "all": [
+            207,
+            263,
+            385
+          ]
+        },
+        "heapGrowthMB": {
+          "median": 9,
+          "p95": 12,
+          "all": [
+            6,
+            9,
+            12
+          ]
+        },
+        "deltasSent": {
+          "median": 8330,
+          "p95": 10437,
+          "all": [
+            7693,
+            8330,
+            10437
+          ]
+        },
+        "widgetCount": {
+          "median": 1,
+          "p95": 1,
+          "all": [
+            1,
+            1,
+            1
+          ]
+        }
+      },
+      "raw": [
+        {
+          "windowMs": 39545,
+          "longTasks": {
+            "count": 30,
+            "totalMs": 25807,
+            "maxMs": 3832,
+            "blockingTimeMs": 24307
+          },
+          "taskLatencyMs": {
+            "samples": 21,
+            "maxMs": 3940,
+            "p95Ms": 3781
+          },
+          "frames": {
+            "samples": 33,
+            "maxGapMs": 3924,
+            "p95GapMs": 3560,
+            "droppedOver50ms": 32
+          },
+          "heap": {
+            "samples": 22,
+            "firstBytes": 10925035,
+            "lastBytes": 17692749,
+            "slopeBytesPerSec": 212303
+          },
+          "marks": {},
+          "deltasSent": 7693,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 588
+        },
+        {
+          "windowMs": 34290,
+          "longTasks": {
+            "count": 23,
+            "totalMs": 30001,
+            "maxMs": 7241,
+            "blockingTimeMs": 28851
+          },
+          "taskLatencyMs": {
+            "samples": 15,
+            "maxMs": 12665,
+            "p95Ms": 12665
+          },
+          "frames": {
+            "samples": 23,
+            "maxGapMs": 7335,
+            "p95GapMs": 5350,
+            "droppedOver50ms": 23
+          },
+          "heap": {
+            "samples": 20,
+            "firstBytes": 10975459,
+            "lastBytes": 20541458,
+            "slopeBytesPerSec": 269286
+          },
+          "marks": {},
+          "deltasSent": 8330,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 784
+        },
+        {
+          "windowMs": 43015,
+          "longTasks": {
+            "count": 40,
+            "totalMs": 28533,
+            "maxMs": 3871,
+            "blockingTimeMs": 26533
+          },
+          "taskLatencyMs": {
+            "samples": 28,
+            "maxMs": 4036,
+            "p95Ms": 3912
+          },
+          "frames": {
+            "samples": 41,
+            "maxGapMs": 3976,
+            "p95GapMs": 2190,
+            "droppedOver50ms": 41
+          },
+          "heap": {
+            "samples": 28,
+            "firstBytes": 10949027,
+            "lastBytes": 23210805,
+            "slopeBytesPerSec": 394219
+          },
+          "marks": {},
+          "deltasSent": 10437,
+          "widgetCount": 1,
+          "streamedDuringWarmup": 784
+        }
+      ]
+    }
+  }
+}

--- a/perf-harness/results/report-master-vs-perf-preview.md
+++ b/perf-harness/results/report-master-vs-perf-preview.md
@@ -1,0 +1,95 @@
+# Freeze metrics: master → perf-preview
+
+- CPU throttle: 10× (master) / 10× (perf-preview); repeats: 3/3; Chrome 149.0.7827.201
+- Values are **medians** across repeats. Lower is better for every metric.
+
+## idle-numeric-24
+_baseline render/CD load: 24 numeric widgets, low data rate (WS4 baseline)_
+
+| Metric | master | perf-preview | Δ |
+|---|--:|--:|--:|
+| Longest task (ms) | 0 | 0 | 0% |
+| Blocking time (ms) | 0 | 0 | 0% |
+| Max handler wait (ms) | 4 | 4 | 0% |
+| p95 handler wait (ms) | 3 | 3 | 0% |
+| Dropped frames | 0 | 0 | 0% |
+| Heap growth (MB) | 0 | 1 | +1 (was 0) |
+| _(context: widgets / deltas)_ | 24/16 | 24/16 | |
+
+## delta-storm-30x10
+_sustained ingestion: 30 paths @ 10Hz over a numeric+gauge dashboard (rank 2, delta coalescing)_
+
+| Metric | master | perf-preview | Δ |
+|---|--:|--:|--:|
+| Longest task (ms) | 0 | 0 | 0% |
+| Blocking time (ms) | 0 | 0 | 0% |
+| Max handler wait (ms) | 8 | 3 | -62% |
+| p95 handler wait (ms) | 3 | 2 | -33% |
+| Dropped frames | 0 | 0 | 0% |
+| Heap growth (MB) | 0 | 1 | +1 (was 0) |
+| _(context: widgets / deltas)_ | 20/119 | 20/118 | |
+
+## reconnect-backlog
+_reconnect snapshot: one frame carrying 6000 values (rank 2, single synchronous parse+fan-out long task)_
+
+| Metric | master | perf-preview | Δ |
+|---|--:|--:|--:|
+| Longest task (ms) | 0 | 0 | 0% |
+| Blocking time (ms) | 0 | 0 | 0% |
+| Max handler wait (ms) | 56 | 49 | -12% |
+| p95 handler wait (ms) | 3 | 3 | 0% |
+| Dropped frames | 0 | 0 | 0% |
+| Heap growth (MB) | 2 | 3 | +50% |
+| _(context: widgets / deltas)_ | 20/29 | 20/29 | |
+
+## resize-storm
+_28 canvas widgets + repeated viewport resizes: shared ResizeObserver reallocates every canvas in one task (rank 1, the fullscreen enter/exit storm)_
+
+| Metric | master | perf-preview | Δ |
+|---|--:|--:|--:|
+| Longest task (ms) | 183 | 148 | -19% |
+| Blocking time (ms) | 1774 | 1097 | -38% |
+| Max handler wait (ms) | 328 | 263 | -20% |
+| p95 handler wait (ms) | 173 | 140 | -19% |
+| Dropped frames | 29 | 44 | +52% |
+| Heap growth (MB) | -1 | 1 | +200% |
+| _(context: widgets / deltas)_ | 28/14 | 28/14 | |
+
+## ais-radar-150
+_150 AIS targets @ 4Hz + streaming own-ship (ranks 4/5, radar render loops)_
+
+| Metric | master | perf-preview | Δ |
+|---|--:|--:|--:|
+| Longest task (ms) | 530 | 1567 | +196% |
+| Blocking time (ms) | 7215 | 9690 | +34% |
+| Max handler wait (ms) | 1025 | 3436 | +235% |
+| p95 handler wait (ms) | 723 | 3436 | +375% |
+| Dropped frames | 47 | 17 | -64% |
+| Heap growth (MB) | 4 | 13 | +225% |
+| _(context: widgets / deltas)_ | 1/7248 | 1/9513 | |
+
+## gauges-16
+_16 radial ng-canvas-gauges @ 4Hz (rank 7, animation duty cycle)_
+
+| Metric | master | perf-preview | Δ |
+|---|--:|--:|--:|
+| Longest task (ms) | 0 | 0 | 0% |
+| Blocking time (ms) | 0 | 0 | 0% |
+| Max handler wait (ms) | 35 | 36 | +3% |
+| p95 handler wait (ms) | 11 | 12 | +9% |
+| Dropped frames | 0 | 0 | 0% |
+| Heap growth (MB) | 1 | 2 | +100% |
+| _(context: widgets / deltas)_ | 16/40 | 16/39 | |
+
+## ais-growth-churn
+_AIS radar with 40 targets + 40 new MMSIs/sec churn for 30s (ranks 8/9, heap growth)_
+
+| Metric | master | perf-preview | Δ |
+|---|--:|--:|--:|
+| Longest task (ms) | 5636 | 3871 | -31% |
+| Blocking time (ms) | 23973 | 26533 | +11% |
+| Max handler wait (ms) | 6486 | 4036 | -38% |
+| p95 handler wait (ms) | 2942 | 3912 | +33% |
+| Dropped frames | 46 | 32 | -30% |
+| Heap growth (MB) | 7 | 9 | +29% |
+| _(context: widgets / deltas)_ | 1/7693 | 1/8330 | |

--- a/perf-harness/results/report-perf-vs-freeze.md
+++ b/perf-harness/results/report-perf-vs-freeze.md
@@ -1,0 +1,95 @@
+# Freeze metrics: perf-preview → freeze-work-v1
+
+- CPU throttle: 10× (perf-preview) / 10× (freeze-work-v1); repeats: 3/3; Chrome 149.0.7827.201
+- Values are **medians** across repeats. Lower is better for every metric.
+
+## idle-numeric-24
+_baseline render/CD load: 24 numeric widgets, low data rate (WS4 baseline)_
+
+| Metric | perf-preview | freeze-work-v1 | Δ |
+|---|--:|--:|--:|
+| Longest task (ms) | 0 | 0 | 0% |
+| Blocking time (ms) | 0 | 0 | 0% |
+| Max handler wait (ms) | 4 | 4 | 0% |
+| p95 handler wait (ms) | 3 | 2 | -33% |
+| Dropped frames | 0 | 0 | 0% |
+| Heap growth (MB) | 1 | 1 | 0% |
+| _(context: widgets / deltas)_ | 24/16 | 24/16 | |
+
+## delta-storm-30x10
+_sustained ingestion: 30 paths @ 10Hz over a numeric+gauge dashboard (rank 2, delta coalescing)_
+
+| Metric | perf-preview | freeze-work-v1 | Δ |
+|---|--:|--:|--:|
+| Longest task (ms) | 0 | 0 | 0% |
+| Blocking time (ms) | 0 | 0 | 0% |
+| Max handler wait (ms) | 3 | 6 | +100% |
+| p95 handler wait (ms) | 2 | 2 | 0% |
+| Dropped frames | 0 | 0 | 0% |
+| Heap growth (MB) | 1 | 1 | 0% |
+| _(context: widgets / deltas)_ | 20/118 | 20/118 | |
+
+## reconnect-backlog
+_reconnect snapshot: one frame carrying 6000 values (rank 2, single synchronous parse+fan-out long task)_
+
+| Metric | perf-preview | freeze-work-v1 | Δ |
+|---|--:|--:|--:|
+| Longest task (ms) | 0 | 0 | 0% |
+| Blocking time (ms) | 0 | 0 | 0% |
+| Max handler wait (ms) | 49 | 46 | -6% |
+| p95 handler wait (ms) | 3 | 3 | 0% |
+| Dropped frames | 0 | 0 | 0% |
+| Heap growth (MB) | 3 | 3 | 0% |
+| _(context: widgets / deltas)_ | 20/29 | 20/29 | |
+
+## resize-storm
+_28 canvas widgets + repeated viewport resizes: shared ResizeObserver reallocates every canvas in one task (rank 1, the fullscreen enter/exit storm)_
+
+| Metric | perf-preview | freeze-work-v1 | Δ |
+|---|--:|--:|--:|
+| Longest task (ms) | 148 | 0 | -100% |
+| Blocking time (ms) | 1097 | 0 | -100% |
+| Max handler wait (ms) | 263 | 71 | -73% |
+| p95 handler wait (ms) | 140 | 43 | -69% |
+| Dropped frames | 44 | 3 | -93% |
+| Heap growth (MB) | 1 | 1 | 0% |
+| _(context: widgets / deltas)_ | 28/14 | 28/14 | |
+
+## ais-radar-150
+_150 AIS targets @ 4Hz + streaming own-ship (ranks 4/5, radar render loops)_
+
+| Metric | perf-preview | freeze-work-v1 | Δ |
+|---|--:|--:|--:|
+| Longest task (ms) | 1567 | 1164 | -26% |
+| Blocking time (ms) | 9690 | 8184 | -16% |
+| Max handler wait (ms) | 3436 | 1284 | -63% |
+| p95 handler wait (ms) | 3436 | 824 | -76% |
+| Dropped frames | 17 | 37 | +118% |
+| Heap growth (MB) | 13 | 15 | +15% |
+| _(context: widgets / deltas)_ | 1/9513 | 1/7248 | |
+
+## gauges-16
+_16 radial ng-canvas-gauges @ 4Hz (rank 7, animation duty cycle)_
+
+| Metric | perf-preview | freeze-work-v1 | Δ |
+|---|--:|--:|--:|
+| Longest task (ms) | 0 | 0 | 0% |
+| Blocking time (ms) | 0 | 0 | 0% |
+| Max handler wait (ms) | 36 | 31 | -14% |
+| p95 handler wait (ms) | 12 | 9 | -25% |
+| Dropped frames | 0 | 0 | 0% |
+| Heap growth (MB) | 2 | 2 | 0% |
+| _(context: widgets / deltas)_ | 16/39 | 16/40 | |
+
+## ais-growth-churn
+_AIS radar with 40 targets + 40 new MMSIs/sec churn for 30s (ranks 8/9, heap growth)_
+
+| Metric | perf-preview | freeze-work-v1 | Δ |
+|---|--:|--:|--:|
+| Longest task (ms) | 3871 | 6506 | +68% |
+| Blocking time (ms) | 26533 | 22336 | -16% |
+| Max handler wait (ms) | 4036 | 8973 | +122% |
+| p95 handler wait (ms) | 3912 | 6659 | +70% |
+| Dropped frames | 32 | 24 | -25% |
+| Heap growth (MB) | 9 | 14 | +56% |
+| _(context: widgets / deltas)_ | 1/8330 | 1/7791 | |

--- a/perf-harness/run.mjs
+++ b/perf-harness/run.mjs
@@ -1,0 +1,140 @@
+/*
+ * Freeze-audit measurement runner.
+ *
+ *   node run.mjs --branch <ref> --label <name> [--scenarios a,b] [--repeats 5]
+ *                [--throttle 4] [--port 4399] [--no-rebuild] [--headed]
+ *
+ * Builds the branch's production bundle in an isolated worktree, serves it +
+ * a mock Signal K server on one origin, injects the identical probe + a
+ * localStorage config into a throttled Chromium, runs each scenario K times,
+ * and writes results/<label>.json (raw + median/p95 aggregate).
+ */
+import { chromium } from 'playwright-core';
+import { readFile, writeFile, mkdir, access } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { buildBranch, WORKTREES } from './lib/build-serve.mjs';
+import { startServer } from './lib/server.mjs';
+import { localStorageBundle } from './lib/kip-config.mjs';
+import { scenarios as ALL } from './scenarios.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const CHROME = process.env.CHROME_BIN || '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+const BASE = '/@mxtommy/kip/';
+
+const arg = (n, d) => { const i = process.argv.indexOf(`--${n}`); return i >= 0 ? process.argv[i + 1] : d; };
+const flag = (n) => process.argv.includes(`--${n}`);
+
+const BRANCH = arg('branch', 'master');
+const LABEL = arg('label', BRANCH.replace(/[^\w.-]/g, '_'));
+const REPEATS = Number(arg('repeats', '4'));
+const THROTTLE = Number(arg('throttle', '10'));
+const PORT = Number(arg('port', '4399'));
+const ONLY = (arg('scenarios', '') || '').split(',').filter(Boolean);
+const scenarios = ONLY.length ? ALL.filter((s) => ONLY.includes(s.label)) : ALL;
+
+const exists = async (p) => { try { await access(p); return true; } catch { return false; } };
+const med = (a) => { if (!a.length) return 0; const s = [...a].sort((x, y) => x - y); return s[Math.floor(s.length / 2)]; };
+const p95 = (a) => { if (!a.length) return 0; const s = [...a].sort((x, y) => x - y); return s[Math.min(s.length - 1, Math.floor(0.95 * s.length))]; };
+
+function aggregate(reps) {
+  const pick = {
+    longTaskCount: (r) => r.longTasks.count,
+    longTaskMaxMs: (r) => r.longTasks.maxMs,
+    blockingTimeMs: (r) => r.longTasks.blockingTimeMs,
+    taskLatencyMaxMs: (r) => r.taskLatencyMs.maxMs,
+    taskLatencyP95Ms: (r) => r.taskLatencyMs.p95Ms,
+    frameMaxGapMs: (r) => r.frames.maxGapMs,
+    framesDropped: (r) => r.frames.droppedOver50ms,
+    heapSlopeKBps: (r) => Math.round(r.heap.slopeBytesPerSec / 1024),
+    heapGrowthMB: (r) => r.heap.firstBytes != null ? Math.round((r.heap.lastBytes - r.heap.firstBytes) / 1048576) : 0,
+    deltasSent: (r) => r.deltasSent || 0,
+    widgetCount: (r) => r.widgetCount || 0,
+  };
+  const out = {};
+  for (const [k, f] of Object.entries(pick)) {
+    const vals = reps.map(f);
+    out[k] = { median: med(vals), p95: p95(vals), all: vals };
+  }
+  return out;
+}
+
+async function prepareBuild() {
+  const forced = arg('public', '');
+  if (forced) { console.log(`[build] using provided public dir: ${forced}`); return forced; }
+  const wtPublic = join(WORKTREES, LABEL, 'public');
+  if (flag('no-rebuild') && await exists(join(wtPublic, 'index.html'))) {
+    console.log(`[build] reusing existing build for ${LABEL}`);
+    return wtPublic;
+  }
+  return buildBranch(BRANCH, LABEL, { rebuild: !flag('no-rebuild') });
+}
+
+async function waitForBoot(page, expectedWidgets) {
+  await page.waitForSelector('widget-host2', { timeout: 25000 }).catch(() => {});
+  // settle a couple of frames
+  await page.waitForTimeout(800);
+  return page.$$eval('widget-host2', (els) => els.length).catch(() => 0);
+}
+
+async function main() {
+  const probeJs = await readFile(join(HERE, 'probe.js'), 'utf8');
+  const publicDir = await prepareBuild();
+  const server = await startServer({ publicDir, base: BASE, port: PORT });
+  console.log(`[serve] ${server.appUrl}  (SignalK mock @ ${server.origin})`);
+
+  const browser = await chromium.launch({
+    executablePath: CHROME, headless: !flag('headed'),
+    args: ['--enable-precise-memory-info', '--js-flags=--expose-gc'],
+  });
+
+  const results = { label: LABEL, branch: BRANCH, throttle: THROTTLE, repeats: REPEATS, chrome: await browser.version(), scenarios: {} };
+
+  for (const s of scenarios) {
+    console.log(`\n=== scenario: ${s.label} — ${s.note} ===`);
+    const reps = [];
+    for (let r = 0; r < REPEATS; r++) {
+      const ctx = await browser.newContext();
+      await ctx.addInitScript({ content: probeJs });
+      const bundle = localStorageBundle({ origin: server.origin, subscribeAll: s.subscribeAll, dashboards: s.dashboards() });
+      const injector = `window.__KIP_TEST__ = true;` +
+        Object.entries(bundle).map(([k, v]) => `localStorage.setItem(${JSON.stringify(k)}, ${JSON.stringify(v)});`).join('');
+      await ctx.addInitScript({ content: injector });
+      const page = await ctx.newPage();
+      const cdp = await ctx.newCDPSession(page);
+      await cdp.send('Emulation.setCPUThrottlingRate', { rate: THROTTLE });
+
+      // fresh stream state
+      server.setControl({ streaming: false, ais: { count: 0, churnPerSec: 0 } });
+      await page.goto(server.appUrl + '#/dashboard/0', { waitUntil: 'load', timeout: 30000 });
+      const widgetCount = await waitForBoot(page);
+
+      // start the scenario data profile, warm up, then measure
+      server.setControl({ streaming: true, ...s.control });
+      const c0 = server.streamCount();
+      await page.waitForTimeout(s.warmupMs ?? 1500);
+      await page.evaluate(() => window.__perf.reset());
+      const sentAtReset = server.streamCount();
+      if (s.action) await s.action(page, server, s.durationMs);
+      else await page.waitForTimeout(s.durationMs);
+      const snap = await page.evaluate(() => window.__perf.snapshot());
+      snap.deltasSent = server.streamCount() - sentAtReset;
+      snap.widgetCount = widgetCount;
+      snap.streamedDuringWarmup = sentAtReset - c0;
+      reps.push(snap);
+      console.log(`  rep ${r + 1}/${REPEATS}: widgets=${widgetCount} deltas=${snap.deltasSent} longTaskMax=${snap.longTasks.maxMs}ms block=${snap.longTasks.blockingTimeMs}ms taskLatMax=${snap.taskLatencyMs.maxMs}ms heapΔ=${snap.heap.firstBytes != null ? Math.round((snap.heap.lastBytes - snap.heap.firstBytes) / 1048576) : '?'}MB`);
+      await ctx.close();
+    }
+    results.scenarios[s.label] = { note: s.note, agg: aggregate(reps), raw: reps.map((r) => ({ ...r, heap: { ...r.heap } })) };
+  }
+
+  await server.stop();
+  await browser.close();
+
+  await mkdir(join(HERE, 'results'), { recursive: true });
+  const outPath = join(HERE, 'results', `${LABEL}.json`);
+  await writeFile(outPath, JSON.stringify(results, null, 2));
+  console.log(`\n[done] wrote ${outPath}`);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/perf-harness/scenarios.mjs
+++ b/perf-harness/scenarios.mjs
@@ -1,0 +1,80 @@
+/*
+ * Measurement scenarios. Each exercises a specific verified audit finding so the
+ * before/after numbers map to a named root cause. Data profiles drive the mock
+ * server; dashboards are built fresh per repeat (unique widget uuids).
+ */
+import { numericWidget, radialGaugeWidget, aisRadarWidget, buildDashboards } from './lib/kip-config.mjs';
+
+const POOL = [
+  'navigation.speedOverGround', 'navigation.headingTrue', 'navigation.courseOverGroundTrue',
+  'environment.depth.belowTransducer', 'environment.wind.angleApparent', 'environment.wind.speedApparent',
+];
+
+// Many extra paths to stress the delta parse + fan-out (widgets need not subscribe;
+// data.service still upserts _skData and emits _pathUpdates$ for every path).
+const manyPaths = (n) => [...POOL, ...Array.from({ length: Math.max(0, n - POOL.length) }, (_, i) => `sensors.mock.n${i}.value`)];
+
+const numericGrid = (n) => buildDashboards(Array.from({ length: n }, (_, i) => numericWidget({ path: 'self.' + POOL[i % POOL.length], sampleTime: 500 })));
+const gaugeGrid = (n) => buildDashboards(Array.from({ length: n }, (_, i) => radialGaugeWidget({ path: 'self.' + POOL[i % POOL.length], sampleTime: 500 })));
+
+export const scenarios = [
+  {
+    label: 'idle-numeric-24',
+    note: 'baseline render/CD load: 24 numeric widgets, low data rate (WS4 baseline)',
+    subscribeAll: false, durationMs: 8000, warmupMs: 2000,
+    dashboards: () => numericGrid(24),
+    control: { rateHz: 2, selfPaths: POOL, ais: { count: 0, churnPerSec: 0 } },
+  },
+  {
+    label: 'delta-storm-30x10',
+    note: 'sustained ingestion: 30 paths @ 10Hz over a numeric+gauge dashboard (rank 2, delta coalescing)',
+    subscribeAll: false, durationMs: 12000, warmupMs: 2000,
+    dashboards: () => numericGrid(20),
+    control: { rateHz: 10, selfPaths: manyPaths(30), ais: { count: 0, churnPerSec: 0 } },
+  },
+  {
+    label: 'reconnect-backlog',
+    note: 'reconnect snapshot: one frame carrying 6000 values (rank 2, single synchronous parse+fan-out long task)',
+    subscribeAll: false, durationMs: 7000, warmupMs: 2000,
+    dashboards: () => numericGrid(20),
+    control: { rateHz: 4, selfPaths: manyPaths(20), ais: { count: 0, churnPerSec: 0 } },
+    async action(page, server, durationMs) {
+      await page.waitForTimeout(1000);
+      server.blastBig(6000); // reconnect snapshot: one big frame => one long task
+      await page.waitForTimeout(durationMs - 1000);
+    },
+  },
+  {
+    label: 'resize-storm',
+    note: '28 canvas widgets + repeated viewport resizes: shared ResizeObserver reallocates every canvas in one task (rank 1, the fullscreen enter/exit storm)',
+    subscribeAll: false, durationMs: 7000, warmupMs: 2500,
+    dashboards: () => numericGrid(28),
+    control: { rateHz: 2, selfPaths: POOL, ais: { count: 0, churnPerSec: 0 } },
+    async action(page, server, durationMs) {
+      const sizes = [[1600, 1000], [900, 1400], [1600, 1000], [1280, 800], [1920, 1080], [800, 1200], [1600, 1000], [1100, 900]];
+      for (const [w, h] of sizes) { await page.setViewportSize({ width: w, height: h }); await page.waitForTimeout(500); }
+      await page.waitForTimeout(Math.max(0, durationMs - sizes.length * 500));
+    },
+  },
+  {
+    label: 'ais-radar-150',
+    note: '150 AIS targets @ 4Hz + streaming own-ship (ranks 4/5, radar render loops)',
+    subscribeAll: true, durationMs: 12000, warmupMs: 3000,
+    dashboards: () => buildDashboards([aisRadarWidget()]),
+    control: { rateHz: 4, selfPaths: ['navigation.position', 'navigation.headingTrue', 'navigation.courseOverGroundTrue', 'navigation.speedOverGround'], ais: { count: 150, churnPerSec: 0 } },
+  },
+  {
+    label: 'gauges-16',
+    note: '16 radial ng-canvas-gauges @ 4Hz (rank 7, animation duty cycle)',
+    subscribeAll: false, durationMs: 10000, warmupMs: 2000,
+    dashboards: () => gaugeGrid(16),
+    control: { rateHz: 4, selfPaths: POOL, ais: { count: 0, churnPerSec: 0 } },
+  },
+  {
+    label: 'ais-growth-churn',
+    note: 'AIS radar with 40 targets + 40 new MMSIs/sec churn for 30s (ranks 8/9, heap growth)',
+    subscribeAll: true, durationMs: 30000, warmupMs: 3000,
+    dashboards: () => buildDashboards([aisRadarWidget()]),
+    control: { rateHz: 5, selfPaths: ['navigation.position', 'navigation.headingTrue'], ais: { count: 40, churnPerSec: 40 } },
+  },
+];

--- a/perf-harness/screenshot.mjs
+++ b/perf-harness/screenshot.mjs
@@ -1,0 +1,54 @@
+/*
+ * Deterministic AIS-radar screenshot for visual verification.
+ *   node screenshot.mjs --public ../public --label before --port 4420
+ * Loads the radar with a fixed scene (own-ship + targets at known bearings/ranges)
+ * so before/after images are directly comparable. Writes results/shots/<label>.png.
+ */
+import { chromium } from 'playwright-core';
+import { mkdir } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { startServer } from './lib/server.mjs';
+import { aisRadarWidget, buildDashboards, localStorageBundle } from './lib/kip-config.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const CHROME = process.env.CHROME_BIN || '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+const arg = (n, d) => { const i = process.argv.indexOf(`--${n}`); return i >= 0 ? process.argv[i + 1] : d; };
+
+const publicDir = arg('public', join(HERE, '..', 'public'));
+const label = arg('label', 'radar');
+const port = Number(arg('port', '4420'));
+
+// Deterministic scene: own-ship + targets at fixed bearings/ranges (nm).
+const own = { lat: 47.6, lon: -122.33, heading: 45, cog: 45, sog: 6 };
+const place = (bearingDeg, rangeNm, extra) => {
+  const b = bearingDeg * Math.PI / 180;
+  const dLat = (rangeNm / 60) * Math.cos(b);
+  const dLon = (rangeNm / 60) * Math.sin(b) / Math.cos(own.lat * Math.PI / 180);
+  return { lat: own.lat + dLat, lon: own.lon + dLon, heading: (bearingDeg + 90) % 360, cog: (bearingDeg + 90) % 360, sog: 5, ...extra };
+};
+let mmsi = 200000000;
+const targets = [];
+for (const r of [3, 7]) for (const b of [0, 45, 90, 135, 180, 225, 270, 315]) targets.push({ mmsi: mmsi++, ...place(b, r) });
+// two targets well beyond a 12nm ring (to visually check range culling later)
+for (const b of [30, 210]) targets.push({ mmsi: mmsi++, ...place(b, 20, { sog: 9 }) });
+
+const server = await startServer({ publicDir, base: '/@mxtommy/kip/', port });
+const browser = await chromium.launch({ executablePath: CHROME, headless: true });
+const ctx = await browser.newContext({ viewport: { width: 900, height: 900 }, deviceScaleFactor: 2 });
+const bundle = localStorageBundle({ origin: server.origin, subscribeAll: true, dashboards: buildDashboards([aisRadarWidget()]) });
+await ctx.addInitScript({ content: `window.__KIP_TEST__=true;` + Object.entries(bundle).map(([k, v]) => `localStorage.setItem(${JSON.stringify(k)}, ${JSON.stringify(v)});`).join('') });
+const page = await ctx.newPage();
+
+server.setControl({ streaming: true, staticScene: { ownShip: own, targets } });
+await page.goto(server.appUrl + '#/dashboard/0', { waitUntil: 'load', timeout: 30000 });
+await page.waitForSelector('widget-ais-radar', { timeout: 20000 });
+await page.waitForTimeout(3500); // let the scene stream in and the radar settle
+
+await mkdir(join(HERE, 'results', 'shots'), { recursive: true });
+const out = join(HERE, 'results', 'shots', `${label}.png`);
+await page.locator('widget-ais-radar').screenshot({ path: out });
+console.log(`[shot] ${out}  (deltas: ${server.streamCount()}, targets: ${targets.length})`);
+
+await browser.close();
+await server.stop();

--- a/perf-harness/serve.mjs
+++ b/perf-harness/serve.mjs
@@ -1,0 +1,67 @@
+/*
+ * Minimal static SPA server for a built KIP bundle.
+ * KIP builds to <root>/public with <base href="/@mxtommy/kip/">, so we mount the
+ * files under that base and SPA-fallback unknown routes to index.html.
+ *
+ * Usage: node serve.mjs --root /path/to/worktree/public --port 4321 [--base /@mxtommy/kip/]
+ */
+import http from 'node:http';
+import { readFile, stat } from 'node:fs/promises';
+import { join, extname, normalize } from 'node:path';
+
+function arg(name, def) {
+  const i = process.argv.indexOf(`--${name}`);
+  return i >= 0 ? process.argv[i + 1] : def;
+}
+
+const ROOT = arg('root', 'public');
+const PORT = Number(arg('port', '4321'));
+let BASE = arg('base', '/@mxtommy/kip/');
+if (!BASE.endsWith('/')) BASE += '/';
+
+const TYPES = {
+  '.html': 'text/html; charset=utf-8', '.js': 'text/javascript', '.mjs': 'text/javascript',
+  '.css': 'text/css', '.json': 'application/json', '.svg': 'image/svg+xml',
+  '.png': 'image/png', '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg', '.webp': 'image/webp',
+  '.ico': 'image/x-icon', '.woff': 'font/woff', '.woff2': 'font/woff2', '.ttf': 'font/ttf',
+  '.wasm': 'application/wasm', '.map': 'application/json',
+};
+
+async function tryFile(p) {
+  try { const s = await stat(p); if (s.isFile()) return p; } catch { /* nope */ }
+  return null;
+}
+
+const server = http.createServer(async (req, res) => {
+  try {
+    let urlPath = decodeURIComponent(new URL(req.url, 'http://x').pathname);
+    // Redirect bare root to the app base so relative asset URLs resolve.
+    if (urlPath === '/' ) { res.writeHead(302, { Location: BASE }); return res.end(); }
+    // Strip the base prefix.
+    let rel = urlPath.startsWith(BASE) ? urlPath.slice(BASE.length) : urlPath.replace(/^\//, '');
+    rel = normalize(rel).replace(/^(\.\.[/\\])+/, '');
+    let filePath = join(ROOT, rel);
+
+    let resolved = await tryFile(filePath);
+    // SPA fallback: unknown route with no file extension -> index.html
+    if (!resolved && !extname(rel)) resolved = await tryFile(join(ROOT, 'index.html'));
+    if (!resolved) { res.writeHead(404); return res.end('not found: ' + rel); }
+
+    const body = await readFile(resolved);
+    res.writeHead(200, {
+      'Content-Type': TYPES[extname(resolved)] || 'application/octet-stream',
+      'Cache-Control': 'no-store',
+    });
+    res.end(body);
+  } catch (e) {
+    res.writeHead(500); res.end(String(e));
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`[serve] ${ROOT} at http://localhost:${PORT}${BASE}`);
+});
+
+// Allow the parent (run.mjs) to shut us down cleanly.
+process.on('SIGTERM', () => server.close(() => process.exit(0)));
+process.on('message', (m) => { if (m === 'shutdown') server.close(() => process.exit(0)); });

--- a/perf-harness/smoke.mjs
+++ b/perf-harness/smoke.mjs
@@ -1,0 +1,50 @@
+/* Smoke test: verify the browser launch + probe measure a synthetic main-thread block. */
+import { chromium } from 'playwright-core';
+import { readFile } from 'node:fs/promises';
+
+const CHROME = process.env.CHROME_BIN
+  || '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+
+const probe = await readFile(new URL('./probe.js', import.meta.url), 'utf8');
+
+const browser = await chromium.launch({
+  executablePath: CHROME,
+  headless: true,
+  args: ['--enable-precise-memory-info', '--js-flags=--expose-gc'],
+});
+const ctx = await browser.newContext();
+await ctx.addInitScript({ content: probe });
+const page = await ctx.newPage();
+
+// Throttle CPU 4x to emulate a low-power marine display.
+const cdp = await ctx.newCDPSession(page);
+await cdp.send('Emulation.setCPUThrottlingRate', { rate: 4 });
+
+await page.goto('data:text/html,<title>smoke</title><body>smoke</body>');
+await page.evaluate(() => window.__perf.reset());
+
+// Synthetic 400ms blocking task scheduled as a REAL page task (setTimeout),
+// so it is attributed as a long task exactly like the app's own work would be.
+await page.evaluate(() => new Promise((resolve) => {
+  setTimeout(() => {
+    const end = performance.now() + 400;
+    while (performance.now() < end) { /* block */ }
+    resolve();
+  }, 0);
+}));
+// Let the canary/observers catch up.
+await page.waitForTimeout(500);
+
+const snap = await page.evaluate(() => window.__perf.snapshot());
+console.log('CHROME:', (await browser.version()));
+console.log(JSON.stringify(snap, null, 2));
+
+await browser.close();
+
+// Assert the probe actually saw the block.
+if (snap.longTasks.maxMs < 200 && snap.taskLatencyMs.maxMs < 200) {
+  console.error('FAIL: probe did not detect the synthetic block');
+  process.exit(1);
+}
+console.log('SMOKE OK: probe detected the block (longtask maxMs=%d, taskLatency maxMs=%d)',
+  snap.longTasks.maxMs, snap.taskLatencyMs.maxMs);

--- a/perf-harness/verify-click.mjs
+++ b/perf-harness/verify-click.mjs
@@ -1,0 +1,56 @@
+/*
+ * Verifies AIS-radar hit-testing after the rotation refactor: with two targets
+ * overlapping at a non-zero view rotation (heading 45deg), clicking them must
+ * open the multi-target disambiguation MENU (findTargetsNearEvent found both) —
+ * not fall back to a single dialog. This is the one correctness path a static
+ * screenshot can't cover (the click-point un-rotate math).
+ */
+import { chromium } from 'playwright-core';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { startServer } from './lib/server.mjs';
+import { aisRadarWidget, buildDashboards, localStorageBundle } from './lib/kip-config.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const CHROME = process.env.CHROME_BIN || '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+const arg = (n, d) => { const i = process.argv.indexOf(`--${n}`); return i >= 0 ? process.argv[i + 1] : d; };
+const publicDir = arg('public', join(HERE, '..', 'public'));
+const port = Number(arg('port', '4425'));
+
+const own = { lat: 47.6, lon: -122.33, heading: 45, cog: 45, sog: 6 };
+// Two vessels at (nearly) the same spot, bearing 90deg / 4nm from own-ship.
+const b = 90 * Math.PI / 180, r = 4;
+const dLat = (r / 60) * Math.cos(b), dLon = (r / 60) * Math.sin(b) / Math.cos(own.lat * Math.PI / 180);
+const targets = [
+  { mmsi: 300000001, lat: own.lat + dLat, lon: own.lon + dLon, heading: 200, cog: 200, sog: 5, name: 'Overlap A' },
+  { mmsi: 300000002, lat: own.lat + dLat, lon: own.lon + dLon, heading: 20, cog: 20, sog: 5, name: 'Overlap B' },
+];
+
+const server = await startServer({ publicDir, base: '/@mxtommy/kip/', port });
+const browser = await chromium.launch({ executablePath: CHROME, headless: true });
+const ctx = await browser.newContext({ viewport: { width: 900, height: 900 }, deviceScaleFactor: 1 });
+const bundle = localStorageBundle({ origin: server.origin, subscribeAll: true, dashboards: buildDashboards([aisRadarWidget()]) });
+await ctx.addInitScript({ content: `window.__KIP_TEST__=true;` + Object.entries(bundle).map(([k, v]) => `localStorage.setItem(${JSON.stringify(k)}, ${JSON.stringify(v)});`).join('') });
+const page = await ctx.newPage();
+
+server.setControl({ streaming: true, staticScene: { ownShip: own, targets } });
+await page.goto(server.appUrl + '#/dashboard/0', { waitUntil: 'load', timeout: 30000 });
+await page.waitForSelector('widget-ais-radar .radar-targets g.target', { timeout: 20000 });
+await page.waitForTimeout(3000);
+
+const count = await page.locator('widget-ais-radar .radar-targets g.target').count();
+const box = await page.locator('widget-ais-radar .radar-targets g.target').first().boundingBox();
+if (!box) { console.error('FAIL: no target box'); process.exit(1); }
+await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+await page.waitForTimeout(600);
+
+const menuOpen = await page.locator('.mat-mdc-menu-panel, [role="menu"]').count();
+const dialogOpen = await page.locator('mat-dialog-container, .cdk-dialog-container, dialog-ais-target').count();
+console.log(`targets rendered: ${count}`);
+console.log(`after click at heading=45deg -> menu panels: ${menuOpen}, dialogs: ${dialogOpen}`);
+if (menuOpen > 0) console.log('PASS: overlapping-target menu opened -> hit-test un-rotate is correct');
+else if (dialogOpen > 0) console.log('WARN: single dialog opened -> findTargetsNearEvent did NOT find the overlap (un-rotate sign?)');
+else console.log('WARN: neither menu nor dialog detected');
+
+await browser.close();
+await server.stop();


### PR DESCRIPTION
## Split out of #1101

Per review feedback on #1101, this PR carries just the `perf-harness/` measurement tooling on its own, so it can be reviewed/played with independently of the freeze-fix optimizations (which now live only in #1101).

### What's in here

A self-contained (own `package.json`/lockfile) Node harness that:
- Builds a branch's production bundle and serves it plus a mock Signal K server on one origin
- Injects a main-thread probe measuring long tasks, event-loop lag (the "can't exit fullscreen" proxy), frame drops and heap growth
- Throttles CPU to emulate low-power marine hardware, across scenarios mapped to the freeze audit
- Includes deterministic screenshot + click (`verify-click.mjs`) tooling used to visually verify the AIS radar rendering changes in #1101
- Includes the captured before/after result snapshots and reports referenced from #1101 (master vs. perf-preview, perf-preview vs. freeze-work, and the two radar-transform verification runs)

Nothing here touches `src/`; it's dev/verification tooling only.