### PR TITLE
Fix DataService.unsubscribePath() having zero call sites

### DIFF
--- a/src/app/core/components/remote-control/remote-control.component.spec.ts
+++ b/src/app/core/components/remote-control/remote-control.component.spec.ts
@@ -84,8 +84,12 @@ describe('RemoteControlComponent releasing DataService registrations', () => {
     await appRef.whenStable();
     fixture.detectChanges();
 
-    expect(dataSvc.unsubCalls).toContainEqual({ path: 'self.displays.display-1', source: 'default' });
-    expect(dataSvc.unsubCalls).toContainEqual({ path: 'self.displays.display-1.screenIndex', source: 'default' });
+    // Exact equality (not just toContainEqual) so a regression that releases twice,
+    // or also releases display-2's brand-new registration, would be caught.
+    expect(dataSvc.unsubCalls).toEqual([
+      { path: 'self.displays.display-1', source: 'default' },
+      { path: 'self.displays.display-1.screenIndex', source: 'default' }
+    ]);
   });
 
   it('releases the selected display\'s subscriptions when the component is destroyed', async () => {
@@ -97,7 +101,9 @@ describe('RemoteControlComponent releasing DataService registrations', () => {
 
     fixture.destroy();
 
-    expect(dataSvc.unsubCalls).toContainEqual({ path: 'self.displays.display-1', source: 'default' });
-    expect(dataSvc.unsubCalls).toContainEqual({ path: 'self.displays.display-1.screenIndex', source: 'default' });
+    expect(dataSvc.unsubCalls).toEqual([
+      { path: 'self.displays.display-1', source: 'default' },
+      { path: 'self.displays.display-1.screenIndex', source: 'default' }
+    ]);
   });
 });

--- a/src/app/core/components/remote-control/remote-control.component.spec.ts
+++ b/src/app/core/components/remote-control/remote-control.component.spec.ts
@@ -1,6 +1,9 @@
+import { ApplicationRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { beforeEach, describe, expect, it } from 'vitest';
+import { Subject } from 'rxjs';
 import { RemoteControlComponent } from './remote-control.component';
+import { DataService } from '../../services/data.service';
 
 describe('RemoteControlComponent', () => {
   let component: RemoteControlComponent;
@@ -19,5 +22,82 @@ describe('RemoteControlComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+});
+
+class FakeDataService {
+  treeSubject = new Subject<{ path: string; update: { data: { value: unknown; timestamp: Date | null }; state: string } }>();
+  unsubCalls: { path: string; source: string }[] = [];
+
+  subscribePathTree() {
+    return this.treeSubject.asObservable();
+  }
+
+  subscribePath() {
+    return new Subject<{ data: { value: unknown; timestamp: Date | null }; state: string }>().asObservable();
+  }
+
+  unsubscribePath(path: string, source: string): void {
+    this.unsubCalls.push({ path, source });
+  }
+}
+
+// A remote display is only picked up once its path payload carries a displayName,
+// mirroring what the real self.displays.<id> root node looks like on the wire.
+function pushDisplay(dataSvc: FakeDataService, displayId: string, displayName: string): void {
+  dataSvc.treeSubject.next({
+    path: `self.displays.${displayId}`,
+    update: { data: { value: { displayName }, timestamp: null }, state: 'normal' }
+  });
+}
+
+describe('RemoteControlComponent releasing DataService registrations', () => {
+  let fixture: ComponentFixture<RemoteControlComponent>;
+  let component: RemoteControlComponent;
+  let dataSvc: FakeDataService;
+  let appRef: ApplicationRef;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [RemoteControlComponent],
+      providers: [{ provide: DataService, useClass: FakeDataService }]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(RemoteControlComponent);
+    component = fixture.componentInstance;
+    dataSvc = TestBed.inject(DataService) as unknown as FakeDataService;
+    appRef = TestBed.inject(ApplicationRef);
+    fixture.detectChanges();
+  });
+
+  it('releases the previous display\'s subscriptions when the selected display switches to another one', async () => {
+    pushDisplay(dataSvc, 'display-1', 'One');
+    pushDisplay(dataSvc, 'display-2', 'Two');
+    await appRef.whenStable();
+    fixture.detectChanges();
+
+    // display-1 sorts first alphabetically and is auto-selected; its two path
+    // registrations (screen list + active screen index) should now be live.
+    expect(dataSvc.unsubCalls).toEqual([]);
+
+    component['displayDashboards']('display-2');
+    await appRef.whenStable();
+    fixture.detectChanges();
+
+    expect(dataSvc.unsubCalls).toContainEqual({ path: 'self.displays.display-1', source: 'default' });
+    expect(dataSvc.unsubCalls).toContainEqual({ path: 'self.displays.display-1.screenIndex', source: 'default' });
+  });
+
+  it('releases the selected display\'s subscriptions when the component is destroyed', async () => {
+    pushDisplay(dataSvc, 'display-1', 'One');
+    await appRef.whenStable();
+    fixture.detectChanges();
+
+    expect(dataSvc.unsubCalls).toEqual([]);
+
+    fixture.destroy();
+
+    expect(dataSvc.unsubCalls).toContainEqual({ path: 'self.displays.display-1', source: 'default' });
+    expect(dataSvc.unsubCalls).toContainEqual({ path: 'self.displays.display-1.screenIndex', source: 'default' });
   });
 });

--- a/src/app/core/components/remote-control/remote-control.component.ts
+++ b/src/app/core/components/remote-control/remote-control.component.ts
@@ -35,6 +35,11 @@ export class RemoteControlComponent {
   private readonly displaysMap = signal<Record<string, IKipDisplayInfo>>({});
   private selectedDisplaySub: Subscription | null = null;
   private selectedScreenIndexSub: Subscription | null = null;
+  // The displayId the two subscriptions above are currently bound to, so their
+  // DataService registrations can be released on rebind/destroy - otherwise every
+  // display switch, and every navigation to/away from this page, leaks one
+  // registration per path for the life of the app.
+  private boundDisplayId: string | null = null;
 
   protected readonly displays = computed<IKipDisplayInfo[]>(() => {
     const items = Object.values(this.displaysMap());
@@ -77,6 +82,8 @@ export class RemoteControlComponent {
     effect(() => {
       this.rebindSelectedDisplaySubscriptions(this.displayId());
     });
+
+    this._destroyRef.onDestroy(() => this.releaseBoundDisplaySubscriptions());
   }
 
   private updateDisplayCatalog(path: string, value: unknown): void {
@@ -112,11 +119,21 @@ export class RemoteControlComponent {
     });
   }
 
+  /** Release the DataService registrations for whichever displayId is currently bound, if any. */
+  private releaseBoundDisplaySubscriptions(): void {
+    const displayId = this.boundDisplayId;
+    if (!displayId) return;
+    this._data.unsubscribePath(`self.displays.${displayId}`, 'default');
+    this._data.unsubscribePath(`self.displays.${displayId}.screenIndex`, 'default');
+    this.boundDisplayId = null;
+  }
+
   private rebindSelectedDisplaySubscriptions(displayId: string | null): void {
     this.selectedDisplaySub?.unsubscribe();
     this.selectedDisplaySub = null;
     this.selectedScreenIndexSub?.unsubscribe();
     this.selectedScreenIndexSub = null;
+    this.releaseBoundDisplaySubscriptions();
 
     if (!displayId) {
       this.screensLoading.set(false);
@@ -125,6 +142,7 @@ export class RemoteControlComponent {
       return;
     }
 
+    this.boundDisplayId = displayId;
     this.screensLoading.set(true);
 
     this.selectedDisplaySub = this._data.subscribePath(`self.displays.${displayId}`, 'default')

--- a/src/app/core/directives/widget-streams.directive.spec.ts
+++ b/src/app/core/directives/widget-streams.directive.spec.ts
@@ -3,11 +3,17 @@ import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 import { Subject, BehaviorSubject, Observable } from 'rxjs';
 import { WidgetStreamsDirective } from './widget-streams.directive';
 import { DataService, IPathUpdate } from '../services/data.service';
+import { SignalKDeltaService } from '../services/signalk-delta.service';
 import { UnitsService } from '../services/units.service';
 import { IWidgetSvcConfig, IWidgetPath } from '../interfaces/widgets-interface';
+import { IPathValueData } from '../interfaces/app-interfaces';
 
 class FakeDataService {
     calls: {
+        path: string;
+        source: string;
+    }[] = [];
+    unsubCalls: {
         path: string;
         source: string;
     }[] = [];
@@ -25,6 +31,10 @@ class FakeDataService {
             this.subjects.set(key, new Subject<IPathUpdate>());
         }
         return this.subjects.get(key)!.asObservable();
+    }
+
+    unsubscribePath(path: string, source: string): void {
+        this.unsubCalls.push({ path, source });
     }
 
     timeoutPathObservable(path: string, pathType: string): void {
@@ -502,6 +512,10 @@ class TtlFakeDataService {
         return this.subjects.get(key)!.asObservable();
     }
 
+    unsubscribePath(): void {
+        // Not exercised by these TTL tests; no-op is sufficient here.
+    }
+
     timeoutPathObservable(path: string, pathType: string): void {
         this.timeoutCalls.push({ path, pathType });
         // Mirror the real DataService: a TTL timeout resets the path value to null.
@@ -556,5 +570,150 @@ describe('WidgetStreamsDirective TTL value reset (#1069)', () => {
         expect(dataSvc.timeoutCalls.length).toBeGreaterThanOrEqual(1);
         // The widget must be reset to null ("--"), not left showing the stale 500.
         expect(hits[hits.length - 1]).toBeNull();
+    });
+});
+
+describe('WidgetStreamsDirective releasing DataService registrations', () => {
+    let directive: WidgetStreamsDirective;
+    let dataSvc: FakeDataService;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [
+                WidgetStreamsDirective,
+                { provide: DataService, useClass: FakeDataService },
+                { provide: UnitsService, useClass: FakeUnitsService }
+            ]
+        });
+        directive = TestBed.inject(WidgetStreamsDirective);
+        dataSvc = TestBed.inject(DataService) as unknown as FakeDataService;
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('releases every subscribed path when the directive is destroyed', () => {
+        const cfg = makeCfg({ key: 'p1', path: 'navigation.speedOverGround', source: 'gps-1' });
+        cfg.paths = {
+            ...cfg.paths,
+            p2: { ...(cfg.paths as Record<string, IWidgetPath>)['p1'], path: 'navigation.headingTrue', source: 'compass-1' }
+        };
+        directive.setStreamsConfig(cfg);
+        directive.observe('p1', () => { });
+        directive.observe('p2', () => { });
+
+        expect(dataSvc.unsubCalls).toEqual([]);
+        TestBed.resetTestingModule();
+
+        expect(dataSvc.unsubCalls).toContainEqual({ path: 'navigation.speedOverGround', source: 'gps-1' });
+        expect(dataSvc.unsubCalls).toContainEqual({ path: 'navigation.headingTrue', source: 'compass-1' });
+        expect(dataSvc.unsubCalls.length).toBe(2);
+    });
+
+    it('releases the old path when a widget is reconfigured to point at a different path, and does not release the new one', () => {
+        const cfgA = makeCfg({ path: 'navigation.speedOverGround', source: 'gps-1' });
+        directive.setStreamsConfig(cfgA);
+        directive.observe('p', () => { });
+        expect(dataSvc.unsubCalls).toEqual([]);
+
+        const cfgB = makeCfg({ path: 'navigation.headingTrue', source: 'compass-1' });
+        directive.applyStreamsConfigDiff(cfgB);
+
+        expect(dataSvc.unsubCalls).toEqual([{ path: 'navigation.speedOverGround', source: 'gps-1' }]);
+    });
+
+    it('does not release the registration when only the callback changes and the path stays the same', () => {
+        const cfg = makeCfg({ path: 'navigation.speedOverGround', source: 'gps-1' });
+        directive.setStreamsConfig(cfg);
+        directive.observe('p', () => { });
+        directive.observe('p', () => { }); // different callback, same path/source
+
+        expect(dataSvc.calls.length).toBe(1); // only ever subscribed once
+        expect(dataSvc.unsubCalls).toEqual([]);
+    });
+
+    it('releases a path removed from the widget config via applyStreamsConfigDiff', () => {
+        const cfgA = makeCfg({ key: 'p1', path: 'navigation.speedOverGround', source: 'gps-1' });
+        directive.setStreamsConfig(cfgA);
+        directive.observe('p1', () => { });
+
+        directive.applyStreamsConfigDiff(makeCfg({ key: 'p2', path: 'navigation.headingTrue', source: 'compass-1' }));
+
+        expect(dataSvc.unsubCalls).toEqual([{ path: 'navigation.speedOverGround', source: 'gps-1' }]);
+    });
+});
+
+describe('WidgetStreamsDirective shared DataService registrations (real DataService, two widgets)', () => {
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('destroying one widget does not break another widget still sharing the same (path, source)', async () => {
+        vi.useFakeTimers();
+        const dataPathUpdates$ = new Subject<IPathValueData>();
+        TestBed.configureTestingModule({
+            providers: [
+                WidgetStreamsDirective,
+                DataService,
+                {
+                    provide: SignalKDeltaService,
+                    useValue: {
+                        subscribeDataPathsUpdates: () => dataPathUpdates$.asObservable(),
+                        subscribeMetadataUpdates: () => new Subject().asObservable(),
+                        subscribeNotificationsUpdates: () => new Subject().asObservable(),
+                        subscribeSelfUpdates: () => new Subject().asObservable(),
+                    },
+                },
+                { provide: UnitsService, useClass: FakeUnitsService }
+            ]
+        });
+
+        // directiveA: the module's own singleton instance (a first widget).
+        const directiveA = TestBed.inject(WidgetStreamsDirective);
+        // directiveB: a genuinely independent second instance (a second widget), created
+        // inside the same injection context so its inject(DataService) resolves to the
+        // SAME real DataService instance as directiveA - exactly like two separate
+        // widget-host2 instances on a dashboard both pointing at the same sensor path.
+        const directiveB = TestBed.runInInjectionContext(() => new WidgetStreamsDirective());
+
+        // Widget configs store the fully-resolved path (as DataService itself keys on),
+        // while the mock delta below uses the raw Signal K wire format (context + bare
+        // path) - matching data.service.spec.ts's own convention.
+        const cfg = makeCfg({ path: 'self.navigation.speedOverGround', source: 'gps-1' });
+
+        // Seed the real value BEFORE either widget subscribes, so subscribePath()'s
+        // initial snapshot (read from DataService's already-updated cache) already has
+        // it - matching how a widget added to a dashboard after data has been flowing
+        // for a while immediately shows the current value via the take(1) fast path,
+        // rather than needing to wait a full sampleTime interval for the next sample.
+        dataPathUpdates$.next({
+            context: 'self', path: 'navigation.speedOverGround', source: 'gps-1',
+            timestamp: '2026-01-01T00:00:01.000Z', value: 5.1,
+        });
+
+        directiveA.setStreamsConfig(cfg);
+        const hitsA: IPathUpdate[] = [];
+        directiveA.observe('p', u => hitsA.push(u));
+
+        directiveB.setStreamsConfig(cfg);
+        const hitsB: IPathUpdate[] = [];
+        directiveB.observe('p', u => hitsB.push(u));
+
+        await vi.advanceTimersByTimeAsync(0); // flush the take(1) fast-path
+        expect(hitsA[hitsA.length - 1].data.value).toBe(5.1);
+        expect(hitsB[hitsB.length - 1].data.value).toBe(5.1);
+
+        // Widget A is destroyed (dashboard switch, widget removed, etc.). Widget B is
+        // still using the exact same (path, source) and must keep receiving live data,
+        // not have its shared Subject silently completed out from under it.
+        directiveA.ngOnDestroy();
+
+        dataPathUpdates$.next({
+            context: 'self', path: 'navigation.speedOverGround', source: 'gps-1',
+            timestamp: '2026-01-01T00:00:02.000Z', value: 7.7,
+        });
+        await vi.advanceTimersByTimeAsync(1100); // past the default 1000ms sampleTime
+        expect(hitsB[hitsB.length - 1].data.value).toBe(7.7);
     });
 });

--- a/src/app/core/directives/widget-streams.directive.ts
+++ b/src/app/core/directives/widget-streams.directive.ts
@@ -43,12 +43,29 @@ export class WidgetStreamsDirective implements OnDestroy {
   private subscriptions = new Map<string, { sub: Subscription; signature: string }>();
   // Track identity of the cached base observable (path + normalized source) per path key
   private baseSignatures = new Map<string, string>();
+  // The (path, source) actually passed to dataService.subscribePath() per path key, so
+  // it can be released via dataService.unsubscribePath() when replaced or removed -
+  // otherwise DataService's shared registration for it is retained for the app's lifetime
+  // regardless of how many times widgets pointed at it come and go.
+  private baseIdentities = new Map<string, { path: string; source: string }>();
   // Root-level signature (timeout settings) to detect when all paths need pipeline rebuild
   private reset$ = new Subject<void>();
   private rootSignature: string | undefined;
 
-  // TODO: release DataService.subscribePath() registrations on destroy/replace.
-  ngOnDestroy(): void { /* not yet implemented */ }
+  /** Release this path key's DataService base registration, if it currently holds one. */
+  private releaseBase(pathName: string): void {
+    const identity = this.baseIdentities.get(pathName);
+    if (identity) {
+      this.dataService.unsubscribePath(identity.path, identity.source);
+      this.baseIdentities.delete(pathName);
+    }
+  }
+
+  ngOnDestroy(): void {
+    for (const pathName of [...this.baseIdentities.keys()]) {
+      this.releaseBase(pathName);
+    }
+  }
 
   /** Build a simple Observer wrapper for a given path key. */
   private buildObserver(pathKey: string, next: ((value: IPathUpdate) => void)): Observer<IPathUpdate> {
@@ -122,16 +139,20 @@ export class WidgetStreamsDirective implements OnDestroy {
       this.subscriptions.delete(pathName);
       this.streams?.delete(pathName);
       this.baseSignatures.delete(pathName);
+      this.releaseBase(pathName);
       return;
     }
 
     // Build base observable if missing, or refresh when path/source changed
     this.ensureStreamsMap();
+    const source = pathCfg.source?.trim() || 'default';
     const baseKey = this.computeBaseKey(normalizedPath, pathCfg.source);
     const currentBaseKey = this.baseSignatures.get(pathName);
     if (!this.streams!.has(pathName) || currentBaseKey !== baseKey) {
-      this.streams!.set(pathName, this.dataService.subscribePath(normalizedPath, pathCfg.source?.trim() || 'default'));
+      this.releaseBase(pathName);
+      this.streams!.set(pathName, this.dataService.subscribePath(normalizedPath, source));
       this.baseSignatures.set(pathName, baseKey);
+      this.baseIdentities.set(pathName, { path: normalizedPath, source });
     }
     const base$ = this.streams!.get(pathName)!;
 
@@ -279,6 +300,9 @@ export class WidgetStreamsDirective implements OnDestroy {
       this.subscriptions.clear();
       this.streams = undefined;
       this.baseSignatures.clear();
+      for (const pathName of [...this.baseIdentities.keys()]) {
+        this.releaseBase(pathName);
+      }
       this.registrations = [];
       return;
     }
@@ -291,6 +315,7 @@ export class WidgetStreamsDirective implements OnDestroy {
       this.subscriptions.delete(r);
       this.streams?.delete(r);
       this.baseSignatures.delete(r);
+      this.releaseBase(r);
       this.registrations = this.registrations.filter(x => x.pathName !== r);
     }
     const rootChanged = prevRootSig !== newRootSig;
@@ -303,6 +328,7 @@ export class WidgetStreamsDirective implements OnDestroy {
         this.subscriptions.delete(p);
         this.streams?.delete(p);
         this.baseSignatures.delete(p);
+        this.releaseBase(p);
         continue;
       }
       const normalizedCfg = { ...pathCfg, path: normalizedPath };
@@ -385,6 +411,7 @@ export class WidgetStreamsDirective implements OnDestroy {
         this.subscriptions.delete(pathName);
         this.streams?.delete(pathName);
         this.baseSignatures.delete(pathName);
+        this.releaseBase(pathName);
       }
       return;
     }
@@ -398,6 +425,7 @@ export class WidgetStreamsDirective implements OnDestroy {
         this.subscriptions.delete(pathName);
         this.streams?.delete(pathName);
         this.baseSignatures.delete(pathName);
+        this.releaseBase(pathName);
       }
       this.registrations = this.registrations.filter(r => r.pathName !== pathName);
       return;

--- a/src/app/core/directives/widget-streams.directive.ts
+++ b/src/app/core/directives/widget-streams.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, DestroyRef, inject, signal } from '@angular/core';
+import { Directive, DestroyRef, inject, OnDestroy, signal } from '@angular/core';
 import { DataService, IPathUpdate } from '../services/data.service';
 import { UnitsService } from '../services/units.service';
 import { IWidgetPath, IWidgetSvcConfig } from '../interfaces/widgets-interface';
@@ -31,7 +31,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
  * - Config changes automatically trigger diff-based subscription updates
  * - All subscriptions auto-cleanup on directive destroy
  */
-export class WidgetStreamsDirective {
+export class WidgetStreamsDirective implements OnDestroy {
   private _streamsConfig = signal<IWidgetSvcConfig | undefined>(undefined);
   private readonly dataService = inject(DataService);
   private readonly unitsService = inject(UnitsService);
@@ -46,6 +46,9 @@ export class WidgetStreamsDirective {
   // Root-level signature (timeout settings) to detect when all paths need pipeline rebuild
   private reset$ = new Subject<void>();
   private rootSignature: string | undefined;
+
+  // TODO: release DataService.subscribePath() registrations on destroy/replace.
+  ngOnDestroy(): void { /* not yet implemented */ }
 
   /** Build a simple Observer wrapper for a given path key. */
   private buildObserver(pathKey: string, next: ((value: IPathUpdate) => void)): Observer<IPathUpdate> {

--- a/src/app/core/services/data.service.spec.ts
+++ b/src/app/core/services/data.service.spec.ts
@@ -42,6 +42,53 @@ describe('DataService', () => {
     expect(service).toBeTruthy();
   });
 
+  it('unsubscribePath only tears down a shared registration once every subscriber has released it', () => {
+    // Two independent consumers of the exact same (path, source) - subscribePath()
+    // dedupes and shares the same underlying registration between them.
+    let completedA = false;
+    let completedB = false;
+    service
+      .subscribePath('self.navigation.speedOverGround', 'default')
+      .subscribe({ next: () => { }, complete: () => (completedA = true) });
+    service
+      .subscribePath('self.navigation.speedOverGround', 'default')
+      .subscribe({ next: () => { }, complete: () => (completedB = true) });
+
+    service.unsubscribePath('self.navigation.speedOverGround', 'default');
+    expect(completedA).toBe(false);
+    expect(completedB).toBe(false);
+
+    dataPathUpdates$.next({
+      context: 'self',
+      path: 'navigation.speedOverGround',
+      source: 'test-source',
+      timestamp: '2026-01-01T00:00:01.000Z',
+      value: 6.2,
+    });
+    // Still live after only one of two consumers released it.
+    expect(service.getPathObject('self.navigation.speedOverGround')).toBeTruthy();
+
+    service.unsubscribePath('self.navigation.speedOverGround', 'default');
+    expect(completedA).toBe(true);
+    expect(completedB).toBe(true);
+  });
+
+  it('unsubscribePath matches by path AND source, leaving other sources on the same path untouched', () => {
+    let completedDefault = false;
+    let completedOther = false;
+    service
+      .subscribePath('self.navigation.speedOverGround', 'default')
+      .subscribe({ next: () => { }, complete: () => (completedDefault = true) });
+    service
+      .subscribePath('self.navigation.speedOverGround', 'gps-2')
+      .subscribe({ next: () => { }, complete: () => (completedOther = true) });
+
+    service.unsubscribePath('self.navigation.speedOverGround', 'default');
+
+    expect(completedDefault).toBe(true);
+    expect(completedOther).toBe(false);
+  });
+
   it('applies notification state to path value updates', () => {
     let latest: IPathUpdate | undefined;
 

--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -90,6 +90,8 @@ const buildPathData = (value: unknown, rawTimestamp: string | number | Date | nu
 interface IPathRegistration {
   path: string;
   source: string;
+  /** Number of live callers sharing this registration; only torn down at 0 (see unsubscribePath). */
+  refCount: number;
   _pathData$: BehaviorSubject<IPathData>;
   _pathState$: BehaviorSubject<TState>;
   pathDataUpdate$: BehaviorSubject<IPathUpdate>;
@@ -228,15 +230,50 @@ export class DataService implements OnDestroy {
     this._isReset.next(true);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  /**
+   * Releases one caller's hold on a subscribePath(path, source) registration.
+   * subscribePath() shares a single registration between every caller that
+   * asks for the same (path, source) pair, so this only actually completes
+   * the underlying Subjects and removes the registration once every caller
+   * that obtained it has released it (refCount reaches 0) - releasing it
+   * while another caller is still using it would silently kill their live
+   * data with no warning.
+   */
   public unsubscribePath(path: string, source: string): void {
-    // TODO: not yet implemented - refCount-aware teardown
+    const index = this._pathRegister.findIndex(registration => registration.path === path && registration.source === source);
+    if (index === -1) return;
+
+    const registration = this._pathRegister[index];
+    registration.refCount--;
+    if (registration.refCount > 0) return;
+
+    // Ensure all observables are completed to avoid memory leaks
+    registration.combinedSub?.unsubscribe();
+    registration._pathData$?.complete();
+    registration._pathState$?.complete();
+    registration.pathDataUpdate$?.complete();
+    registration.pathMeta$?.complete();
+
+    // Use splice to remove the item without changing the entire
+    // array reference.
+    this._pathRegister.splice(index, 1);
+
+    const registrations = this._pathRegisterByPath.get(path);
+    if (registrations) {
+      const updated = registrations.filter(item => item !== registration);
+      if (updated.length) {
+        this._pathRegisterByPath.set(path, updated);
+      } else {
+        this._pathRegisterByPath.delete(path);
+      }
+    }
   }
 
   public subscribePath(path: string, source: string): Observable<IPathUpdate> {
     const registrations = this._pathRegisterByPath.get(path);
     const matchingPaths = registrations?.find(item => item.path === path && item.source === source);
     if (matchingPaths) {
+      matchingPaths.refCount++;
       return matchingPaths.pathDataUpdate$;
     }
 
@@ -275,6 +312,7 @@ export class DataService implements OnDestroy {
     const newPathSubject: IPathRegistration = {
       path: path,
       source: source,
+      refCount: 1,
       _pathData$: new BehaviorSubject<IPathData>(pathUpdate.data),
       _pathState$: new BehaviorSubject<TState>(pathUpdate.state),
       pathDataUpdate$: new BehaviorSubject<IPathUpdate>(pathUpdate),

--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -228,33 +228,9 @@ export class DataService implements OnDestroy {
     this._isReset.next(true);
   }
 
-  public unsubscribePath(path: string): void {
-    const index = this._pathRegister.findIndex(registration => registration.path === path);
-
-    if (index !== -1) {
-      const registration = this._pathRegister[index];
-
-      // Ensure all observables are completed to avoid memory leaks
-      registration.combinedSub?.unsubscribe();
-      registration._pathData$?.complete();
-      registration._pathState$?.complete();
-      registration.pathDataUpdate$?.complete();
-      registration.pathMeta$?.complete();
-
-      // Use splice to remove the item without changing the entire
-      // array reference.
-      this._pathRegister.splice(index, 1);
-
-      const registrations = this._pathRegisterByPath.get(path);
-      if (registrations) {
-        const updated = registrations.filter(item => item !== registration);
-        if (updated.length) {
-          this._pathRegisterByPath.set(path, updated);
-        } else {
-          this._pathRegisterByPath.delete(path);
-        }
-      }
-    }
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  public unsubscribePath(path: string, source: string): void {
+    // TODO: not yet implemented - refCount-aware teardown
   }
 
   public subscribePath(path: string, source: string): Observable<IPathUpdate> {

--- a/src/app/core/services/dataset-stream.service.spec.ts
+++ b/src/app/core/services/dataset-stream.service.spec.ts
@@ -11,6 +11,7 @@ import { firstValueFrom, of } from 'rxjs';
 
 describe('DatasetStreamService', () => {
     let historyServiceMock: { getValues: ReturnType<typeof vi.fn> };
+    let dataServiceMock: Partial<DataService> & { unsubscribePath: ReturnType<typeof vi.fn> };
 
     beforeEach(() => {
         historyServiceMock = {
@@ -27,9 +28,10 @@ describe('DatasetStreamService', () => {
             saveDataSets: () => undefined
         };
 
-        const dataServiceMock: Partial<DataService> = {
+        dataServiceMock = {
             getPathUnitType: () => 'number',
-            subscribePath: () => of({ data: { value: 1, timestamp: null }, state: 'normal' })
+            subscribePath: () => of({ data: { value: 1, timestamp: null }, state: 'normal' }),
+            unsubscribePath: vi.fn().mockName("DataService.unsubscribePath")
         };
 
         TestBed.configureTestingModule({
@@ -290,6 +292,30 @@ describe('DatasetStreamService', () => {
         expect(dataSource.pathObserverSubscription.closed).toBe(false);
 
         service.ngOnDestroy();
+    }));
+
+    it('releases the DataService registration when a dataset is stopped', inject([DatasetStreamService], async (service: DatasetStreamService) => {
+        const config = {
+            uuid: 'ds-stop-release',
+            path: 'navigation.speedThroughWater',
+            pathSource: 'test-source',
+            baseUnit: 'number',
+            timeScaleFormat: 'Last 5 Minutes' as const,
+            period: 1,
+            label: 'test-stop-release'
+        };
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (service as any)._svcDatasetConfigs = [config];
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await (service as any).start(config.uuid);
+
+        expect(dataServiceMock.unsubscribePath).not.toHaveBeenCalled();
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (service as any).stop(config.uuid);
+
+        expect(dataServiceMock.unsubscribePath).toHaveBeenCalledWith('navigation.speedThroughWater', 'test-source');
     }));
 
     it('sets dataset stats only on final history datapoint using datapoint values', inject([DatasetStreamService], (service: DatasetStreamService) => {

--- a/src/app/core/services/dataset-stream.service.spec.ts
+++ b/src/app/core/services/dataset-stream.service.spec.ts
@@ -11,7 +11,7 @@ import { firstValueFrom, of } from 'rxjs';
 
 describe('DatasetStreamService', () => {
     let historyServiceMock: { getValues: ReturnType<typeof vi.fn> };
-    let dataServiceMock: Partial<DataService> & { unsubscribePath: ReturnType<typeof vi.fn> };
+    let dataServiceMock: Partial<DataService> & { subscribePath: ReturnType<typeof vi.fn>; unsubscribePath: ReturnType<typeof vi.fn> };
 
     beforeEach(() => {
         historyServiceMock = {
@@ -30,7 +30,7 @@ describe('DatasetStreamService', () => {
 
         dataServiceMock = {
             getPathUnitType: () => 'number',
-            subscribePath: () => of({ data: { value: 1, timestamp: null }, state: 'normal' }),
+            subscribePath: vi.fn(() => of({ data: { value: 1, timestamp: null }, state: 'normal' as const })).mockName("DataService.subscribePath"),
             unsubscribePath: vi.fn().mockName("DataService.unsubscribePath")
         };
 
@@ -316,6 +316,42 @@ describe('DatasetStreamService', () => {
         (service as any).stop(config.uuid);
 
         expect(dataServiceMock.unsubscribePath).toHaveBeenCalledWith('navigation.speedThroughWater', 'test-source');
+    }));
+
+    it('does not release someone else\'s registration or leak one when stop() races a pending history seed', inject([DatasetStreamService], async (service: DatasetStreamService) => {
+        let resolveHistory: (value: unknown) => void;
+        historyServiceMock.getValues.mockImplementation(() => new Promise(resolve => { resolveHistory = resolve; }));
+
+        const config = {
+            uuid: 'ds-race',
+            path: 'navigation.speedThroughWater',
+            pathSource: 'race-source',
+            baseUnit: 'number',
+            timeScaleFormat: 'Last 5 Minutes' as const,
+            period: 1,
+            label: 'test-race'
+        };
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (service as any)._svcDatasetConfigs = [config];
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const startPromise = (service as any).start(config.uuid);
+
+        // stop() runs while start() is still awaiting the history response: the
+        // dataSource entry exists (path/pathSource are already set) but
+        // DataService.subscribePath() has not been called yet.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (service as any).stop(config.uuid);
+
+        expect(dataServiceMock.unsubscribePath).not.toHaveBeenCalled();
+
+        resolveHistory!({ context: 'vessels.self', range: { from: '2026-01-01T00:00:00.000Z', to: '2026-01-01T00:00:00.000Z' }, values: [], data: [] });
+        await startPromise;
+
+        // start()'s continuation must not resurrect a registration for an already-stopped
+        // dataset - that registration would never get released, reintroducing the leak.
+        expect(dataServiceMock.subscribePath).not.toHaveBeenCalled();
+        expect(dataServiceMock.unsubscribePath).not.toHaveBeenCalled();
     }));
 
     it('sets dataset stats only on final history datapoint using datapoint values', inject([DatasetStreamService], (service: DatasetStreamService) => {

--- a/src/app/core/services/dataset-stream.service.ts
+++ b/src/app/core/services/dataset-stream.service.ts
@@ -296,6 +296,13 @@ export class DatasetStreamService implements OnDestroy {
       await this.seedHistoryData(dataSource, configuration, historyResolutionSeconds, angleDomain);
     }
 
+    // A concurrent stop() may have removed this dataSource while history was loading -
+    // don't resurrect a DataService registration for a dataset that's already stopped;
+    // nothing would ever release it.
+    if (!this._svcDataSource.includes(dataSource)) {
+      return;
+    }
+
     // Share the latest non-null value so we can:
     // 1) emit immediately on first value (chart isn't blank)
     // 2) then emit periodically using the latest known value
@@ -428,8 +435,13 @@ export class DatasetStreamService implements OnDestroy {
     }
     console.log(`[DatasetStreamService] Stopping Dataset ${uuid} data capture`);
     const dataSource = this._svcDataSource[dsIndex];
-    dataSource.pathObserverSubscription?.unsubscribe();
-    this.data.unsubscribePath(dataSource.path, dataSource.pathSource);
+    // pathObserverSubscription is only set once start() has actually reached its
+    // subscribePath() call (it may still be awaiting a history seed) - only release
+    // a registration this dataSource actually acquired.
+    if (dataSource.pathObserverSubscription) {
+      dataSource.pathObserverSubscription.unsubscribe();
+      this.data.unsubscribePath(dataSource.path, dataSource.pathSource);
+    }
     this._svcDataSource.splice(dsIndex, 1);
   }
 

--- a/src/app/core/services/dataset-stream.service.ts
+++ b/src/app/core/services/dataset-stream.service.ts
@@ -44,6 +44,8 @@ export interface IDatasetServiceDataSourceInfo {
 
 interface IDatasetServiceDataSource extends IDatasetServiceDataSourceInfo {
   uuid: string;
+  path: string;
+  pathSource: string;
   pathObserverSubscription: Subscription | null;
   historicalData: number[];
 };
@@ -184,6 +186,8 @@ export class DatasetStreamService implements OnDestroy {
 
     const newDataSourceConfiguration: IDatasetServiceDataSource = {
       uuid: dsConf.uuid,
+      path: dsConf.path,
+      pathSource: dsConf.pathSource,
       pathObserverSubscription: null,
       sampleTime: derivedSampleTimeMs,
       maxDataPoints,
@@ -423,7 +427,9 @@ export class DatasetStreamService implements OnDestroy {
       return;
     }
     console.log(`[DatasetStreamService] Stopping Dataset ${uuid} data capture`);
-    this._svcDataSource[dsIndex].pathObserverSubscription?.unsubscribe();
+    const dataSource = this._svcDataSource[dsIndex];
+    dataSource.pathObserverSubscription?.unsubscribe();
+    this.data.unsubscribePath(dataSource.path, dataSource.pathSource);
     this._svcDataSource.splice(dsIndex, 1);
   }
 


### PR DESCRIPTION
## Fix DataService.unsubscribePath() having zero call sites

`DataService.subscribePath(path, source)` creates a shared, reference-counted registration for a given (path, source) identity, reused by every caller who asks for the same one. But `unsubscribePath(path, source)` - the method meant to release that share when a caller no longer needs it - had zero call sites anywhere in the app. Every widget, page, and service that ever called `subscribePath()` kept its registration alive for the life of the tab, even after being destroyed, reconfigured, or torn down.

This was noted but deliberately left out of scope in #1129 - it's a distinct bug with a different root cause (missing release calls, not missing context eviction), so it gets its own PR. Both touch `DataService`, but this one is independent of #1129's fix and targets master directly rather than stacking on it.

### The fix

**Ref counting in DataService** (`IPathRegistration.refCount`): `subscribePath()` now increments a ref count whether it's creating a new registration or handing out an existing shared one; `unsubscribePath()` decrements it and only tears the registration down (completing its Subjects, unsubscribing from the underlying delta stream) at zero. This matters because `subscribePath()` already deduped/shared registrations across callers before this fix - without ref counting, one caller releasing would have broken every other caller still using the same path/source.

**Three real call sites wired up:**
- `WidgetStreamsDirective` - the highest-traffic one, used by nearly every widget via `hostDirectives`. Releases on destroy, and on any rebind/removal of a path (reconfigure, config diff, invalid path).
- `RemoteControlComponent` - a routed page, not a widget. Releases the previously-selected display's two subscriptions (screen list, active screen index) on every display switch and on page close.
- `DatasetStreamService` - releases a dataset's registration in `stop()`, covering explicit stop/remove/update flows and the app-teardown sweep.

**Two other call sites** (`RemoteDashboardsService`, `AppService`) were found during research but left alone on purpose: both are root singletons that subscribe exactly once at construction and never rebuild, so there's nothing to release until the app itself closes - fixing them would be pure defensive code with no real leak behind it.

### A second bug found during adversarial review

Reviewing the `DatasetStreamService` change surfaced a genuine race: `start()` pushes its tracking entry (with `path`/`pathSource` already set) *before* awaiting an optional History API seed, and only calls `subscribePath()` after that await resolves. If `stop()` ran during that gap, it would call `unsubscribePath()` for an identity this `start()` call had never actually acquired - potentially tearing down a different caller's still-in-use shared registration - and then `start()`'s continuation would go on to call `subscribePath()` anyway for an already-stopped dataset, creating a new registration nothing would ever release (reintroducing the very leak this PR fixes). Reproduced with a controllable pending Promise in a unit test, then fixed: `start()` now checks it's still tracked after the await before subscribing, and `stop()` only releases a registration it can confirm was actually acquired.

### Verification

- **Test-first (RED→GREEN)** throughout, including the race-condition fix.
- `WidgetStreamsDirective`: unit tests against a fake DataService, plus an integration test against the real DataService proving one widget's teardown doesn't disrupt a second widget sharing the same (path, source).
- `RemoteControlComponent` and `DatasetStreamService`: unit tests against fake/mocked DataService, with exact call-sequence assertions (tightened during review so a double-release regression would be caught, not just "was it called at all").
- Full suite: 458/458. Lint and production build clean.
