### PR TITLE
Fix minor gauge steel memory leak

### DIFF
--- a/src/app/widgets/gauge-steel/gauge-steel.component.ts
+++ b/src/app/widgets/gauge-steel/gauge-steel.component.ts
@@ -341,6 +341,12 @@ export class GaugeSteelComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   ngOnDestroy(): void {
+    // Clear pending resize debounce callback so it cannot fire after destroy
+    if (this.resizeTimer !== null) {
+      window.clearTimeout(this.resizeTimer);
+      this.resizeTimer = null;
+    }
+
     // Stop any running animations before cleanup
     if (this.gauge && this.gauge.setValue) {
       // Call setValue to stop any running setValueAnimated animations


### PR DESCRIPTION
Clear the resize timer in the `ngOnDestroy` lifecycle method to prevent potential memory leaks when the component is destroyed.