### PR TITLE
Retain latest measured size across rebuilds in GaugeSteelComponent

### DIFF
--- a/src/app/widgets/gauge-steel/gauge-steel.component.spec.ts
+++ b/src/app/widgets/gauge-steel/gauge-steel.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi, afterEach } from 'vitest';
 import { GaugeSteelComponent } from './gauge-steel.component';
 import { UnitsService } from '../../core/services/units.service';
 
@@ -28,7 +28,26 @@ describe('GaugeSteelComponent', () => {
     fixture.detectChanges();
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('should be created', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('keeps latest measured size across rebuild', () => {
+    vi.useFakeTimers();
+
+    const resizeEntry = {
+      contentRect: { width: 420, height: 180 },
+    } as ResizeObserverEntry;
+
+    component.onResized(resizeEntry);
+    vi.runAllTimers();
+
+    const gaugeOptions = (component as unknown as { gaugeOptions: Record<string, unknown> }).gaugeOptions;
+    expect(gaugeOptions.width).toBe(420);
+    expect(gaugeOptions.height).toBe(180);
   });
 });

--- a/src/app/widgets/gauge-steel/gauge-steel.component.ts
+++ b/src/app/widgets/gauge-steel/gauge-steel.component.ts
@@ -101,6 +101,7 @@ export class GaugeSteelComponent implements OnInit, OnChanges, OnDestroy {
   private gaugeStarted = false;
   private gauge: SteelGaugeHandle | null = null;
   private gaugeOptions: Record<string, unknown> = {};
+  private latestSizeOptions: Record<string, number> = {};
   protected paddingTop = 0;
   private lastSizeSignature = '';
   private resizeTimer: number | null = null;
@@ -232,6 +233,9 @@ export class GaugeSteelComponent implements OnInit, OnChanges, OnDestroy {
     this.gaugeOptions['thresholdVisible'] = false;
     this.gaugeOptions['threshold'] = this.maxValue();
     this.gaugeOptions['ledVisible'] = false;
+
+    // Keep the latest measured size across rebuilds.
+    Object.assign(this.gaugeOptions, this.latestSizeOptions);
   }
 
   private setGaugeType(radialSize: string | undefined): unknown {
@@ -286,11 +290,13 @@ export class GaugeSteelComponent implements OnInit, OnChanges, OnDestroy {
     let signature: string;
     if (this.subType() === 'radial') {
       const size =  Math.floor(Math.min(event.contentRect.height, event.contentRect.width));
+      this.latestSizeOptions = { size };
       this.gaugeOptions['size'] = size;
       signature = 'radial:' + size;
     } else {
       const w = Math.floor(event.contentRect.width);
       const h = Math.floor(event.contentRect.height);
+      this.latestSizeOptions = { width: w, height: h };
       this.gaugeOptions['width'] = w;
       this.gaugeOptions['height'] = h;
       signature = `linear:${w}x${h}`;


### PR DESCRIPTION
Enhance the GaugeSteelComponent to retain the latest measured size during rebuilds, ensuring consistent gauge dimensions. This update includes tests to verify the functionality.