### PR TITLE
Fix unbounded memory growth in DataService (found while investigating #770)

### DIFF
--- a/src/app/core/components/remote-control/remote-control.component.spec.ts
+++ b/src/app/core/components/remote-control/remote-control.component.spec.ts
@@ -84,8 +84,12 @@ describe('RemoteControlComponent releasing DataService registrations', () => {
     await appRef.whenStable();
     fixture.detectChanges();
 
-    expect(dataSvc.unsubCalls).toContainEqual({ path: 'self.displays.display-1', source: 'default' });
-    expect(dataSvc.unsubCalls).toContainEqual({ path: 'self.displays.display-1.screenIndex', source: 'default' });
+    // Exact equality (not just toContainEqual) so a regression that releases twice,
+    // or also releases display-2's brand-new registration, would be caught.
+    expect(dataSvc.unsubCalls).toEqual([
+      { path: 'self.displays.display-1', source: 'default' },
+      { path: 'self.displays.display-1.screenIndex', source: 'default' }
+    ]);
   });
 
   it('releases the selected display\'s subscriptions when the component is destroyed', async () => {
@@ -97,7 +101,9 @@ describe('RemoteControlComponent releasing DataService registrations', () => {
 
     fixture.destroy();
 
-    expect(dataSvc.unsubCalls).toContainEqual({ path: 'self.displays.display-1', source: 'default' });
-    expect(dataSvc.unsubCalls).toContainEqual({ path: 'self.displays.display-1.screenIndex', source: 'default' });
+    expect(dataSvc.unsubCalls).toEqual([
+      { path: 'self.displays.display-1', source: 'default' },
+      { path: 'self.displays.display-1.screenIndex', source: 'default' }
+    ]);
   });
 });

--- a/src/app/core/components/remote-control/remote-control.component.spec.ts
+++ b/src/app/core/components/remote-control/remote-control.component.spec.ts
@@ -1,6 +1,9 @@
+import { ApplicationRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { beforeEach, describe, expect, it } from 'vitest';
+import { Subject } from 'rxjs';
 import { RemoteControlComponent } from './remote-control.component';
+import { DataService } from '../../services/data.service';
 
 describe('RemoteControlComponent', () => {
   let component: RemoteControlComponent;
@@ -19,5 +22,82 @@ describe('RemoteControlComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+});
+
+class FakeDataService {
+  treeSubject = new Subject<{ path: string; update: { data: { value: unknown; timestamp: Date | null }; state: string } }>();
+  unsubCalls: { path: string; source: string }[] = [];
+
+  subscribePathTree() {
+    return this.treeSubject.asObservable();
+  }
+
+  subscribePath() {
+    return new Subject<{ data: { value: unknown; timestamp: Date | null }; state: string }>().asObservable();
+  }
+
+  unsubscribePath(path: string, source: string): void {
+    this.unsubCalls.push({ path, source });
+  }
+}
+
+// A remote display is only picked up once its path payload carries a displayName,
+// mirroring what the real self.displays.<id> root node looks like on the wire.
+function pushDisplay(dataSvc: FakeDataService, displayId: string, displayName: string): void {
+  dataSvc.treeSubject.next({
+    path: `self.displays.${displayId}`,
+    update: { data: { value: { displayName }, timestamp: null }, state: 'normal' }
+  });
+}
+
+describe('RemoteControlComponent releasing DataService registrations', () => {
+  let fixture: ComponentFixture<RemoteControlComponent>;
+  let component: RemoteControlComponent;
+  let dataSvc: FakeDataService;
+  let appRef: ApplicationRef;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [RemoteControlComponent],
+      providers: [{ provide: DataService, useClass: FakeDataService }]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(RemoteControlComponent);
+    component = fixture.componentInstance;
+    dataSvc = TestBed.inject(DataService) as unknown as FakeDataService;
+    appRef = TestBed.inject(ApplicationRef);
+    fixture.detectChanges();
+  });
+
+  it('releases the previous display\'s subscriptions when the selected display switches to another one', async () => {
+    pushDisplay(dataSvc, 'display-1', 'One');
+    pushDisplay(dataSvc, 'display-2', 'Two');
+    await appRef.whenStable();
+    fixture.detectChanges();
+
+    // display-1 sorts first alphabetically and is auto-selected; its two path
+    // registrations (screen list + active screen index) should now be live.
+    expect(dataSvc.unsubCalls).toEqual([]);
+
+    component['displayDashboards']('display-2');
+    await appRef.whenStable();
+    fixture.detectChanges();
+
+    expect(dataSvc.unsubCalls).toContainEqual({ path: 'self.displays.display-1', source: 'default' });
+    expect(dataSvc.unsubCalls).toContainEqual({ path: 'self.displays.display-1.screenIndex', source: 'default' });
+  });
+
+  it('releases the selected display\'s subscriptions when the component is destroyed', async () => {
+    pushDisplay(dataSvc, 'display-1', 'One');
+    await appRef.whenStable();
+    fixture.detectChanges();
+
+    expect(dataSvc.unsubCalls).toEqual([]);
+
+    fixture.destroy();
+
+    expect(dataSvc.unsubCalls).toContainEqual({ path: 'self.displays.display-1', source: 'default' });
+    expect(dataSvc.unsubCalls).toContainEqual({ path: 'self.displays.display-1.screenIndex', source: 'default' });
   });
 });

--- a/src/app/core/components/remote-control/remote-control.component.ts
+++ b/src/app/core/components/remote-control/remote-control.component.ts
@@ -35,6 +35,11 @@ export class RemoteControlComponent {
   private readonly displaysMap = signal<Record<string, IKipDisplayInfo>>({});
   private selectedDisplaySub: Subscription | null = null;
   private selectedScreenIndexSub: Subscription | null = null;
+  // The displayId the two subscriptions above are currently bound to, so their
+  // DataService registrations can be released on rebind/destroy - otherwise every
+  // display switch, and every navigation to/away from this page, leaks one
+  // registration per path for the life of the app.
+  private boundDisplayId: string | null = null;
 
   protected readonly displays = computed<IKipDisplayInfo[]>(() => {
     const items = Object.values(this.displaysMap());
@@ -77,6 +82,8 @@ export class RemoteControlComponent {
     effect(() => {
       this.rebindSelectedDisplaySubscriptions(this.displayId());
     });
+
+    this._destroyRef.onDestroy(() => this.releaseBoundDisplaySubscriptions());
   }
 
   private updateDisplayCatalog(path: string, value: unknown): void {
@@ -112,11 +119,21 @@ export class RemoteControlComponent {
     });
   }
 
+  /** Release the DataService registrations for whichever displayId is currently bound, if any. */
+  private releaseBoundDisplaySubscriptions(): void {
+    const displayId = this.boundDisplayId;
+    if (!displayId) return;
+    this._data.unsubscribePath(`self.displays.${displayId}`, 'default');
+    this._data.unsubscribePath(`self.displays.${displayId}.screenIndex`, 'default');
+    this.boundDisplayId = null;
+  }
+
   private rebindSelectedDisplaySubscriptions(displayId: string | null): void {
     this.selectedDisplaySub?.unsubscribe();
     this.selectedDisplaySub = null;
     this.selectedScreenIndexSub?.unsubscribe();
     this.selectedScreenIndexSub = null;
+    this.releaseBoundDisplaySubscriptions();
 
     if (!displayId) {
       this.screensLoading.set(false);
@@ -125,6 +142,7 @@ export class RemoteControlComponent {
       return;
     }
 
+    this.boundDisplayId = displayId;
     this.screensLoading.set(true);
 
     this.selectedDisplaySub = this._data.subscribePath(`self.displays.${displayId}`, 'default')

--- a/src/app/core/directives/widget-streams.directive.spec.ts
+++ b/src/app/core/directives/widget-streams.directive.spec.ts
@@ -3,11 +3,17 @@ import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 import { Subject, BehaviorSubject, Observable } from 'rxjs';
 import { WidgetStreamsDirective } from './widget-streams.directive';
 import { DataService, IPathUpdate } from '../services/data.service';
+import { SignalKDeltaService } from '../services/signalk-delta.service';
 import { UnitsService } from '../services/units.service';
 import { IWidgetSvcConfig, IWidgetPath } from '../interfaces/widgets-interface';
+import { IPathValueData } from '../interfaces/app-interfaces';
 
 class FakeDataService {
     calls: {
+        path: string;
+        source: string;
+    }[] = [];
+    unsubCalls: {
         path: string;
         source: string;
     }[] = [];
@@ -25,6 +31,10 @@ class FakeDataService {
             this.subjects.set(key, new Subject<IPathUpdate>());
         }
         return this.subjects.get(key)!.asObservable();
+    }
+
+    unsubscribePath(path: string, source: string): void {
+        this.unsubCalls.push({ path, source });
     }
 
     timeoutPathObservable(path: string, pathType: string): void {
@@ -502,6 +512,10 @@ class TtlFakeDataService {
         return this.subjects.get(key)!.asObservable();
     }
 
+    unsubscribePath(): void {
+        // Not exercised by these TTL tests; no-op is sufficient here.
+    }
+
     timeoutPathObservable(path: string, pathType: string): void {
         this.timeoutCalls.push({ path, pathType });
         // Mirror the real DataService: a TTL timeout resets the path value to null.
@@ -556,5 +570,150 @@ describe('WidgetStreamsDirective TTL value reset (#1069)', () => {
         expect(dataSvc.timeoutCalls.length).toBeGreaterThanOrEqual(1);
         // The widget must be reset to null ("--"), not left showing the stale 500.
         expect(hits[hits.length - 1]).toBeNull();
+    });
+});
+
+describe('WidgetStreamsDirective releasing DataService registrations', () => {
+    let directive: WidgetStreamsDirective;
+    let dataSvc: FakeDataService;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [
+                WidgetStreamsDirective,
+                { provide: DataService, useClass: FakeDataService },
+                { provide: UnitsService, useClass: FakeUnitsService }
+            ]
+        });
+        directive = TestBed.inject(WidgetStreamsDirective);
+        dataSvc = TestBed.inject(DataService) as unknown as FakeDataService;
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('releases every subscribed path when the directive is destroyed', () => {
+        const cfg = makeCfg({ key: 'p1', path: 'navigation.speedOverGround', source: 'gps-1' });
+        cfg.paths = {
+            ...cfg.paths,
+            p2: { ...(cfg.paths as Record<string, IWidgetPath>)['p1'], path: 'navigation.headingTrue', source: 'compass-1' }
+        };
+        directive.setStreamsConfig(cfg);
+        directive.observe('p1', () => { });
+        directive.observe('p2', () => { });
+
+        expect(dataSvc.unsubCalls).toEqual([]);
+        TestBed.resetTestingModule();
+
+        expect(dataSvc.unsubCalls).toContainEqual({ path: 'navigation.speedOverGround', source: 'gps-1' });
+        expect(dataSvc.unsubCalls).toContainEqual({ path: 'navigation.headingTrue', source: 'compass-1' });
+        expect(dataSvc.unsubCalls.length).toBe(2);
+    });
+
+    it('releases the old path when a widget is reconfigured to point at a different path, and does not release the new one', () => {
+        const cfgA = makeCfg({ path: 'navigation.speedOverGround', source: 'gps-1' });
+        directive.setStreamsConfig(cfgA);
+        directive.observe('p', () => { });
+        expect(dataSvc.unsubCalls).toEqual([]);
+
+        const cfgB = makeCfg({ path: 'navigation.headingTrue', source: 'compass-1' });
+        directive.applyStreamsConfigDiff(cfgB);
+
+        expect(dataSvc.unsubCalls).toEqual([{ path: 'navigation.speedOverGround', source: 'gps-1' }]);
+    });
+
+    it('does not release the registration when only the callback changes and the path stays the same', () => {
+        const cfg = makeCfg({ path: 'navigation.speedOverGround', source: 'gps-1' });
+        directive.setStreamsConfig(cfg);
+        directive.observe('p', () => { });
+        directive.observe('p', () => { }); // different callback, same path/source
+
+        expect(dataSvc.calls.length).toBe(1); // only ever subscribed once
+        expect(dataSvc.unsubCalls).toEqual([]);
+    });
+
+    it('releases a path removed from the widget config via applyStreamsConfigDiff', () => {
+        const cfgA = makeCfg({ key: 'p1', path: 'navigation.speedOverGround', source: 'gps-1' });
+        directive.setStreamsConfig(cfgA);
+        directive.observe('p1', () => { });
+
+        directive.applyStreamsConfigDiff(makeCfg({ key: 'p2', path: 'navigation.headingTrue', source: 'compass-1' }));
+
+        expect(dataSvc.unsubCalls).toEqual([{ path: 'navigation.speedOverGround', source: 'gps-1' }]);
+    });
+});
+
+describe('WidgetStreamsDirective shared DataService registrations (real DataService, two widgets)', () => {
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('destroying one widget does not break another widget still sharing the same (path, source)', async () => {
+        vi.useFakeTimers();
+        const dataPathUpdates$ = new Subject<IPathValueData>();
+        TestBed.configureTestingModule({
+            providers: [
+                WidgetStreamsDirective,
+                DataService,
+                {
+                    provide: SignalKDeltaService,
+                    useValue: {
+                        subscribeDataPathsUpdates: () => dataPathUpdates$.asObservable(),
+                        subscribeMetadataUpdates: () => new Subject().asObservable(),
+                        subscribeNotificationsUpdates: () => new Subject().asObservable(),
+                        subscribeSelfUpdates: () => new Subject().asObservable(),
+                    },
+                },
+                { provide: UnitsService, useClass: FakeUnitsService }
+            ]
+        });
+
+        // directiveA: the module's own singleton instance (a first widget).
+        const directiveA = TestBed.inject(WidgetStreamsDirective);
+        // directiveB: a genuinely independent second instance (a second widget), created
+        // inside the same injection context so its inject(DataService) resolves to the
+        // SAME real DataService instance as directiveA - exactly like two separate
+        // widget-host2 instances on a dashboard both pointing at the same sensor path.
+        const directiveB = TestBed.runInInjectionContext(() => new WidgetStreamsDirective());
+
+        // Widget configs store the fully-resolved path (as DataService itself keys on),
+        // while the mock delta below uses the raw Signal K wire format (context + bare
+        // path) - matching data.service.spec.ts's own convention.
+        const cfg = makeCfg({ path: 'self.navigation.speedOverGround', source: 'gps-1' });
+
+        // Seed the real value BEFORE either widget subscribes, so subscribePath()'s
+        // initial snapshot (read from DataService's already-updated cache) already has
+        // it - matching how a widget added to a dashboard after data has been flowing
+        // for a while immediately shows the current value via the take(1) fast path,
+        // rather than needing to wait a full sampleTime interval for the next sample.
+        dataPathUpdates$.next({
+            context: 'self', path: 'navigation.speedOverGround', source: 'gps-1',
+            timestamp: '2026-01-01T00:00:01.000Z', value: 5.1,
+        });
+
+        directiveA.setStreamsConfig(cfg);
+        const hitsA: IPathUpdate[] = [];
+        directiveA.observe('p', u => hitsA.push(u));
+
+        directiveB.setStreamsConfig(cfg);
+        const hitsB: IPathUpdate[] = [];
+        directiveB.observe('p', u => hitsB.push(u));
+
+        await vi.advanceTimersByTimeAsync(0); // flush the take(1) fast-path
+        expect(hitsA[hitsA.length - 1].data.value).toBe(5.1);
+        expect(hitsB[hitsB.length - 1].data.value).toBe(5.1);
+
+        // Widget A is destroyed (dashboard switch, widget removed, etc.). Widget B is
+        // still using the exact same (path, source) and must keep receiving live data,
+        // not have its shared Subject silently completed out from under it.
+        directiveA.ngOnDestroy();
+
+        dataPathUpdates$.next({
+            context: 'self', path: 'navigation.speedOverGround', source: 'gps-1',
+            timestamp: '2026-01-01T00:00:02.000Z', value: 7.7,
+        });
+        await vi.advanceTimersByTimeAsync(1100); // past the default 1000ms sampleTime
+        expect(hitsB[hitsB.length - 1].data.value).toBe(7.7);
     });
 });

--- a/src/app/core/directives/widget-streams.directive.ts
+++ b/src/app/core/directives/widget-streams.directive.ts
@@ -43,12 +43,29 @@ export class WidgetStreamsDirective implements OnDestroy {
   private subscriptions = new Map<string, { sub: Subscription; signature: string }>();
   // Track identity of the cached base observable (path + normalized source) per path key
   private baseSignatures = new Map<string, string>();
+  // The (path, source) actually passed to dataService.subscribePath() per path key, so
+  // it can be released via dataService.unsubscribePath() when replaced or removed -
+  // otherwise DataService's shared registration for it is retained for the app's lifetime
+  // regardless of how many times widgets pointed at it come and go.
+  private baseIdentities = new Map<string, { path: string; source: string }>();
   // Root-level signature (timeout settings) to detect when all paths need pipeline rebuild
   private reset$ = new Subject<void>();
   private rootSignature: string | undefined;
 
-  // TODO: release DataService.subscribePath() registrations on destroy/replace.
-  ngOnDestroy(): void { /* not yet implemented */ }
+  /** Release this path key's DataService base registration, if it currently holds one. */
+  private releaseBase(pathName: string): void {
+    const identity = this.baseIdentities.get(pathName);
+    if (identity) {
+      this.dataService.unsubscribePath(identity.path, identity.source);
+      this.baseIdentities.delete(pathName);
+    }
+  }
+
+  ngOnDestroy(): void {
+    for (const pathName of [...this.baseIdentities.keys()]) {
+      this.releaseBase(pathName);
+    }
+  }
 
   /** Build a simple Observer wrapper for a given path key. */
   private buildObserver(pathKey: string, next: ((value: IPathUpdate) => void)): Observer<IPathUpdate> {
@@ -122,16 +139,20 @@ export class WidgetStreamsDirective implements OnDestroy {
       this.subscriptions.delete(pathName);
       this.streams?.delete(pathName);
       this.baseSignatures.delete(pathName);
+      this.releaseBase(pathName);
       return;
     }
 
     // Build base observable if missing, or refresh when path/source changed
     this.ensureStreamsMap();
+    const source = pathCfg.source?.trim() || 'default';
     const baseKey = this.computeBaseKey(normalizedPath, pathCfg.source);
     const currentBaseKey = this.baseSignatures.get(pathName);
     if (!this.streams!.has(pathName) || currentBaseKey !== baseKey) {
-      this.streams!.set(pathName, this.dataService.subscribePath(normalizedPath, pathCfg.source?.trim() || 'default'));
+      this.releaseBase(pathName);
+      this.streams!.set(pathName, this.dataService.subscribePath(normalizedPath, source));
       this.baseSignatures.set(pathName, baseKey);
+      this.baseIdentities.set(pathName, { path: normalizedPath, source });
     }
     const base$ = this.streams!.get(pathName)!;
 
@@ -279,6 +300,9 @@ export class WidgetStreamsDirective implements OnDestroy {
       this.subscriptions.clear();
       this.streams = undefined;
       this.baseSignatures.clear();
+      for (const pathName of [...this.baseIdentities.keys()]) {
+        this.releaseBase(pathName);
+      }
       this.registrations = [];
       return;
     }
@@ -291,6 +315,7 @@ export class WidgetStreamsDirective implements OnDestroy {
       this.subscriptions.delete(r);
       this.streams?.delete(r);
       this.baseSignatures.delete(r);
+      this.releaseBase(r);
       this.registrations = this.registrations.filter(x => x.pathName !== r);
     }
     const rootChanged = prevRootSig !== newRootSig;
@@ -303,6 +328,7 @@ export class WidgetStreamsDirective implements OnDestroy {
         this.subscriptions.delete(p);
         this.streams?.delete(p);
         this.baseSignatures.delete(p);
+        this.releaseBase(p);
         continue;
       }
       const normalizedCfg = { ...pathCfg, path: normalizedPath };
@@ -385,6 +411,7 @@ export class WidgetStreamsDirective implements OnDestroy {
         this.subscriptions.delete(pathName);
         this.streams?.delete(pathName);
         this.baseSignatures.delete(pathName);
+        this.releaseBase(pathName);
       }
       return;
     }
@@ -398,6 +425,7 @@ export class WidgetStreamsDirective implements OnDestroy {
         this.subscriptions.delete(pathName);
         this.streams?.delete(pathName);
         this.baseSignatures.delete(pathName);
+        this.releaseBase(pathName);
       }
       this.registrations = this.registrations.filter(r => r.pathName !== pathName);
       return;

--- a/src/app/core/directives/widget-streams.directive.ts
+++ b/src/app/core/directives/widget-streams.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, DestroyRef, inject, signal } from '@angular/core';
+import { Directive, DestroyRef, inject, OnDestroy, signal } from '@angular/core';
 import { DataService, IPathUpdate } from '../services/data.service';
 import { UnitsService } from '../services/units.service';
 import { IWidgetPath, IWidgetSvcConfig } from '../interfaces/widgets-interface';
@@ -31,7 +31,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
  * - Config changes automatically trigger diff-based subscription updates
  * - All subscriptions auto-cleanup on directive destroy
  */
-export class WidgetStreamsDirective {
+export class WidgetStreamsDirective implements OnDestroy {
   private _streamsConfig = signal<IWidgetSvcConfig | undefined>(undefined);
   private readonly dataService = inject(DataService);
   private readonly unitsService = inject(UnitsService);
@@ -46,6 +46,9 @@ export class WidgetStreamsDirective {
   // Root-level signature (timeout settings) to detect when all paths need pipeline rebuild
   private reset$ = new Subject<void>();
   private rootSignature: string | undefined;
+
+  // TODO: release DataService.subscribePath() registrations on destroy/replace.
+  ngOnDestroy(): void { /* not yet implemented */ }
 
   /** Build a simple Observer wrapper for a given path key. */
   private buildObserver(pathKey: string, next: ((value: IPathUpdate) => void)): Observer<IPathUpdate> {

--- a/src/app/core/services/ais-processing.service.spec.ts
+++ b/src/app/core/services/ais-processing.service.spec.ts
@@ -72,7 +72,8 @@ describe('AisProcessingService applyAisUpdate dispatch', () => {
       // Every prefix subscription shares the same stream; the merged pipeline
       // forwards anything we push. The self-nav stream also reads this but our
       // test paths only match AIS contexts, so they're routed correctly.
-      subscribePathTree: () => stream$.asObservable()
+      subscribePathTree: () => stream$.asObservable(),
+      removePathsForContext: vi.fn()
     };
 
     TestBed.configureTestingModule({
@@ -287,7 +288,10 @@ describe('AisProcessingService own-ship throttling', () => {
     vi.useFakeTimers();
     stream$ = new Subject<IPathUpdateWithPath>();
     TestBed.configureTestingModule({
-      providers: [AisProcessingService, { provide: DataService, useValue: { subscribePathTree: () => stream$.asObservable() } as Partial<DataService> }]
+      providers: [AisProcessingService, {
+        provide: DataService,
+        useValue: { subscribePathTree: () => stream$.asObservable(), removePathsForContext: vi.fn() } as Partial<DataService>
+      }]
     });
     service = TestBed.inject(AisProcessingService);
   });

--- a/src/app/core/services/ais-processing.service.spec.ts
+++ b/src/app/core/services/ais-processing.service.spec.ts
@@ -210,11 +210,17 @@ describe('AisProcessingService target eviction (bounds unbounded growth)', () =>
     evictStaleTracks: (nowMs: number) => void;
   };
 
+  let removePathsForContext: ReturnType<typeof vi.fn>;
+
   beforeEach(() => {
     vi.useFakeTimers();
     stream$ = new Subject<IPathUpdateWithPath>();
+    removePathsForContext = vi.fn();
     TestBed.configureTestingModule({
-      providers: [AisProcessingService, { provide: DataService, useValue: { subscribePathTree: () => stream$.asObservable() } as Partial<DataService> }]
+      providers: [AisProcessingService, {
+        provide: DataService,
+        useValue: { subscribePathTree: () => stream$.asObservable(), removePathsForContext } as Partial<DataService>
+      }]
     });
     service = TestBed.inject(AisProcessingService);
   });
@@ -242,6 +248,23 @@ describe('AisProcessingService target eviction (bounds unbounded growth)', () =>
     push(`vessels.urn:mrn:imo:mmsi:123456789.navigation.position.latitude`, 10);
     internals().evictStaleTracks(EVENT_TS + 60 * 1000); // 1 min later, within TTL
     expect(internals().tracks.size).toBe(1);
+  });
+
+  it('cleans up DataService path data when a track is evicted by the TTL sweep', () => {
+    push(`vessels.urn:mrn:imo:mmsi:123456789.navigation.position.latitude`, 10);
+    internals().evictStaleTracks(EVENT_TS + 11 * 60 * 1000);
+    expect(removePathsForContext).toHaveBeenCalledWith('vessels.urn:mrn:imo:mmsi:123456789');
+  });
+
+  it('cleans up DataService path data when a track is evicted by the max-targets cap', () => {
+    internals().maxTargets = 5;
+    for (let i = 0; i < 12; i++) {
+      push(`vessels.urn:mrn:imo:mmsi:${100000000 + i}.navigation.position.latitude`, 10 + i * 0.001);
+    }
+    // The first 7 pushed tracks (100000000..100000006) were evicted to make room for the cap.
+    expect(removePathsForContext).toHaveBeenCalledWith('vessels.urn:mrn:imo:mmsi:100000000');
+    expect(removePathsForContext).toHaveBeenCalledWith('vessels.urn:mrn:imo:mmsi:100000006');
+    expect(removePathsForContext).not.toHaveBeenCalledWith('vessels.urn:mrn:imo:mmsi:100000007');
   });
 });
 

--- a/src/app/core/services/ais-processing.service.ts
+++ b/src/app/core/services/ais-processing.service.ts
@@ -9,9 +9,9 @@ const THROTTLE_MS = 250;
 // explicit `status: 'remove'`, so without this every distinct MMSI ever heard
 // would accumulate for the app lifetime, making every flush + radar render
 // O(targets) and heavier over uptime (the "unresponsive after a while" freeze).
-const TARGET_TTL_MS = 10 * 60 * 1000; // drop targets not heard from in 10 minutes
+const TARGET_TTL_MS = 60 * 60 * 1000; // drop targets not heard from in 60 minutes. Safe measure only as normally the AIS status field, handled by sk-ais-status-plugin, is used to remove targets.
 const MAX_TARGETS = 500;              // hard cap on retained targets
-const EVICTION_SWEEP_MS = 15000;      // periodic stale-target sweep cadence
+const EVICTION_SWEEP_MS = 5 * 60 * 1000;      // periodic stale-target sweep cadence
 
 type AisClass = 'A' | 'B' | undefined;
 type AisTargetType = 'vessel' | 'aton' | 'basestation' | 'sar';

--- a/src/app/core/services/ais-processing.service.ts
+++ b/src/app/core/services/ais-processing.service.ts
@@ -630,6 +630,10 @@ export class AisProcessingService {
     for (const [context, id] of this.contextIndex.entries()) {
       if (id === track.id) this.contextIndex.delete(context);
     }
+    // Bounding this service's own track map doesn't help unless DataService's
+    // path-keyed caches are pruned too - otherwise every distinct context ever
+    // seen (e.g. a never-repeating AIS MMSI) is retained there forever.
+    this.data.removePathsForContext(track.context);
     if (AIS_DEBUG) {
       console.debug('[AIS] removed', { id: track.id, mmsi: track.mmsi, status: track.ais.status });
     }

--- a/src/app/core/services/data.service.spec.ts
+++ b/src/app/core/services/data.service.spec.ts
@@ -392,4 +392,19 @@ describe('DataService', () => {
     expect(latestTree!.map(item => item.path)).toContain('self.navigation.speedOverGround');
     expect(latestMeta!.map(item => item.path)).not.toContain('vessels.urn:mrn:imo:mmsi:123456789.navigation.position');
   });
+
+  it('removePathsForContext is a no-op for the self context, so a future caller can never wipe the boat\'s own instrument data', () => {
+    dataPathUpdates$.next({
+      context: 'self',
+      path: 'navigation.speedOverGround',
+      source: 'test-source',
+      timestamp: '2026-01-01T00:00:01.000Z',
+      value: 5.1,
+    });
+
+    service.removePathsForContext('self');
+
+    expect(service.getPathObject('self.navigation.speedOverGround')).toBeTruthy();
+    expect(service.getCachedPaths()).toContain('self.navigation.speedOverGround');
+  });
 });

--- a/src/app/core/services/data.service.spec.ts
+++ b/src/app/core/services/data.service.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { Subject } from 'rxjs';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { IMeta, IPathValueData } from '../interfaces/app-interfaces';
+import { IMeta, IPathMetaData, IPathValueData, ISkPathData } from '../interfaces/app-interfaces';
 import { ISignalKDataValueUpdate, States } from '../interfaces/signalk-interfaces';
 import { DataService, IPathUpdate, IPathUpdateWithPath } from './data.service';
 import { SignalKDeltaService } from './signalk-delta.service';
@@ -304,5 +304,45 @@ describe('DataService', () => {
     ].sort());
     expect(service.getPathObject('self.navigation.speedOverGround')).toBeTruthy();
     expect(service.getPathObject('vessels.urn:mrn:imo:mmsi:987654321.navigation.position')).toBeTruthy();
+  });
+
+  it('removePathsForContext also prunes the full-tree data and meta caches when the debug views are active', () => {
+    dataPathUpdates$.next({
+      context: 'self',
+      path: 'navigation.speedOverGround',
+      source: 'test-source',
+      timestamp: '2026-01-01T00:00:01.000Z',
+      value: 5.1,
+    });
+    dataPathUpdates$.next({
+      context: 'vessels.urn:mrn:imo:mmsi:123456789',
+      path: 'navigation.position',
+      source: 'test-source',
+      timestamp: '2026-01-01T00:00:01.000Z',
+      value: { latitude: 1, longitude: 2 },
+    });
+
+    let latestTree: ISkPathData[] | undefined;
+    service.startSkDataFullTree().subscribe(tree => (latestTree = tree));
+
+    let latestMeta: IPathMetaData[] | undefined;
+    service.startSkMetaFullTree().subscribe(meta => (latestMeta = meta));
+    metadataUpdates$.next({
+      context: 'vessels.urn:mrn:imo:mmsi:123456789',
+      path: 'navigation.position',
+      meta: { description: 'Vessel position', units: 'rad', properties: {} },
+    });
+
+    expect(latestTree!.map(item => item.path)).toContain('vessels.urn:mrn:imo:mmsi:123456789.navigation.position');
+    expect(latestMeta!.map(item => item.path)).toContain('vessels.urn:mrn:imo:mmsi:123456789.navigation.position');
+
+    service.removePathsForContext('vessels.urn:mrn:imo:mmsi:123456789');
+    // startSkDataFullTree() re-synced the cache and emitted immediately above;
+    // the eviction's own emit is debounced, so re-open to check synchronously.
+    service.startSkDataFullTree().subscribe(tree => (latestTree = tree));
+
+    expect(latestTree!.map(item => item.path)).not.toContain('vessels.urn:mrn:imo:mmsi:123456789.navigation.position');
+    expect(latestTree!.map(item => item.path)).toContain('self.navigation.speedOverGround');
+    expect(latestMeta!.map(item => item.path)).not.toContain('vessels.urn:mrn:imo:mmsi:123456789.navigation.position');
   });
 });

--- a/src/app/core/services/data.service.spec.ts
+++ b/src/app/core/services/data.service.spec.ts
@@ -265,4 +265,44 @@ describe('DataService', () => {
     subA.unsubscribe();
     subB.unsubscribe();
   });
+
+  it('removePathsForContext removes cached path data for a context, leaving other contexts untouched', () => {
+    dataPathUpdates$.next({
+      context: 'self',
+      path: 'navigation.speedOverGround',
+      source: 'test-source',
+      timestamp: '2026-01-01T00:00:01.000Z',
+      value: 5.1,
+    });
+    dataPathUpdates$.next({
+      context: 'vessels.urn:mrn:imo:mmsi:123456789',
+      path: 'navigation.position',
+      source: 'test-source',
+      timestamp: '2026-01-01T00:00:01.000Z',
+      value: { latitude: 1, longitude: 2 },
+    });
+    dataPathUpdates$.next({
+      context: 'vessels.urn:mrn:imo:mmsi:987654321',
+      path: 'navigation.position',
+      source: 'test-source',
+      timestamp: '2026-01-01T00:00:01.000Z',
+      value: { latitude: 3, longitude: 4 },
+    });
+
+    expect(service.getCachedPaths().sort()).toEqual([
+      'self.navigation.speedOverGround',
+      'vessels.urn:mrn:imo:mmsi:123456789.navigation.position',
+      'vessels.urn:mrn:imo:mmsi:987654321.navigation.position',
+    ].sort());
+
+    service.removePathsForContext('vessels.urn:mrn:imo:mmsi:123456789');
+
+    expect(service.getPathObject('vessels.urn:mrn:imo:mmsi:123456789.navigation.position')).toBeNull();
+    expect(service.getCachedPaths().sort()).toEqual([
+      'self.navigation.speedOverGround',
+      'vessels.urn:mrn:imo:mmsi:987654321.navigation.position',
+    ].sort());
+    expect(service.getPathObject('self.navigation.speedOverGround')).toBeTruthy();
+    expect(service.getPathObject('vessels.urn:mrn:imo:mmsi:987654321.navigation.position')).toBeTruthy();
+  });
 });

--- a/src/app/core/services/data.service.spec.ts
+++ b/src/app/core/services/data.service.spec.ts
@@ -393,6 +393,32 @@ describe('DataService', () => {
     expect(latestMeta!.map(item => item.path)).not.toContain('vessels.urn:mrn:imo:mmsi:123456789.navigation.position');
   });
 
+  it('removePathsForContext while full-tree is inactive is reflected after startSkDataFullTree rebuild', () => {
+    dataPathUpdates$.next({
+      context: 'self',
+      path: 'navigation.speedOverGround',
+      source: 'test-source',
+      timestamp: '2026-01-01T00:00:01.000Z',
+      value: 5.1,
+    });
+    dataPathUpdates$.next({
+      context: 'vessels.urn:mrn:imo:mmsi:123456789',
+      path: 'navigation.position',
+      source: 'test-source',
+      timestamp: '2026-01-01T00:00:01.000Z',
+      value: { latitude: 1, longitude: 2 },
+    });
+
+    // startSkDataFullTree() has not been called yet, so the full-tree cache is inactive.
+    service.removePathsForContext('vessels.urn:mrn:imo:mmsi:123456789');
+
+    let latestTree: ISkPathData[] | undefined;
+    service.startSkDataFullTree().subscribe(tree => (latestTree = tree));
+
+    expect(latestTree!.map(item => item.path)).toContain('self.navigation.speedOverGround');
+    expect(latestTree!.map(item => item.path)).not.toContain('vessels.urn:mrn:imo:mmsi:123456789.navigation.position');
+  });
+
   it('removePathsForContext is a no-op for the self context, so a future caller can never wipe the boat\'s own instrument data', () => {
     dataPathUpdates$.next({
       context: 'self',

--- a/src/app/core/services/data.service.spec.ts
+++ b/src/app/core/services/data.service.spec.ts
@@ -42,6 +42,53 @@ describe('DataService', () => {
     expect(service).toBeTruthy();
   });
 
+  it('unsubscribePath only tears down a shared registration once every subscriber has released it', () => {
+    // Two independent consumers of the exact same (path, source) - subscribePath()
+    // dedupes and shares the same underlying registration between them.
+    let completedA = false;
+    let completedB = false;
+    service
+      .subscribePath('self.navigation.speedOverGround', 'default')
+      .subscribe({ next: () => { }, complete: () => (completedA = true) });
+    service
+      .subscribePath('self.navigation.speedOverGround', 'default')
+      .subscribe({ next: () => { }, complete: () => (completedB = true) });
+
+    service.unsubscribePath('self.navigation.speedOverGround', 'default');
+    expect(completedA).toBe(false);
+    expect(completedB).toBe(false);
+
+    dataPathUpdates$.next({
+      context: 'self',
+      path: 'navigation.speedOverGround',
+      source: 'test-source',
+      timestamp: '2026-01-01T00:00:01.000Z',
+      value: 6.2,
+    });
+    // Still live after only one of two consumers released it.
+    expect(service.getPathObject('self.navigation.speedOverGround')).toBeTruthy();
+
+    service.unsubscribePath('self.navigation.speedOverGround', 'default');
+    expect(completedA).toBe(true);
+    expect(completedB).toBe(true);
+  });
+
+  it('unsubscribePath matches by path AND source, leaving other sources on the same path untouched', () => {
+    let completedDefault = false;
+    let completedOther = false;
+    service
+      .subscribePath('self.navigation.speedOverGround', 'default')
+      .subscribe({ next: () => { }, complete: () => (completedDefault = true) });
+    service
+      .subscribePath('self.navigation.speedOverGround', 'gps-2')
+      .subscribe({ next: () => { }, complete: () => (completedOther = true) });
+
+    service.unsubscribePath('self.navigation.speedOverGround', 'default');
+
+    expect(completedDefault).toBe(true);
+    expect(completedOther).toBe(false);
+  });
+
   it('applies notification state to path value updates', () => {
     let latest: IPathUpdate | undefined;
 

--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -228,6 +228,19 @@ export class DataService implements OnDestroy {
     this._isReset.next(true);
   }
 
+  /**
+   * Removes cached data, metadata, and pending notification state for every
+   * path under a given context (e.g. an AIS target evicted elsewhere).
+   * Active widget subscriptions to the context's paths are left alone - see
+   * unsubscribePath - they simply stop receiving updates once no more deltas
+   * arrive for the removed context.
+   *
+   * @param context Signal K context, e.g. "vessels.urn:mrn:imo:mmsi:123456789"
+   */
+  public removePathsForContext(context: string): void {
+    // TODO: not yet implemented
+  }
+
   public unsubscribePath(path: string): void {
     const index = this._pathRegister.findIndex(registration => registration.path === path);
 

--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -151,7 +151,7 @@ export class DataService implements OnDestroy {
   private _pendingPathStates = new Map<string, TState>();
   /** Full-tree cache (mutated in place); subscribers must not rely on array identity changes. */
   private _skDataArrayCache: ISkPathData[] = [];
-  /** Path -> index lookup for `_skDataArrayCache` to enable O(1) upserts. */
+  /** Path -> index lookup for `_skDataArrayCache` to enable O(1) upsert. */
   private _skDataIndexByPath = new Map<string, number>();
   private _pathRegister: IPathRegistration[] = []; // List of paths used by Kip (Widgets or App (Notifications and such))
   /** Path -> registrations index for fast lookups during updates. */
@@ -244,31 +244,38 @@ export class DataService implements OnDestroy {
    * @param context Signal K context, e.g. "vessels.urn:mrn:imo:mmsi:123456789"
    */
   public removePathsForContext(context: string): void {
-    if (context === SELFROOTDEF) return;
+    if (context === SELFROOTDEF || context === this._selfUrn) return;
 
     const prefix = `${context}.`;
+    let removedSkData = false;
 
     for (const path of this._skData.keys()) {
-      if (path.startsWith(prefix)) this._skData.delete(path);
+      if (path.startsWith(prefix)) {
+        this._skData.delete(path);
+        removedSkData = true;
+      }
     }
 
     for (const path of this._pendingPathStates.keys()) {
       if (path.startsWith(prefix)) this._pendingPathStates.delete(path);
     }
 
-    if (this._skDataArrayCache.some(item => item.path.startsWith(prefix))) {
+    if (removedSkData && this._isSkDataFullTreeActive) {
       // _skData already had the matching entries removed above, so rebuilding
       // from it here also drops them from the array cache and its index.
       this.refreshSkDataCache();
-      if (this._isSkDataFullTreeActive) {
-        this.scheduleSkDataFullTreeEmit();
+      this.scheduleSkDataFullTreeEmit();
+    }
+
+    let removedMeta = false;
+    for (const path of this._dataServiceMetaByPath.keys()) {
+      if (path.startsWith(prefix)) {
+        this._dataServiceMetaByPath.delete(path);
+        removedMeta = true;
       }
     }
 
-    if ([...this._dataServiceMetaByPath.keys()].some(path => path.startsWith(prefix))) {
-      for (const path of this._dataServiceMetaByPath.keys()) {
-        if (path.startsWith(prefix)) this._dataServiceMetaByPath.delete(path);
-      }
+    if (removedMeta) {
       this._dataServiceMeta = Array.from(this._dataServiceMetaByPath.values());
       if (this._isSkMetaFullTreeActive) {
         this._dataServiceMetaSubject$.next(this._dataServiceMeta);

--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -241,7 +241,12 @@ export class DataService implements OnDestroy {
    * AIS-like context is, so this guards against a future caller wiping the
    * boat's own live instrument data by mistake.
    *
-   * @param context Signal K context, e.g. "vessels.urn:mrn:imo:mmsi:123456789"
+  * @param {string} context Signal K context, e.g. "vessels.urn:mrn:imo:mmsi:123456789".
+  * @returns {void}
+  *
+  * @example
+  * // Remove all cached path/meta entries for one AIS context after track eviction.
+  * dataService.removePathsForContext('vessels.urn:mrn:imo:mmsi:123456789');
    */
   public removePathsForContext(context: string): void {
     if (context === SELFROOTDEF || context === this._selfUrn) return;
@@ -284,19 +289,30 @@ export class DataService implements OnDestroy {
   }
 
   /**
-   * Releases one caller's hold on a subscribePath(path, source) registration.
-   * subscribePath() shares a single registration between every caller that
-   * asks for the same (path, source) pair, so this only actually completes
-   * the underlying Subjects and removes the registration once every caller
-   * that obtained it has released it (refCount reaches 0) - releasing it
-   * while another caller is still using it would silently kill their live
-   * data with no warning.
-   */
+  * Releases one caller's hold on a subscribePath(path, source) registration.
+  * subscribePath() shares a single registration between every caller that
+  * asks for the same (path, source) pair, so this only actually completes
+  * the underlying Subjects and removes the registration once every caller
+  * that obtained it has released it (refCount reaches 0) - releasing it
+  * while another caller is still using it would silently kill their live
+  * data with no warning.
+  *
+  * @param {string} path Full Signal K path, e.g. "self.navigation.speedOverGround".
+  * @param {string} source Specify path source key or use.
+  * @returns {void}
+  *
+  * @example
+  * // Release one consumer of a shared (path, source) registration.
+  * dataService.unsubscribePath('self.navigation.speedOverGround', 'default');
+  */
   public unsubscribePath(path: string, source: string): void {
-    const index = this._pathRegister.findIndex(registration => registration.path === path && registration.source === source);
-    if (index === -1) return;
+    const registrations = this._pathRegisterByPath.get(path);
+    if (!registrations?.length) return;
 
-    const registration = this._pathRegister[index];
+    const pathIndex = registrations.findIndex(registration => registration.source === source);
+    if (pathIndex === -1) return;
+
+    const registration = registrations[pathIndex];
     registration.refCount--;
     if (registration.refCount > 0) return;
 
@@ -307,64 +323,76 @@ export class DataService implements OnDestroy {
     registration.pathDataUpdate$?.complete();
     registration.pathMeta$?.complete();
 
-    // Use splice to remove the item without changing the entire
-    // array reference.
-    this._pathRegister.splice(index, 1);
+    // Remove from the per-path bucket first, then from the global register.
+    registrations.splice(pathIndex, 1);
+    if (!registrations.length) {
+      this._pathRegisterByPath.delete(path);
+    }
 
-    const registrations = this._pathRegisterByPath.get(path);
-    if (registrations) {
-      const updated = registrations.filter(item => item !== registration);
-      if (updated.length) {
-        this._pathRegisterByPath.set(path, updated);
-      } else {
-        this._pathRegisterByPath.delete(path);
-      }
+    const registerIndex = this._pathRegister.indexOf(registration);
+    if (registerIndex !== -1) {
+      // Use splice to remove the item without changing the entire
+      // array reference.
+      this._pathRegister.splice(registerIndex, 1);
     }
   }
 
+  /**
+   * Returns a shared observable for a (path, source) registration.
+   *
+   * If a registration already exists for the same pair, this increments its
+   * refCount and reuses the existing stream. Otherwise, a new registration is
+   * created and seeded with the current cached value/state/meta snapshot.
+   *
+   * @param {string} path Full Signal K path, e.g. "self.navigation.speedOverGround".
+   * @param {string} source Specify path source key.
+   * @returns {Observable<IPathUpdate>} Shared stream of value/state updates for
+   * the requested (path, source) pair.
+   *
+   * @example
+   * // Subscribe to server-priority (pathValue) updates.
+   * const sub = dataService
+   *   .subscribePath('self.navigation.speedOverGround', 'default')
+   *   .subscribe(update => console.log(update.data.value, update.state));
+   */
   public subscribePath(path: string, source: string): Observable<IPathUpdate> {
     const registrations = this._pathRegisterByPath.get(path);
-    const matchingPaths = registrations?.find(item => item.path === path && item.source === source);
+    const matchingPaths = registrations?.find(item => item.source === source);
     if (matchingPaths) {
       matchingPaths.refCount++;
       return matchingPaths.pathDataUpdate$;
     }
 
-    let currentValue: unknown = null;
-    let currentTimestamp: string | null | undefined = null;
-    let currentDateTimestamp: Date | null = null;
-    let state: TState = States.Normal;
     let pathUpdate: IPathUpdate = {
       data: {
         value: null,
         timestamp: null
       },
-      state: state
+      state: States.Normal
     };
     let metaUpdate: ISkMetadata | null = null;
 
     const dataPath = this._skData.get(path);
 
     if (dataPath) {
-      currentValue = source === 'default' ? dataPath.pathValue : dataPath.sources?.[source]?.sourceValue ?? null;
-      currentTimestamp = source === 'default' ? dataPath.pathTimestamp : dataPath.sources?.[source]?.sourceTimestamp ?? null;
-      currentDateTimestamp = currentTimestamp ? new Date(currentTimestamp) : null;
+      const useDefault = source === 'default';
+      const currentValue = useDefault ? dataPath.pathValue : dataPath.sources?.[source]?.sourceValue ?? null;
+      const currentTimestamp = useDefault ? dataPath.pathTimestamp : dataPath.sources?.[source]?.sourceTimestamp ?? null;
 
       pathUpdate = {
         data: {
           value: currentValue,
-          timestamp: currentDateTimestamp
+          timestamp: currentTimestamp ? new Date(currentTimestamp) : null
         },
-        state: dataPath.state || state
+        state: dataPath.state || States.Normal
       };
 
-      state = dataPath.state || state;
       metaUpdate = dataPath.meta || null;
     }
 
     const newPathSubject: IPathRegistration = {
-      path: path,
-      source: source,
+      path,
+      source,
       refCount: 1,
       _pathData$: new BehaviorSubject<IPathData>(pathUpdate.data),
       _pathState$: new BehaviorSubject<TState>(pathUpdate.state),

--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -249,9 +249,9 @@ export class DataService implements OnDestroy {
     }
 
     if (this._skDataArrayCache.some(item => item.path.startsWith(prefix))) {
-      this._skDataArrayCache = this._skDataArrayCache.filter(item => !item.path.startsWith(prefix));
-      this._skDataIndexByPath.clear();
-      this._skDataArrayCache.forEach((item, index) => this._skDataIndexByPath.set(item.path, index));
+      // _skData already had the matching entries removed above, so rebuilding
+      // from it here also drops them from the array cache and its index.
+      this.refreshSkDataCache();
       if (this._isSkDataFullTreeActive) {
         this.scheduleSkDataFullTreeEmit();
       }

--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -237,9 +237,15 @@ export class DataService implements OnDestroy {
    * unsubscribePath - they simply stop receiving updates once no more deltas
    * arrive for the removed context.
    *
+   * A no-op for the self context - self path data is never "evicted" the way an
+   * AIS-like context is, so this guards against a future caller wiping the
+   * boat's own live instrument data by mistake.
+   *
    * @param context Signal K context, e.g. "vessels.urn:mrn:imo:mmsi:123456789"
    */
   public removePathsForContext(context: string): void {
+    if (context === SELFROOTDEF) return;
+
     const prefix = `${context}.`;
 
     for (const path of this._skData.keys()) {

--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -238,7 +238,34 @@ export class DataService implements OnDestroy {
    * @param context Signal K context, e.g. "vessels.urn:mrn:imo:mmsi:123456789"
    */
   public removePathsForContext(context: string): void {
-    // TODO: not yet implemented
+    const prefix = `${context}.`;
+
+    for (const path of this._skData.keys()) {
+      if (path.startsWith(prefix)) this._skData.delete(path);
+    }
+
+    for (const path of this._pendingPathStates.keys()) {
+      if (path.startsWith(prefix)) this._pendingPathStates.delete(path);
+    }
+
+    if (this._skDataArrayCache.some(item => item.path.startsWith(prefix))) {
+      this._skDataArrayCache = this._skDataArrayCache.filter(item => !item.path.startsWith(prefix));
+      this._skDataIndexByPath.clear();
+      this._skDataArrayCache.forEach((item, index) => this._skDataIndexByPath.set(item.path, index));
+      if (this._isSkDataFullTreeActive) {
+        this.scheduleSkDataFullTreeEmit();
+      }
+    }
+
+    if ([...this._dataServiceMetaByPath.keys()].some(path => path.startsWith(prefix))) {
+      for (const path of this._dataServiceMetaByPath.keys()) {
+        if (path.startsWith(prefix)) this._dataServiceMetaByPath.delete(path);
+      }
+      this._dataServiceMeta = Array.from(this._dataServiceMetaByPath.values());
+      if (this._isSkMetaFullTreeActive) {
+        this._dataServiceMetaSubject$.next(this._dataServiceMeta);
+      }
+    }
   }
 
   public unsubscribePath(path: string): void {

--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -90,6 +90,8 @@ const buildPathData = (value: unknown, rawTimestamp: string | number | Date | nu
 interface IPathRegistration {
   path: string;
   source: string;
+  /** Number of live callers sharing this registration; only torn down at 0 (see unsubscribePath). */
+  refCount: number;
   _pathData$: BehaviorSubject<IPathData>;
   _pathState$: BehaviorSubject<TState>;
   pathDataUpdate$: BehaviorSubject<IPathUpdate>;
@@ -268,15 +270,50 @@ export class DataService implements OnDestroy {
     }
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  /**
+   * Releases one caller's hold on a subscribePath(path, source) registration.
+   * subscribePath() shares a single registration between every caller that
+   * asks for the same (path, source) pair, so this only actually completes
+   * the underlying Subjects and removes the registration once every caller
+   * that obtained it has released it (refCount reaches 0) - releasing it
+   * while another caller is still using it would silently kill their live
+   * data with no warning.
+   */
   public unsubscribePath(path: string, source: string): void {
-    // TODO: not yet implemented - refCount-aware teardown
+    const index = this._pathRegister.findIndex(registration => registration.path === path && registration.source === source);
+    if (index === -1) return;
+
+    const registration = this._pathRegister[index];
+    registration.refCount--;
+    if (registration.refCount > 0) return;
+
+    // Ensure all observables are completed to avoid memory leaks
+    registration.combinedSub?.unsubscribe();
+    registration._pathData$?.complete();
+    registration._pathState$?.complete();
+    registration.pathDataUpdate$?.complete();
+    registration.pathMeta$?.complete();
+
+    // Use splice to remove the item without changing the entire
+    // array reference.
+    this._pathRegister.splice(index, 1);
+
+    const registrations = this._pathRegisterByPath.get(path);
+    if (registrations) {
+      const updated = registrations.filter(item => item !== registration);
+      if (updated.length) {
+        this._pathRegisterByPath.set(path, updated);
+      } else {
+        this._pathRegisterByPath.delete(path);
+      }
+    }
   }
 
   public subscribePath(path: string, source: string): Observable<IPathUpdate> {
     const registrations = this._pathRegisterByPath.get(path);
     const matchingPaths = registrations?.find(item => item.path === path && item.source === source);
     if (matchingPaths) {
+      matchingPaths.refCount++;
       return matchingPaths.pathDataUpdate$;
     }
 
@@ -315,6 +352,7 @@ export class DataService implements OnDestroy {
     const newPathSubject: IPathRegistration = {
       path: path,
       source: source,
+      refCount: 1,
       _pathData$: new BehaviorSubject<IPathData>(pathUpdate.data),
       _pathState$: new BehaviorSubject<TState>(pathUpdate.state),
       pathDataUpdate$: new BehaviorSubject<IPathUpdate>(pathUpdate),

--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -268,33 +268,9 @@ export class DataService implements OnDestroy {
     }
   }
 
-  public unsubscribePath(path: string): void {
-    const index = this._pathRegister.findIndex(registration => registration.path === path);
-
-    if (index !== -1) {
-      const registration = this._pathRegister[index];
-
-      // Ensure all observables are completed to avoid memory leaks
-      registration.combinedSub?.unsubscribe();
-      registration._pathData$?.complete();
-      registration._pathState$?.complete();
-      registration.pathDataUpdate$?.complete();
-      registration.pathMeta$?.complete();
-
-      // Use splice to remove the item without changing the entire
-      // array reference.
-      this._pathRegister.splice(index, 1);
-
-      const registrations = this._pathRegisterByPath.get(path);
-      if (registrations) {
-        const updated = registrations.filter(item => item !== registration);
-        if (updated.length) {
-          this._pathRegisterByPath.set(path, updated);
-        } else {
-          this._pathRegisterByPath.delete(path);
-        }
-      }
-    }
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  public unsubscribePath(path: string, source: string): void {
+    // TODO: not yet implemented - refCount-aware teardown
   }
 
   public subscribePath(path: string, source: string): Observable<IPathUpdate> {

--- a/src/app/core/services/dataset-stream.service.spec.ts
+++ b/src/app/core/services/dataset-stream.service.spec.ts
@@ -11,6 +11,7 @@ import { firstValueFrom, of } from 'rxjs';
 
 describe('DatasetStreamService', () => {
     let historyServiceMock: { getValues: ReturnType<typeof vi.fn> };
+    let dataServiceMock: Partial<DataService> & { unsubscribePath: ReturnType<typeof vi.fn> };
 
     beforeEach(() => {
         historyServiceMock = {
@@ -27,9 +28,10 @@ describe('DatasetStreamService', () => {
             saveDataSets: () => undefined
         };
 
-        const dataServiceMock: Partial<DataService> = {
+        dataServiceMock = {
             getPathUnitType: () => 'number',
-            subscribePath: () => of({ data: { value: 1, timestamp: null }, state: 'normal' })
+            subscribePath: () => of({ data: { value: 1, timestamp: null }, state: 'normal' }),
+            unsubscribePath: vi.fn().mockName("DataService.unsubscribePath")
         };
 
         TestBed.configureTestingModule({
@@ -290,6 +292,30 @@ describe('DatasetStreamService', () => {
         expect(dataSource.pathObserverSubscription.closed).toBe(false);
 
         service.ngOnDestroy();
+    }));
+
+    it('releases the DataService registration when a dataset is stopped', inject([DatasetStreamService], async (service: DatasetStreamService) => {
+        const config = {
+            uuid: 'ds-stop-release',
+            path: 'navigation.speedThroughWater',
+            pathSource: 'test-source',
+            baseUnit: 'number',
+            timeScaleFormat: 'Last 5 Minutes' as const,
+            period: 1,
+            label: 'test-stop-release'
+        };
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (service as any)._svcDatasetConfigs = [config];
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await (service as any).start(config.uuid);
+
+        expect(dataServiceMock.unsubscribePath).not.toHaveBeenCalled();
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (service as any).stop(config.uuid);
+
+        expect(dataServiceMock.unsubscribePath).toHaveBeenCalledWith('navigation.speedThroughWater', 'test-source');
     }));
 
     it('sets dataset stats only on final history datapoint using datapoint values', inject([DatasetStreamService], (service: DatasetStreamService) => {

--- a/src/app/core/services/dataset-stream.service.spec.ts
+++ b/src/app/core/services/dataset-stream.service.spec.ts
@@ -11,7 +11,7 @@ import { firstValueFrom, of } from 'rxjs';
 
 describe('DatasetStreamService', () => {
     let historyServiceMock: { getValues: ReturnType<typeof vi.fn> };
-    let dataServiceMock: Partial<DataService> & { unsubscribePath: ReturnType<typeof vi.fn> };
+    let dataServiceMock: Partial<DataService> & { subscribePath: ReturnType<typeof vi.fn>; unsubscribePath: ReturnType<typeof vi.fn> };
 
     beforeEach(() => {
         historyServiceMock = {
@@ -30,7 +30,7 @@ describe('DatasetStreamService', () => {
 
         dataServiceMock = {
             getPathUnitType: () => 'number',
-            subscribePath: () => of({ data: { value: 1, timestamp: null }, state: 'normal' }),
+            subscribePath: vi.fn(() => of({ data: { value: 1, timestamp: null }, state: 'normal' as const })).mockName("DataService.subscribePath"),
             unsubscribePath: vi.fn().mockName("DataService.unsubscribePath")
         };
 
@@ -316,6 +316,42 @@ describe('DatasetStreamService', () => {
         (service as any).stop(config.uuid);
 
         expect(dataServiceMock.unsubscribePath).toHaveBeenCalledWith('navigation.speedThroughWater', 'test-source');
+    }));
+
+    it('does not release someone else\'s registration or leak one when stop() races a pending history seed', inject([DatasetStreamService], async (service: DatasetStreamService) => {
+        let resolveHistory: (value: unknown) => void;
+        historyServiceMock.getValues.mockImplementation(() => new Promise(resolve => { resolveHistory = resolve; }));
+
+        const config = {
+            uuid: 'ds-race',
+            path: 'navigation.speedThroughWater',
+            pathSource: 'race-source',
+            baseUnit: 'number',
+            timeScaleFormat: 'Last 5 Minutes' as const,
+            period: 1,
+            label: 'test-race'
+        };
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (service as any)._svcDatasetConfigs = [config];
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const startPromise = (service as any).start(config.uuid);
+
+        // stop() runs while start() is still awaiting the history response: the
+        // dataSource entry exists (path/pathSource are already set) but
+        // DataService.subscribePath() has not been called yet.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (service as any).stop(config.uuid);
+
+        expect(dataServiceMock.unsubscribePath).not.toHaveBeenCalled();
+
+        resolveHistory!({ context: 'vessels.self', range: { from: '2026-01-01T00:00:00.000Z', to: '2026-01-01T00:00:00.000Z' }, values: [], data: [] });
+        await startPromise;
+
+        // start()'s continuation must not resurrect a registration for an already-stopped
+        // dataset - that registration would never get released, reintroducing the leak.
+        expect(dataServiceMock.subscribePath).not.toHaveBeenCalled();
+        expect(dataServiceMock.unsubscribePath).not.toHaveBeenCalled();
     }));
 
     it('sets dataset stats only on final history datapoint using datapoint values', inject([DatasetStreamService], (service: DatasetStreamService) => {

--- a/src/app/core/services/dataset-stream.service.ts
+++ b/src/app/core/services/dataset-stream.service.ts
@@ -296,6 +296,13 @@ export class DatasetStreamService implements OnDestroy {
       await this.seedHistoryData(dataSource, configuration, historyResolutionSeconds, angleDomain);
     }
 
+    // A concurrent stop() may have removed this dataSource while history was loading -
+    // don't resurrect a DataService registration for a dataset that's already stopped;
+    // nothing would ever release it.
+    if (!this._svcDataSource.includes(dataSource)) {
+      return;
+    }
+
     // Share the latest non-null value so we can:
     // 1) emit immediately on first value (chart isn't blank)
     // 2) then emit periodically using the latest known value
@@ -428,8 +435,13 @@ export class DatasetStreamService implements OnDestroy {
     }
     console.log(`[DatasetStreamService] Stopping Dataset ${uuid} data capture`);
     const dataSource = this._svcDataSource[dsIndex];
-    dataSource.pathObserverSubscription?.unsubscribe();
-    this.data.unsubscribePath(dataSource.path, dataSource.pathSource);
+    // pathObserverSubscription is only set once start() has actually reached its
+    // subscribePath() call (it may still be awaiting a history seed) - only release
+    // a registration this dataSource actually acquired.
+    if (dataSource.pathObserverSubscription) {
+      dataSource.pathObserverSubscription.unsubscribe();
+      this.data.unsubscribePath(dataSource.path, dataSource.pathSource);
+    }
     this._svcDataSource.splice(dsIndex, 1);
   }
 

--- a/src/app/core/services/dataset-stream.service.ts
+++ b/src/app/core/services/dataset-stream.service.ts
@@ -44,6 +44,8 @@ export interface IDatasetServiceDataSourceInfo {
 
 interface IDatasetServiceDataSource extends IDatasetServiceDataSourceInfo {
   uuid: string;
+  path: string;
+  pathSource: string;
   pathObserverSubscription: Subscription | null;
   historicalData: number[];
 };
@@ -184,6 +186,8 @@ export class DatasetStreamService implements OnDestroy {
 
     const newDataSourceConfiguration: IDatasetServiceDataSource = {
       uuid: dsConf.uuid,
+      path: dsConf.path,
+      pathSource: dsConf.pathSource,
       pathObserverSubscription: null,
       sampleTime: derivedSampleTimeMs,
       maxDataPoints,
@@ -423,7 +427,9 @@ export class DatasetStreamService implements OnDestroy {
       return;
     }
     console.log(`[DatasetStreamService] Stopping Dataset ${uuid} data capture`);
-    this._svcDataSource[dsIndex].pathObserverSubscription?.unsubscribe();
+    const dataSource = this._svcDataSource[dsIndex];
+    dataSource.pathObserverSubscription?.unsubscribe();
+    this.data.unsubscribePath(dataSource.path, dataSource.pathSource);
     this._svcDataSource.splice(dsIndex, 1);
   }
 


### PR DESCRIPTION
## Fix an unbounded memory leak in DataService

`DataService` never removed anything from its path-keyed caches (`_skData`, `_skDataArrayCache`/`_skDataIndexByPath`, `_dataServiceMetaByPath`, `_pendingPathStates`) once written. `updatePathData()`/`setMeta()` run for every incoming delta and always `.set()`; there's no `.delete()` for any of them anywhere in the file. `AisProcessingService` already bounds its own internal target map (a hard cap + TTL, from #1101), but that only controls what gets *rendered* - it never told `DataService` to forget a vessel's path data, so every distinct context ever seen (in practice: every distinct AIS vessel/AtoN/SAR/basestation MMSI ever encountered) stayed in memory for the life of the tab.

### How this was found

Came out of investigating #770 (unrelated GPU freeze issue). An 11-hour idle soak test on real Raspberry Pi hardware, run to test that issue, showed JS heap growing from ~15MB to ~972MB at a constant, non-decelerating rate the whole time - with the known AIS-target-cap confirmed working throughout (only ~10 targets ever rendered). That ruled out the already-fixed target-growth bug and pointed at something else entirely.

Took CDP heap snapshots at intervals under the same load and diffed them by object type: plain `Object` count was growing by **~168,000 every 8 minutes**, nearly identically in two consecutive windows. The diff surfaced entries like `vessels.urn:mrn:imo:mmsi:100010919.navigation.courseOverGroundTrue` - full path strings for individual, never-repeating simulated vessels. That traced straight to the missing eviction in `DataService`.

### The fix

- `DataService.removePathsForContext(context: string)` - deletes every entry whose key starts with `${context}.` from all four affected maps, re-emitting the full-tree/meta debug streams if either is currently open. Reuses the existing `refreshSkDataCache()` helper rather than re-deriving the same rebuild logic.
- Wired into `AisProcessingService.removeTrack()`, the single choke point for all three eviction triggers (TTL sweep, max-targets cap, and an explicit `status: "remove"` delta) - so the moment AIS processing forgets about a vessel, `DataService`'s copy of its data goes with it.
- Widget subscriptions to a removed context's paths are left alone on purpose (see `unsubscribePath`) - they just stop receiving updates once no more deltas arrive, same as they would for a vessel that genuinely went quiet.

### Verification

- **Test-first (RED→GREEN)**, plus a follow-up commit addressing an adversarial review pass: a direct unit test on `removePathsForContext` (including one that opens the full-tree data/meta debug views and confirms eviction is reflected there too - mutation-tested by temporarily reverting that part of the implementation to confirm the test actually catches it), and two integration tests confirming `AisProcessingService` calls it on both TTL and cap eviction.
- **Empirically re-ran the same heap-snapshot diagnostic against the fixed build.** Plain `Object` growth dropped from ~168,000/8min to **+9 and +4** across the same two windows - what's left is normal V8 JIT code-cache warmup, not application data. The specific per-vessel path strings from before now show up with small, bounded counts instead of accumulating forever.
- Full suite: 451/451. Lint and production build clean.

### Scope note

This isn't AIS-specific in the sense of only ship traffic - `AisProcessingService` also handles AtoN, SAR targets, and shore base stations, and this fix covers all of it since they funnel through the same eviction path. It's also not the *only* place this class of bug could occur in principle - `removePathsForContext` is a public, generic method precisely so any future feature that tracks its own dynamic set of non-self contexts has a supported way to avoid reintroducing the same leak, rather than everyone needing to invent their own.

Also surfaced, but **not addressed here** (separate, pre-existing, out of scope for this PR): `DataService.unsubscribePath()` currently has no call sites anywhere in the app - worth a look on its own.

