### PR TITLE
Update version to 4.8.3 and add sk-ais-status-plugin dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "@mxtommy/kip",
-  "version": "4.8.1",
+  "version": "4.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mxtommy/kip",
-      "version": "4.8.1",
+      "version": "4.8.2",
       "license": "MIT",
       "dependencies": {
-        "@signalk/server-api": "^2.22.0"
+        "@signalk/server-api": "^2.22.0",
+        "sk-ais-status-plugin": "^1.0.0"
       },
       "devDependencies": {
         "@angular-devkit/schematics-cli": "^20.1.6",
@@ -62,7 +63,6 @@
         "rxjs": "^7.8.2",
         "sass": "^1.49.9",
         "screenfull": "^6.0.2",
-        "sk-ais-status-plugin": "^1.0.0",
         "steelseries": "^2.0.9",
         "ts-node": "^10.9.2",
         "tslib": "^2.6.2",
@@ -14933,7 +14933,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/sk-ais-status-plugin/-/sk-ais-status-plugin-1.0.0.tgz",
       "integrity": "sha512-K0FirWlbyge+ZtHwFmUdu9ygsrSIpmFnd06D5t+9oxuBxQL1DFbdj0qEF4xCcVgOEtSvFwytOfZIcrJdAVYqtQ==",
-      "dev": true,
       "license": "Apache-20",
       "dependencies": {
         "@signalk/server-api": "^2.10.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mxtommy/kip",
-  "version": "4.8.2",
+  "version": "4.8.3",
   "description": "An advanced and versatile marine instrumentation package to display Signal K data.",
   "license": "MIT",
   "author": {
@@ -115,7 +115,6 @@
     "rxjs": "^7.8.2",
     "sass": "^1.49.9",
     "screenfull": "^6.0.2",
-    "sk-ais-status-plugin": "^1.0.0",
     "steelseries": "^2.0.9",
     "ts-node": "^10.9.2",
     "tslib": "^2.6.2",
@@ -123,6 +122,7 @@
     "vitest": "^4.1.0"
   },
   "dependencies": {
-    "@signalk/server-api": "^2.22.0"
+    "@signalk/server-api": "^2.22.0",
+    "sk-ais-status-plugin": "^1.0.0"
   }
 }


### PR DESCRIPTION
Bump the package version to 4.8.3 and include the sk-ais-status-plugin as a dependency.