### PR TITLE
Fix frame visibility logic in gauge options for WidgetHorizonComponent

### DIFF
--- a/src/app/widgets/widget-horizon/widget-horizon.component.ts
+++ b/src/app/widgets/widget-horizon/widget-horizon.component.ts
@@ -251,7 +251,7 @@ export class WidgetHorizonComponent implements AfterViewInit, OnDestroy {
     const faceColor = (cfg.gauge?.faceColor ?? 'anthracite') as keyof ReturnType<typeof getSteelFrameDesign>;
     this.gaugeOptions = {
       pointerColor: pointerMap.Red,
-      frameVisible: !(cfg.gauge?.noFrameVisible ?? false),
+      frameVisible: (cfg.gauge?.noFrameVisible ?? false),
       frameDesign: frameMap[faceColor],
       foregroundVisible: false,
       size


### PR DESCRIPTION
Correct the logic determining frame visibility in the gauge options to ensure it reflects the intended configuration.
fixes #1124